### PR TITLE
Add Tailscale exit node

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,9 @@ homelab/
   the tailnet.
 - `acer` is the primary Nomad and HTTP ingress node on the LAN.
 - `zimaboard-0` continues to advertise the `10.1.0.0/24` subnet into
-  Tailscale until the new primary has completed first-time tailnet enrollment;
-  the Debian hosts themselves do not accept tailnet routes during bootstrap.
+  Tailscale and is the declared Tailscale exit node until the new primary has
+  completed first-time tailnet enrollment; the Debian hosts themselves do not
+  accept tailnet routes during bootstrap.
 - Traefik is pinned to `nomad-primary` so `80` and `443` stay stable on the
   designated ingress node.
 - Traefik also publishes the Nomad and Consul UIs at

--- a/ansible/collections/requirements.yml
+++ b/ansible/collections/requirements.yml
@@ -1,2 +1,3 @@
 collections:
   - name: amazon.aws
+  - name: ansible.posix

--- a/ansible/inventories/production/group_vars/all.yml
+++ b/ansible/inventories/production/group_vars/all.yml
@@ -25,6 +25,7 @@ aws_region: us-east-1
 tailscale_enabled: true
 tailscale_accept_routes: false
 tailscale_advertise_routes: []
+tailscale_advertise_exit_node: false
 tailscale_args:
   - --ssh
 docker_apt_release: bookworm

--- a/ansible/inventories/production/hosts.yml
+++ b/ansible/inventories/production/hosts.yml
@@ -20,6 +20,7 @@ all:
           nomad_node_class: worker
           tailscale_advertise_routes:
             - 10.1.0.0/24
+          tailscale_advertise_exit_node: true
         zimaboard-1:
           ansible_host: 10.1.0.201
           tailscale_ip: 100.102.247.126

--- a/ansible/roles/tailscale/tasks/main.yml
+++ b/ansible/roles/tailscale/tasks/main.yml
@@ -104,9 +104,6 @@
   when:
     - tailscale_enabled
     - tailscale_up_argv is defined
-    - tailscale_status.rc != 0 or '"BackendState":"Running"' not in tailscale_status.stdout
-      or tailscale_advertise_exit_node | default(false) | bool
-      or (tailscale_advertise_routes | default([]) | length > 0)
 
 - name: Read Tailscale Funnel status when configured
   ansible.builtin.command: tailscale funnel status

--- a/ansible/roles/tailscale/tasks/main.yml
+++ b/ansible/roles/tailscale/tasks/main.yml
@@ -42,12 +42,36 @@
     - tailscale_status.rc == 0
     - tailscale_status.stdout | default('') | length > 0
 
