### PR TITLE
Persist OpenClaw config on shared storage

### DIFF
--- a/nomad/jobs/openclaw/job.nomad.hcl
+++ b/nomad/jobs/openclaw/job.nomad.hcl
@@ -1,0 +1,153 @@
+variable "openclaw_nomad_node_name" {
+  type    = string
+  default = "nomad-primary"
+}
+
+job "openclaw" {
+  datacenters = ["homelab"]
+  type        = "service"
+
+  group "openclaw" {
+    count = 1
+
+    constraint {
+      attribute = "${node.unique.name}"
+      value     = var.openclaw_nomad_node_name
+    }
+
+    network {
+      mode = "bridge"
+
+      port "http" {
+        to = 18789
+      }
+    }
+
+    volume "shared-data" {
+      type            = "csi"
+      source          = "shared-data"
+      read_only       = false
+      attachment_mode = "file-system"
+      access_mode     = "multi-node-multi-writer"
+
+      mount_options {
+        fs_type     = "nfs"
+        mount_flags = ["vers=4.1", "noatime", "nodiratime"]
+      }
+    }
+
+    service {
+      name = "openclaw"
+      port = "http"
+
+      tags = [
+        "traefik.enable=true",
+        "traefik.http.routers.openclaw.rule=Host(`openclaw.stinkyboi.com`)",
+        "traefik.http.routers.openclaw.entrypoints=websecure",
+        "traefik.http.routers.openclaw.tls=true",
+        "traefik.http.routers.openclaw.tls.certresolver=letsencrypt",
+      ]
+
+      check {
+        name     = "openclaw-ready"
+        type     = "http"
+        path     = "/readyz"
+        port     = "http"
+        interval = "30s"
+        timeout  = "10s"
+      }
+    }
+
+    task "openclaw-init" {
+      driver = "docker"
+      user   = "1000"
+      lifecycle {
+        hook = "prestart"
+      }
+
+      config {
+        image   = "ghcr.io/openclaw/openclaw:2026.4.15"
+        command = "sh"
+        args = [
+          "-c",
+          "mkdir -p /data/openclaw/config /data/openclaw/state /data/openclaw/workspace",
+        ]
+      }
+
+      volume_mount {
+        volume      = "shared-data"
+        destination = "/data"
+        read_only   = false
+      }
+
+      resources {
+        cpu    = 100
+        memory = 128
+      }
+    }
+
+    task "openclaw" {
+      driver = "docker"
+      user   = "1000"
+
+      config {
+        image   = "ghcr.io/openclaw/openclaw:2026.4.15"
+        command = "sh"
+        args = [
+          "-c",
+          "if [ ! -s /data/openclaw/config/openclaw.json ]; then cp ${NOMAD_SECRETS_DIR}/openclaw.bootstrap.json /data/openclaw/config/openclaw.json; fi; chmod 0600 /data/openclaw/config/openclaw.json; exec node dist/index.js gateway --port 18789",
+        ]
+        ports = ["http"]
+      }
+
+      template {
+        data        = <<-EOT
+          {{- with nomadVar "nomad/jobs/openclaw/config" -}}
+          {
+            gateway: {
+              mode: "local",
+              bind: "lan",
+              auth: {
+                mode: "token",
+                token: {{ .gateway_token.Value | toJSON }},
+              },
+              controlUi: {
+                allowedOrigins: [{{ .public_url.Value | toJSON }}],
+              },
+            },
+            agents: {
+              defaults: {
+                workspace: "/data/openclaw/workspace",
+              },
+            },
+            session: {
+              dmScope: "per-channel-peer",
+            },
+          }
+        {{- end -}}
+        EOT
+        destination = "secrets/openclaw.bootstrap.json"
+        change_mode = "restart"
+        uid         = 1000
+        gid         = 1000
+        perms       = "0400"
+      }
+
+      env {
+        OPENCLAW_CONFIG_PATH = "/data/openclaw/config/openclaw.json"
+        OPENCLAW_STATE_DIR   = "/data/openclaw/state"
+      }
+
+      volume_mount {
+        volume      = "shared-data"
+        destination = "/data"
+        read_only   = false
+      }
+
+      resources {
+        cpu    = 3000
+        memory = 4096
+      }
+    }
+  }
+}

