### PR TITLE
ci: Release trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,4 +18,4 @@ permissions:
 
 jobs:
   release:
-    uses: Stuhlmuller/workflows/.github/workflows/release.yml@f396233c815800e049c9def65a3562899a56110b # main
+    uses: Stuhlmuller/workflows/.github/workflows/release.yml@main


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by OSS CodeReviewer -->
### Summary by CodeReviewer

- New Feature: Added `workflow_dispatch` trigger to the GitHub Actions workflow. This allows manual triggering of the workflow from the GitHub interface, providing more control over when the workflow should run.
- Chore: Updated the `uses` reference in the GitHub Actions workflow to point to the `main` branch, ensuring that the latest stable version of the action is always used.
<!-- end of auto-generated comment: release notes by OSS CodeReviewer -->