+- name: Enable IPv4 forwarding for Tailscale routers
+  ansible.posix.sysctl:
+    name: net.ipv4.ip_forward
+    value: "1"
+    state: present
+    reload: true
+    sysctl_set: true
+  when:
+    - tailscale_enabled
+    - (tailscale_advertise_exit_node | default(false) | bool)
+      or (tailscale_advertise_routes | default([]) | length > 0)
+
+- name: Enable IPv6 forwarding for Tailscale exit nodes
+  ansible.posix.sysctl:
+    name: net.ipv6.conf.all.forwarding
+    value: "1"
+    state: present
+    reload: true
+    sysctl_set: true
+  when:
+    - tailscale_enabled
+    - tailscale_advertise_exit_node | default(false) | bool
+
 - name: Build Tailscale up arguments
   ansible.builtin.set_fact:
     tailscale_up_argv: >-
       {{
         ['tailscale', 'up', '--reset']
         + (tailscale_accept_routes | default(false) | bool | ternary(['--accept-routes'], []))
+        + (tailscale_advertise_exit_node | default(false) | bool | ternary(['--advertise-exit-node'], []))
         + (
           (tailscale_advertise_routes | default([]) | length > 0)
           | ternary(
@@ -81,6 +105,8 @@
     - tailscale_enabled
     - tailscale_up_argv is defined
     - tailscale_status.rc != 0 or '"BackendState":"Running"' not in tailscale_status.stdout
+      or tailscale_advertise_exit_node | default(false) | bool
+      or (tailscale_advertise_routes | default([]) | length > 0)
 
 - name: Read Tailscale Funnel status when configured
   ansible.builtin.command: tailscale funnel status

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -37,9 +37,11 @@ class InventoryTests(unittest.TestCase):
         self.assertIn("target: http://127.0.0.1:18080", content)
         self.assertIn("tailscale_advertise_routes:", content)
         self.assertIn("10.1.0.0/24", content)
+        self.assertIn("tailscale_advertise_exit_node: true", content)
 
     def test_group_vars_do_not_accept_tailscale_routes_by_default(self) -> None:
         content = GROUP_VARS.read_text()
         self.assertIn("tailscale_accept_routes: false", content)
+        self.assertIn("tailscale_advertise_exit_node: false", content)
         self.assertNotIn("  - --accept-routes", content)
         self.assertNotIn("--advertise-tags=tag:homelab", content)

--- a/tests/test_live_ops.py
+++ b/tests/test_live_ops.py
@@ -61,6 +61,11 @@ class LiveOpsTests(unittest.TestCase):
         self.assertIn("import boto3, botocore", content)
         self.assertIn("repository validation", content)
 
+    def test_ansible_collections_include_posix_for_sysctl(self) -> None:
+        content = (ROOT / "ansible" / "collections" / "requirements.yml").read_text()
+        self.assertIn("amazon.aws", content)
+        self.assertIn("ansible.posix", content)
+
     def test_live_workload_validation_checks_tailscale_backend_state(self) -> None:
         content = (ROOT / "scripts/validate-live-workloads.sh").read_text()
         self.assertIn('tailscale status --json', content)
@@ -107,6 +112,13 @@ class LiveOpsTests(unittest.TestCase):
         self.assertIn("--set-path=", content)
         self.assertIn("--bg", content)
         self.assertIn("--yes", content)
+
+    def test_tailscale_role_can_advertise_exit_node(self) -> None:
+        content = (ROOT / "ansible" / "roles" / "tailscale" / "tasks" / "main.yml").read_text()
+        self.assertIn("tailscale_advertise_exit_node", content)
+        self.assertIn("--advertise-exit-node", content)
+        self.assertIn("net.ipv4.ip_forward", content)
+        self.assertIn("net.ipv6.conf.all.forwarding", content)
 
     def test_deploy_script_does_not_mix_terragrunt_all_with_graph(self) -> None:
         content = (ROOT / "scripts/deploy-live.sh").read_text()

--- a/tests/test_live_ops.py
+++ b/tests/test_live_ops.py
@@ -119,6 +119,7 @@ class LiveOpsTests(unittest.TestCase):
         self.assertIn("--advertise-exit-node", content)
         self.assertIn("net.ipv4.ip_forward", content)
         self.assertIn("net.ipv6.conf.all.forwarding", content)
+        self.assertNotIn('"BackendState":"Running"', content)
 
     def test_deploy_script_does_not_mix_terragrunt_all_with_graph(self) -> None:
         content = (ROOT / "scripts/deploy-live.sh").read_text()


### PR DESCRIPTION
## Summary

This PR declares `zimaboard-0` as the homelab Tailscale exit node while preserving its existing `10.1.0.0/24` subnet-route advertisement.

The existing Tailscale role had the route advertisement wired through inventory, but it only reran `tailscale up` when the daemon was not already running. That meant an already-enrolled and healthy node could miss later inventory changes such as exit-node advertising. This change adds an explicit `tailscale_advertise_exit_node` inventory default, enables it for `zimaboard-0`, and includes `--advertise-exit-node` in the reconciled `tailscale up` arguments.

The role now also enables the forwarding sysctls needed by subnet routers and exit nodes before applying Tailscale settings. Since those sysctls use the `ansible.posix.sysctl` module, the collection requirements now include `ansible.posix` so fresh controllers can run the playbook reliably.

README and repository tests were updated to document and pin the intended behavior.

## Validation

- `./scripts/survey-cluster.sh` completed read-only, but this environment could not ping the LAN nodes.
- `make validate` passed.
- Commit hooks passed during `git commit`, including validate-nomad, validate-terraform, validate-ansible, and repo-tests.

## Completion Gate

- [x] I ran repository validation (`make validate`) after my final code edits.
- [x] I committed and pushed the final implementation changes for this issue.
- [x] I understand this work is only complete after this PR is merged into `main`.