### PR TITLE
fix(ci): stabilize terragrunt plan action for PRs

### DIFF
--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -83,7 +83,6 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          terragrunt run --all --tf-path "${TG_TF_PATH}" init --working-dir "${WORKING_DIR}" -- -backend=false -input=false
           set +e
           terragrunt run --all --tf-path "${TG_TF_PATH}" plan --working-dir "${WORKING_DIR}" -- -refresh=false -lock=false -input=false -no-color 2>&1 | tee "${PLAN_LOG}"
           exit_code="${PIPESTATUS[0]}"

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -83,8 +83,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          terragrunt run --all --tf-path "${TG_TF_PATH}" init --working-dir "${WORKING_DIR}" -- -backend=false -input=false
           set +e
-          terragrunt run --all --tf-path "${TG_TF_PATH}" plan --working-dir "${WORKING_DIR}" -- -refresh=false 2>&1 | tee "${PLAN_LOG}"
+          terragrunt run --all --tf-path "${TG_TF_PATH}" plan --working-dir "${WORKING_DIR}" -- -refresh=false -lock=false -input=false -no-color 2>&1 | tee "${PLAN_LOG}"
           exit_code="${PIPESTATUS[0]}"
           set -e
           echo "exit_code=${exit_code}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
## Summary
Avoid S3 backend access in the PR Terragrunt plan action by matching the CI-safe verification lane sequence.

## Changes
- Run `terragrunt ... init -- -backend=false -input=false` before plan.
- Run plan with `-refresh=false -lock=false -input=false -no-color`.

## Why
PR #199 plan run failed in GitHub Actions with backend state read errors (`S3 HeadObject 403 Forbidden`) before emitting usable plan summaries. This change removes that backend dependency for PR plan checks.

## Validation
- Run inspected: https://github.com/Stuhlmuller/homelab/actions/runs/24299212307
- Local check: `python3 -m unittest discover -s tests -p 'test_*.py'`

<!-- homelab-terragrunt-plan:start -->
## Homelab Terragrunt Plan

- Status: `success`
- Stack: `terraform/live/homelab`
- Commit: `7dca3e7688ca`
- Run: [Workflow run](https://github.com/Stuhlmuller/homelab/actions/runs/24299772823)
- Artifact: `terragrunt-plan-pr-200-7dca3e7688ca179ebdf6e5cfc6abb402fece3eb4`

### Summary

- Aggregated 1 Terraform plan summaries: 0 to add, 1 to change, 0 to destroy.
<!-- homelab-terragrunt-plan:end -->
