### PR TITLE
fix(ci): detect tailscale lockout reliably in preflight

### DIFF
--- a/.github/actions/setup-infrastructure/action.yml
+++ b/.github/actions/setup-infrastructure/action.yml
@@ -174,21 +174,7 @@ runs:
         deadline=$((SECONDS + CONNECTIVITY_TIMEOUT_SECONDS))
 
         while ((SECONDS < deadline)); do
-          if tailscale status --json 2>/dev/null | python3 - <<'PY'
-        import json
-        import sys
-
-        try:
-            payload = json.load(sys.stdin)
-        except Exception:
-            raise SystemExit(1)
-
-        for item in payload.get("Health", []):
-            if "locked out" in item.lower():
-                raise SystemExit(0)
-
-        raise SystemExit(1)
-        PY
+          if tailscale status --json 2>/dev/null | python3 -c 'import json, sys; payload = json.load(sys.stdin); sys.exit(0 if any("locked out" in str(item).lower() for item in payload.get("Health", [])) else 1)'
           then
             echo "::error::Tailscale reports this CI node is locked out (Tailnet Lock). Sign the node key or provide a preapproved auth key."
             exit 1


### PR DESCRIPTION
## Summary
- replace the heredoc-based lockout detection with a single-line Python JSON check in setup-infrastructure
- ensure Tailnet Lock health state is detected reliably before waiting for TCP probe timeout

## Verification
- `python3 -m unittest tests.test_secrets tests.test_ci_workflows -v`

## Context
Follow-up to #214: the initial lockout check used an indented heredoc block that did not evaluate as intended in composite-action YAML. This keeps the same behavior with deterministic parsing.

<!-- homelab-terragrunt-plan:start -->
## Homelab Terragrunt Plan

- Status: `failed`
- Stack: `terraform/live/homelab`
- Commit: `a811bfde1243`
- Run: [Workflow run](https://github.com/Stuhlmuller/homelab/actions/runs/24580399119)
- Artifact: `terragrunt-plan-pr-216-a811bfde1243eb3dc2ee919b86b63238b1c5e608`

### Summary

- Plan failed before Terraform emitted a standard summary line.
<!-- homelab-terragrunt-plan:end -->