--- a/terraform/live/homelab/jobs/openclaw/.terraform.lock.hcl
+++ b/terraform/live/homelab/jobs/openclaw/.terraform.lock.hcl
@@ -1,0 +1,41 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version = "6.45.0"
+  hashes = [
+    "h1:bAJenJM4HYzv6H82yvj27+KOoEm6LBZyUJGNVS6t1hY=",
+    "zh:0aed87baf61465ff47ec9f73785fd42f80271705c28ea5d145a220a70bc52e12",
+    "zh:1599fc46d0bd5b621ef054a93d69bbaba1e74828d9a59741ff13b10366dad245",
+    "zh:233b84d24e042e7187efc1ff601cdada61ee1bfab6facc454430d880660145ef",
+    "zh:295133d1097c14254729a24a61f4cb2e8d7f278f80a8cbfafd3ac9401ab370d6",
+    "zh:3f1ea8e92d2c9a51261ddd530d5a6224d99de31d1aa2d99586fd3c75d578fcc5",
+    "zh:412075c5252cd10857f8efee22b49243dc9150451fbcba31768035d3eaf283f0",
+    "zh:49ecd456fb8fee5562725c36bd5992b6982704100ead0164d26c6cbb11b07653",
+    "zh:4a5c7dde3bfa2458710f0c3bb95612b2751c38fd4e27c45c6b65f6175e9a8323",
+    "zh:56e58696b118291ccbc611349cb6e8ee16f3ae49204b62da4899286be879faeb",
+    "zh:5df6108ff27db2183c2f45fa988ad90cb6c37193ab6c29f923f6de69275e9de4",
+    "zh:82972a5ff709738c3ea27aa3ec02d4847221ede6601ac79788a8da34650f901b",
+    "zh:8f4f9ebdf23ee99552ee3d1b0acc8b47ca8ea4bb14aabecde693be5341b95265",
+    "zh:abf8e841bc94e872daf68874a9ba7a73e5487c11c59e31d3bcd11f73f6b8e29e",
+    "zh:b05796c799ab11b12f2510a06343d30fd61fdad09835ec24ac1741970a3d8f48",
+    "zh:d84d3e91e3c1f89b7f3b5914aedb1a78f5eb3a23b4e4fc6ba9214a54bb5a07c3",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/nomad" {
+  version     = "2.5.2"
+  constraints = "~> 2.5.2"
+  hashes = [
+    "h1:GLMMAUCTUmOliU8CkdgYcFr3w8TYjMneJgrP3S7QAE8=",
+    "zh:2ef8139181e8855c318be2e0f1bc3180f52a675a158ea1ddb3939f9ef79202c3",
+    "zh:33c7350e986756b0c4a2fcc5dad417823f1c4535699dad2fcb736e8838709c14",
+    "zh:3a4fa226ceded41ca4513cd9d261eb396cb3ed3549c9708eddd2d6eb8a3c4204",
+    "zh:3bc2956a3e25e617e2b65ee28d7f10fd330ec400a8dec8c0e50c4643b2283464",
+    "zh:534d2101c5d349e1b4b0614e57a47a56e0f8bf126c798f93dbc8ecf7943984e6",
+    "zh:57652799408405acb4476a2ab3b8dd022aa9d726516d3b7927aa2a097cbe9286",
+    "zh:6b61f2b3c898979c7fd939e45509370df1292c7d377df928996b16f4768289b1",
+    "zh:78870b227f9a90884bb47e352abdbf52bac0364ac9a5f584636a8637ab4a95f8",
+    "zh:ceda24edada8ed297bdf88a312b3476a080396636e6a115734adc279aa009f35",
+  ]
+}

--- a/terraform/live/homelab/jobs/openclaw/terragrunt.hcl
+++ b/terraform/live/homelab/jobs/openclaw/terragrunt.hcl
@@ -1,0 +1,23 @@
+terraform {
+  source = "../../../../modules/nomad_job"
+}
+
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+dependencies {
+  paths = [
+    "../../volumes/shared-data",
+  ]
+}
+
+inputs = {
+  jobspec_file     = "${dirname(find_in_parent_folders("root.hcl"))}/../nomad/jobs/openclaw/job.nomad.hcl"
+  purge_on_destroy = true
+  rerun_if_dead    = true
+
+  hcl2_vars = {
+    openclaw_nomad_node_name = "nomad-primary"
+  }
+}

