### PR TITLE
ci: Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [":semanticCommits", ":rebaseStalePrs", "group:allNonMajor", "automerge:all"],
   "lockFileMaintenance": {
     "enabled": true
   }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the entire `extends` array from `renovate.json`, stripping out four preset behaviors that were previously inherited. The change makes the Renovate configuration more minimal and removes automatic merging (a safety improvement), but also removes useful automation like PR grouping, automatic rebasing, and semantic commit formatting.

- **`:semanticCommits` removed** → Renovate will no longer format commit messages using Conventional Commits (e.g., `chore(deps): ...`)
- **`:rebaseStalePrs` removed** → Stale dependency PRs will no longer be automatically rebased; manual intervention required
- **`group:allNonMajor` removed** → Minor and patch updates will each get their own PR instead of being batched, which may significantly increase PR volume
- **`automerge:all` removed** → All dependency update PRs now require manual review and merge (a safer default)

<h3>Confidence Score: 4/5</h3>

Safe to merge; the config is valid and removing automerge is a positive safety improvement

The change is intentional and the JSON is valid — score of 4 rather than 5 because the removal of group:allNonMajor could cause noticeable PR noise and is worth confirming as intentional

renovate.json — verify that ungrouped individual update PRs are the desired workflow

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| renovate.json | Removes all four `extends` presets, disabling semantic commits, auto-rebase, PR grouping, and automerge in one change. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Dependency Update Available] --> B[Old Config]
    A --> C[New Config]

    B --> D[Group all non-major updates]
    D --> E[Single batched PR opened]
    E --> F[Auto-rebase if stale]
    F --> G[Automerge when CI passes]
    G --> H[Semantic commit: chore deps update X]

    C --> I[Individual PR per dependency]
    I --> J[Stale PR needs manual rebase]
    J --> K[Manual review required]
    K --> L[Manual merge required]
    L --> M[Plain commit message]
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Arenovate.json%3A2%0A**Potential%20PR%20noise%20from%20removing%20grouping**%0A%0ARemoving%20%60group%3AallNonMajor%60%20means%20every%20non-major%20dependency%20update%20will%20now%20open%20its%20own%20PR.%20Depending%20on%20the%20number%20of%20dependencies%20in%20this%20homelab%20repo%2C%20this%20could%20generate%20significant%20PR%20noise%20and%20make%20it%20harder%20to%20keep%20up%20with%20updates.%0A%0AIf%20the%20intent%20is%20to%20review%20each%20update%20individually%2C%20this%20is%20fine%20%E2%80%94%20but%20if%20grouping%20is%20still%20desired%2C%20consider%20re-adding%20it%20explicitly%3A%0A%0A%60%60%60suggestion%0A%20%20%22%24schema%22%3A%20%22https%3A%2F%2Fdocs.renovatebot.com%2Frenovate-schema.json%22%2C%0A%20%20%22extends%22%3A%20%5B%22group%3AallNonMajor%22%5D%2C%0A%60%60%60%0A%0A&repo=stuhlmuller%2Fhomelab"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<sub>Reviews (1): Last reviewed commit: ["ci: fix renovate config"](https://github.com/stuhlmuller/homelab/commit/1e292ce10f953e831e32e6f8f18482a30fb5207d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27382659)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->