### PR TITLE
Document QNAP NFS storage configuration for homelab

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,7 @@ Known details from the existing onboarding guide:
 - Base worker config reference: `.talos/worker.yaml`
 - Worker nodes use hyphenated names such as `zimaboard-0`, `zimaboard-1`, and
   `zimaboard-2`.
+- Persistent storage NAS: QNAP NFS share `homelab` at `10.1.0.2`.
 
 Refresh these notes whenever the cluster topology changes. If they conflict
 with a newer runbook or live read-only inspection, update the docs in the same

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -31,6 +31,8 @@ as `zimaboard_1`; underscores are not valid Kubernetes node hostnames.
 - Control-plane config: `.talos/controlplane.yaml`
 - Base worker config: `.talos/worker.yaml`
 - Worker install disk: `/dev/mmcblk0`
+- Persistent storage NAS: QNAP at `10.1.0.2`
+- Persistent storage NFS share: `homelab`
 - USB install media appears as `/dev/sda` and must not remain the system disk.
 - Worker NICs are expected to look like:
   - `enp2s0`: linked and active
@@ -42,6 +44,63 @@ authenticated Talos API calls through `.talos/talosconfig`.
 
 The old `10.1.0.216` control-plane address is stale. Do not use it as the
 canonical Kubernetes API endpoint or Talos endpoint for new work.
+
+## Persistent Storage
+
+Shared persistent storage for Kubernetes workloads is provided by a QNAP NAS on
+the homelab LAN.
+
+| System | Address | Protocol | Share | Intended use |
+| --- | --- | --- | --- | --- |
+| QNAP NAS | `10.1.0.2` | NFS | `homelab` | Backing storage for Kubernetes persistent volumes |
+
+The NAS share is the cluster-level durable storage target. It is separate from
+Talos node persistence: each node should still boot from and keep Talos state on
+its internal system disk, while workload data that must survive pod rescheduling
+or node replacement should use the QNAP-backed storage class once that class is
+defined in Kubernetes.
+
+NAS-side expectations:
+
+- NFS service is enabled on the QNAP.
+- A shared folder or export named `homelab` exists.
+- The export allows read/write access from the Talos node addresses
+  `10.1.0.199`, `10.1.0.200`, `10.1.0.201`, and `10.1.0.202`, or from the
+  narrower trusted node subnet if the node list changes.
+- Access controls, UID/GID ownership, and squash behavior are documented beside
+  any workload that depends on a specific filesystem identity.
+
+Kubernetes storage integration should be declared in git rather than configured
+by hand in the cluster. When a CSI driver, external provisioner, or static
+`PersistentVolume` is added, use these source values:
+
+```yaml
+server: 10.1.0.2
+share: homelab
+```
+
+Record the exact QNAP NFS export path in the storage manifest when it is wired
+into Kubernetes. Many examples use paths like `10.1.0.2:/homelab`, but QNAP can
+show a device-specific export path in its UI. Prefer the path reported by the
+NAS over an assumed path.
+
+Operator workstation checks:
+
+```sh
+showmount -e 10.1.0.2
+```
+
+Expected evidence:
+
+```text
+Export list for 10.1.0.2:
+<qnap-export-path-for-homelab>  <allowed-clients>
+```
+
+Before making the QNAP-backed storage class the default, verify that a test PVC
+can be created, written, deleted, and recreated with the expected reclaim
+policy. Document backup and restore expectations before placing important
+stateful workloads on this storage.
 
 ## Required Control-Plane Config
 


### PR DESCRIPTION
## Summary
- Document the QNAP NAS at `10.1.0.2` as the cluster’s persistent storage backend.
- Record the `homelab` NFS share and the expected NAS-side access requirements.
- Add guidance for wiring the export into Kubernetes storage manifests and verifying it before making it the default.
- Mirror the key storage note in `AGENTS.md` so future agents have the same cluster context.

## Testing
- Not run (not requested).