### PR TITLE
fix(ci): probe deploy workflow against Nomad port 4646

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,7 +107,7 @@ jobs:
         with:
           aws-region: us-east-1
           connectivity-probe-address: 100.94.104.7
-          connectivity-probe-port: "22"
+          connectivity-probe-port: "4646"
           tailscale-auth-key: ${{ secrets.TS_AUTH_KEY }}
           tailscale-auth-key-parameter: ${{ vars.TAILSCALE_AUTH_KEY_SSM_PARAMETER }}
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -73,7 +73,7 @@ class WorkflowTests(unittest.TestCase):
         self.assertIn("Install Ansible controller dependencies", content)
         self.assertIn("python -m pip install --upgrade pip ansible boto3 botocore", content)
         self.assertIn("connectivity-probe-address: 100.94.104.7", content)
-        self.assertIn('connectivity-probe-port: "22"', content)
+        self.assertIn('connectivity-probe-port: "4646"', content)
         self.assertIn("tailscale-auth-key: ${{ secrets.TS_AUTH_KEY }}", content)
         self.assertIn("tailscale-auth-key-parameter: ${{ vars.TAILSCALE_AUTH_KEY_SSM_PARAMETER }}", content)
         self.assertIn("INGRESS_IP: 100.94.104.7", content)


### PR DESCRIPTION
## Summary
- switch deploy workflow connectivity probe from TCP/22 to TCP/4646
- update CI workflow unit test assertion to match deploy workflow probe port

## Validation
- python3 -m unittest tests/test_ci_workflows.py -v
- ./scripts/validate.sh (passes unit/skill checks; fails at validate-nomad due to missing nomad binary in this environment)

## Context
Addresses HOM-450 and unblocks HOM-469 QA verification of Setup infrastructure access behavior.

<!-- homelab-terragrunt-plan:start -->
## Homelab Terragrunt Plan

- Status: `success`
- Stack: `terraform/live/homelab`
- Commit: `672ecc9ad480`
- Run: [Workflow run](https://github.com/Stuhlmuller/homelab/actions/runs/24301108972)
- Artifact: `terragrunt-plan-pr-201-672ecc9ad4807fd1a2ae9acd05c24640eca4bbf2`

### Summary

- Aggregated 1 Terraform plan summaries: 0 to add, 1 to change, 0 to destroy.
<!-- homelab-terragrunt-plan:end -->
