### PR TITLE
fix(ci): restore setup-infrastructure action parsing

### DIFF
--- a/.github/actions/setup-infrastructure/action.yml
+++ b/.github/actions/setup-infrastructure/action.yml
@@ -136,32 +136,32 @@ runs:
         tailscale ping -c 3 "${CONNECTIVITY_PROBE_ADDRESS}" > artifacts/tailscale-ping.txt 2>&1 || true
 
         python3 - <<'PY' > artifacts/tcp-probe-summary.md
-import json
-import os
-import socket
-import time
+        import json
+        import os
+        import socket
+        import time
 
-address = os.environ["CONNECTIVITY_PROBE_ADDRESS"]
-port_text = os.environ.get("CONNECTIVITY_PROBE_PORT", "")
-ports = [int(port_text)] if port_text else [22, 4646]
+        address = os.environ["CONNECTIVITY_PROBE_ADDRESS"]
+        port_text = os.environ.get("CONNECTIVITY_PROBE_PORT", "")
+        ports = [int(port_text)] if port_text else [22, 4646]
 
-print("## Pre-Probe TCP Snapshot")
-print("")
-print(f"- target: `{address}`")
-print("")
-for port in ports:
-    started = time.time()
-    ok = True
-    err = ""
-    try:
-        socket.create_connection((address, port), timeout=1).close()
-    except Exception as exc:
-        ok = False
-        err = str(exc)
-    elapsed_ms = int((time.time() - started) * 1000)
-    status = "open" if ok else "timeout_or_blocked"
-    print(f"- `{address}:{port}` -> `{status}` ({elapsed_ms} ms){' - ' + err if err else ''}")
-PY
+        print("## Pre-Probe TCP Snapshot")
+        print("")
+        print(f"- target: `{address}`")
+        print("")
+        for port in ports:
+            started = time.time()
+            ok = True
+            err = ""
+            try:
+                socket.create_connection((address, port), timeout=1).close()
+            except Exception as exc:
+                ok = False
+                err = str(exc)
+            elapsed_ms = int((time.time() - started) * 1000)
+            status = "open" if ok else "timeout_or_blocked"
+            print(f"- `{address}:{port}` -> `{status}` ({elapsed_ms} ms){' - ' + err if err else ''}")
+        PY
 
     - name: Wait for Tailscale subnet reachability
       if: inputs.connectivity-probe-address != ''


### PR DESCRIPTION
## Summary
Fixes a YAML heredoc indentation regression in `.github/actions/setup-infrastructure/action.yml` that caused `Homelab Deploy` to fail before running any setup steps.

## Evidence
- Failing runs on `main` due to parser error: `24316528047`, `24316708241`
- Error: `action.yml: (Line: 140) could not find expected ':'`

## Change
- Indent the inline Python heredoc body under the composite-action `run` block so GitHub Actions parses the manifest correctly.

## Impact
- Unblocks `Setup infrastructure access` execution and allows diagnostics/proof collection in subsequent deploy runs.

<!-- homelab-terragrunt-plan:start -->
## Homelab Terragrunt Plan

- Status: `failed`
- Stack: `terraform/live/homelab`
- Commit: `a39b9037bb2a`
- Run: [Workflow run](https://github.com/Stuhlmuller/homelab/actions/runs/24316754984)
- Artifact: `terragrunt-plan-pr-206-a39b9037bb2a4f8649814337baf0e61257371923`

### Summary

- Plan failed before Terraform emitted a standard summary line.
<!-- homelab-terragrunt-plan:end -->
