### PR TITLE
fix: use different stack

### DIFF
--- a/IaC/modules/monitoring/main.tf
+++ b/IaC/modules/monitoring/main.tf
@@ -11,7 +11,7 @@ resource "kubernetes_namespace_v1" "monitoring" {
 
 resource "argocd_application" "prometheus" {
   metadata {
-    name = "kube-prometheus-stack"
+    name = "prometheus"
   }
 
   spec {


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Updated `name` attribute to `kube-prometheus-stack`.

- Changed `chart` attribute to `kube-prometheus-stack`.

- Added `sync_options` attribute with value `["ServerSideApply=true"]`.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Update resource attributes and add sync_options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

IaC/modules/monitoring/main.tf

<ul><li>Updated resource <code>name</code> and <code>chart</code> attributes.<br> <li> Added <code>sync_options</code> attribute.</ul>


</details>


  </td>
  <td><a href="https://github.com/Stuhlmuller/homelab/pull/118/files#diff-9f282b7f0092c1e324fde7aeff1b74657b83748aa8a96a8675df58caf2436226">+4/-10</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