--- a/tests/test_live_ops.py
+++ b/tests/test_live_ops.py
@@ -27,6 +27,7 @@ class LiveOpsTests(unittest.TestCase):
         traefik = (ROOT / "terraform/live/homelab/jobs/traefik/terragrunt.hcl").read_text()
         dokploy = (ROOT / "terraform/live/homelab/jobs/dokploy/terragrunt.hcl").read_text()
         fleetdm = (ROOT / "terraform/live/homelab/jobs/fleetdm/terragrunt.hcl").read_text()
+        openclaw = (ROOT / "terraform/live/homelab/jobs/openclaw/terragrunt.hcl").read_text()
         paperclip = (ROOT / "terraform/live/homelab/jobs/paperclip/terragrunt.hcl").read_text()
         policy_bot = (ROOT / "terraform/live/homelab/jobs/policy-bot/terragrunt.hcl").read_text()
 
@@ -36,6 +37,7 @@ class LiveOpsTests(unittest.TestCase):
         self.assertIn("../../variables/dokploy/config", dokploy)
         self.assertIn("../../volumes/shared-data", dokploy)
         self.assertIn("../../variables/fleetdm/config", fleetdm)
+        self.assertIn("../../volumes/shared-data", openclaw)
         self.assertIn("../../variables/paperclip/config", paperclip)
         self.assertIn("../../volumes/shared-data", paperclip)
         self.assertIn("../../variables/policy-bot/config", policy_bot)

--- a/tests/test_nomad_jobs.py
+++ b/tests/test_nomad_jobs.py
@@ -66,6 +66,17 @@ class NomadJobTests(unittest.TestCase):
         self.assertIn('OPENROUTER_API_KEY="{{ .openrouter_api_key.Value | trimSpace }}"', content)
         self.assertIn('Host = ["paperclip.stinkyboi.com"]', content)
 
+    def test_openclaw_persists_mutable_config_on_shared_storage(self) -> None:
+        content = (ROOT / "nomad" / "jobs" / "openclaw" / "job.nomad.hcl").read_text()
+        self.assertIn("ghcr.io/openclaw/openclaw:2026.4.15", content)
+        self.assertIn("traefik.http.routers.openclaw.rule", content)
+        self.assertIn('OPENCLAW_CONFIG_PATH = "/data/openclaw/config/openclaw.json"', content)
+        self.assertIn('OPENCLAW_STATE_DIR   = "/data/openclaw/state"', content)
+        self.assertIn("openclaw.bootstrap.json", content)
+        self.assertIn("if [ ! -s /data/openclaw/config/openclaw.json ]; then cp", content)
+        self.assertIn("chmod 0600 /data/openclaw/config/openclaw.json", content)
+        self.assertNotIn('OPENCLAW_CONFIG_PATH = "${NOMAD_SECRETS_DIR}/openclaw.json"', content)
+
     def test_policy_bot_job_routes_only_github_endpoints_through_traefik(self) -> None:
         content = (ROOT / "nomad" / "jobs" / "policy-bot" / "job.nomad.hcl").read_text()
         self.assertIn("palantirtechnologies/policy-bot:1.41.1", content)


### PR DESCRIPTION
## Summary
- Added a dedicated OpenClaw Nomad jobspec and live Terragrunt unit.
- Switched mutable app state off Nomad secrets and onto shared storage at `/data/openclaw/config/openclaw.json` so Discord/default model settings survive restarts.
- Kept a one-time bootstrap path for initial config materialization, then made the persisted config writable for subsequent UI updates.
- Added regression tests for the new job and live dependency wiring.

## Testing
- `make validate`
- Applied the live OpenClaw Terragrunt unit successfully and verified the job reached a healthy running deployment.

## Completion Gate
- [x] I ran repository validation (`make validate`) after my final code edits.
- [x] I committed and pushed the final implementation changes for this issue.
- [x] I understand this work is only complete after this PR is merged into `main`.

<!-- homelab-terragrunt-plan:start -->
## Homelab Terragrunt Plan

- Status: `success`
- Stack: `terraform/live/homelab`
- Commit: `fd5d2fe1aa30`
- Run: [Workflow run](https://github.com/Stuhlmuller/homelab/actions/runs/25952851471)
- Artifact: `terragrunt-plan-pr-232-fd5d2fe1aa3018858b1d757775e44ff5283de806`

### Summary

- Aggregated 1 Terraform plan summaries: 0 to add, 1 to change, 0 to destroy.
<!-- homelab-terragrunt-plan:end -->
