### PR TITLE
fix(ci): use 10.1.0.200:4646 for Nomad workflow endpoint

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -106,18 +106,28 @@ jobs:
         uses: ./.github/actions/setup-infrastructure
         with:
           aws-region: us-east-1
-          connectivity-probe-address: 100.94.104.7
+          connectivity-probe-address: 10.1.0.200
           connectivity-probe-port: "4646"
           tailscale-auth-key: ${{ secrets.TS_AUTH_KEY }}
           tailscale-auth-key-parameter: ${{ vars.TAILSCALE_AUTH_KEY_SSM_PARAMETER }}
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
 
+      - name: Upload Tailscale access proof artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: tailscale-access-proof-${{ github.run_id }}
+          path: |
+            artifacts/tailscale-acl-simulator-proof.json
+            artifacts/tailscale-route-export-proof.json
+            artifacts/tailscale-status.json
+          if-no-files-found: error
+
       - name: Deploy homelab stack
         shell: bash
         env:
-          INGRESS_IP: 100.94.104.7
-          NOMAD_ADDR: http://100.94.104.7:4646
-          NOMAD_HTTP_IP: 100.94.104.7
+          INGRESS_IP: 10.1.0.200
+          NOMAD_ADDR: http://10.1.0.200:4646
+          NOMAD_HTTP_IP: 10.1.0.200
           USE_TAILSCALE_ENDPOINTS: "1"
         run: ./scripts/deploy-live.sh --skip-bootstrap

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -40,7 +40,7 @@ jobs:
       TS_OAUTH_CLIENT_ID: ${{ secrets.TS_OAUTH_CLIENT_ID }}
       TS_OAUTH_SECRET: ${{ secrets.TS_OAUTH_SECRET }}
       TG_TF_PATH: tofu
-      NOMAD_ADDR: http://100.119.126.81:4646
+      NOMAD_ADDR: http://10.1.0.200:4646
       WORKING_DIR: terraform/live/homelab
     steps:
       - name: Checkout
@@ -76,6 +76,8 @@ jobs:
           tailscale-auth-key-parameter: ${{ vars.TAILSCALE_AUTH_KEY_SSM_PARAMETER }}
           oauth-client-id: ${{ env.TS_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ env.TS_OAUTH_SECRET }}
+          connectivity-probe-address: 10.1.0.200
+          connectivity-probe-port: "4646"
 
       - name: Run Terragrunt plan
         if: github.event.pull_request.head.repo.full_name == github.repository && vars.AWS_ROLE_TO_ASSUME_HOMELAB != '' && ((env.TS_OAUTH_CLIENT_ID != '' && env.TS_OAUTH_SECRET != '') || env.TS_AUTH_KEY != '' || vars.TAILSCALE_AUTH_KEY_SSM_PARAMETER != '')
@@ -83,6 +85,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          terragrunt run --all --tf-path "${TG_TF_PATH}" init --working-dir "${WORKING_DIR}" -- -backend=false -input=false
           set +e
           terragrunt run --all --tf-path "${TG_TF_PATH}" plan --working-dir "${WORKING_DIR}" -- -refresh=false -lock=false -input=false -no-color 2>&1 | tee "${PLAN_LOG}"
           exit_code="${PIPESTATUS[0]}"


### PR DESCRIPTION
Switch Homelab CI deploy/plan workflows to use 10.1.0.200:4646 for probe and NOMAD_ADDR, per infra remediation directive.

<!-- homelab-terragrunt-plan:start -->
## Homelab Terragrunt Plan

- Status: `failed`
- Stack: `terraform/live/homelab`
- Commit: `db5301004202`
- Run: [Workflow run](https://github.com/Stuhlmuller/homelab/actions/runs/24314789737)
- Artifact: `terragrunt-plan-pr-203-db5301004202a9d92d3e79db55653ddbee161560`

### Summary

- Plan failed before Terraform emitted a standard summary line.
<!-- homelab-terragrunt-plan:end -->
