### PR TITLE
chore(ci): capture tailnet diagnostics before timeout

### DIFF
--- a/.github/actions/setup-infrastructure/action.yml
+++ b/.github/actions/setup-infrastructure/action.yml
@@ -121,6 +121,48 @@ runs:
       shell: bash
       run: sudo tailscale set --accept-routes=true
 
+    - name: Capture pre-probe tailnet diagnostics
+      if: inputs.connectivity-probe-address != ''
+      env:
+        CONNECTIVITY_PROBE_ADDRESS: ${{ inputs.connectivity-probe-address }}
+        CONNECTIVITY_PROBE_PORT: ${{ inputs.connectivity-probe-port }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        mkdir -p artifacts
+
+        tailscale status --json > artifacts/tailscale-status.json || true
+        ip route show > artifacts/ip-route.txt || true
+        tailscale ping -c 3 "${CONNECTIVITY_PROBE_ADDRESS}" > artifacts/tailscale-ping.txt 2>&1 || true
+
+        python3 - <<'PY' > artifacts/tcp-probe-summary.md
+import json
+import os
+import socket
+import time
+
+address = os.environ["CONNECTIVITY_PROBE_ADDRESS"]
+port_text = os.environ.get("CONNECTIVITY_PROBE_PORT", "")
+ports = [int(port_text)] if port_text else [22, 4646]
+
+print("## Pre-Probe TCP Snapshot")
+print("")
+print(f"- target: `{address}`")
+print("")
+for port in ports:
+    started = time.time()
+    ok = True
+    err = ""
+    try:
+        socket.create_connection((address, port), timeout=1).close()
+    except Exception as exc:
+        ok = False
+        err = str(exc)
+    elapsed_ms = int((time.time() - started) * 1000)
+    status = "open" if ok else "timeout_or_blocked"
+    print(f"- `{address}:{port}` -> `{status}` ({elapsed_ms} ms){' - ' + err if err else ''}")
+PY
+
     - name: Wait for Tailscale subnet reachability
       if: inputs.connectivity-probe-address != ''
       env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -114,14 +114,16 @@ jobs:
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
 
       - name: Upload Tailscale access proof artifact
+        if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: tailscale-access-proof-${{ github.run_id }}
           path: |
-            artifacts/tailscale-acl-simulator-proof.json
-            artifacts/tailscale-route-export-proof.json
             artifacts/tailscale-status.json
-          if-no-files-found: error
+            artifacts/ip-route.txt
+            artifacts/tailscale-ping.txt
+            artifacts/tcp-probe-summary.md
+          if-no-files-found: warn
 
       - name: Deploy homelab stack
         shell: bash


### PR DESCRIPTION
Collect tailscale status/route/ping/tcp snapshot before setup probe timeout, and upload artifact even on failure.

<!-- homelab-terragrunt-plan:start -->
## Homelab Terragrunt Plan

- Status: `failed`
- Stack: `terraform/live/homelab`
- Commit: `3fe362d84acf`
- Run: [Workflow run](https://github.com/Stuhlmuller/homelab/actions/runs/24316525360)
- Artifact: `terragrunt-plan-pr-205-3fe362d84acf751cced43bc0ba086d7e784ffd15`

### Summary

- Plan failed before Terraform emitted a standard summary line.
<!-- homelab-terragrunt-plan:end -->
