### PR TITLE
fix(deps): block Nomad provider 2.6.0 until upstream fix release

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "description": "Temporarily block hashicorp/nomad 2.6.0 due to upstream schema mismatch (hashicorp/terraform-provider-nomad#609, fix in #608 pending release)",
+      "matchManagers": ["terraform"],
+      "matchPackageNames": ["hashicorp/nomad"],
+      "allowedVersions": "<2.6.0"
+    }
+  ],
   "lockFileMaintenance": {
     "enabled": true
   }


### PR DESCRIPTION
## Summary
Temporarily blocks Renovate from opening `hashicorp/nomad` provider bumps to `2.6.0`, which currently fails validation due to an upstream provider schema mismatch bug.

## Why
- Homelab validate is failing on PRs that bump Nomad provider to `~> 2.6.0`.
- Upstream bug: https://github.com/hashicorp/terraform-provider-nomad/issues/609
- Upstream fix merged: https://github.com/hashicorp/terraform-provider-nomad/pull/608
- As of April 17, 2026, that fix is merged but not yet released in a provider version.

## Change
- Added a Renovate `packageRules` entry in `renovate.json`:
  - manager: `terraform`
  - package: `hashicorp/nomad`
  - allowed versions: `<2.6.0`

## Follow-up
Once a Nomad provider release includes #608, relax/remove this rule and allow upgrades again.