### PR TITLE
feat: add Argo CD OIDC SSO via Dex and AWS SSM

### DIFF
--- a/IaC/bootstrap/argocd/README.md
+++ b/IaC/bootstrap/argocd/README.md
@@ -14,6 +14,23 @@ The stack installs Argo CD into the `argocd` namespace with the pinned
 CD Application CRD and applies the repo-owned `argocd-self-management`
 manifest.
 
+The Helm values also configure Argo CD SSO through the bundled Dex server with
+a SAML connector. The SAML connector reads its provider-specific values through
+the Argo CD secret reference syntax from a Kubernetes Secret named
+`argocd-saml-sso`. That Secret is created by External Secrets Operator from AWS
+Systems Manager Parameter Store through the `argocd-ssm` `SecretStore`.
+
+Required Parameter Store paths:
+
+| Path | Kubernetes key | Purpose |
+| --- | --- | --- |
+| `/homelab/argocd/saml/url` | `url` | Browser-facing Argo CD base URL registered with the IdP. |
+| `/homelab/argocd/saml/sso-url` | `ssoURL` | SAML IdP HTTP POST SSO URL. |
+| `/homelab/argocd/saml/ca-data` | `caData` | Base64-encoded PEM CA/signing certificate data for Dex SAML validation. |
+| `/homelab/argocd/saml/callback-url` | `callback` | Dex callback URL, normally `<url>/api/dex/callback`. |
+| `/homelab/argocd/saml/client-id` | `clientID` | SAML SP entity ID/client ID used as Dex `entityIssuer`. |
+| `/homelab/argocd/saml/client-secret` | `clientSecret` | IdP-issued client secret kept out of git. Dex SAML does not consume this field directly. |
+
 The `terraform.source` value points directly at the Terragrunt catalog
 `helm-release` module pinned to version `0.3.0`. There are no repository-local
 OpenTofu modules in this bootstrap stack.
@@ -22,4 +39,5 @@ All desired-state inputs here are committed non-secret values. Do not add
 `get_env`, `TF_VAR_*`, shell-exported values, raw kubeconfigs, repository
 tokens, private keys, or certificate material to this stack. CI/CD may inject
 credentials at runtime; the desired state must remain visible in this file or
-the module defaults it calls.
+the module defaults it calls. Keep SAML client secrets and IdP certificate
+material in AWS Parameter Store, not in this repository or Helm values.

--- a/IaC/bootstrap/argocd/README.md
+++ b/IaC/bootstrap/argocd/README.md
@@ -15,21 +15,28 @@ CD Application CRD and applies the repo-owned `argocd-self-management`
 manifest.
 
 The Helm values also configure Argo CD SSO through the bundled Dex server with
-a SAML connector. The SAML connector reads its provider-specific values through
-the Argo CD secret reference syntax from a Kubernetes Secret named
-`argocd-saml-sso`. That Secret is created by External Secrets Operator from AWS
-Systems Manager Parameter Store through the `argocd-ssm` `SecretStore`.
+an OpenID Connect connector. The connector reads its provider-specific values
+through the Argo CD secret reference syntax from a Kubernetes Secret named
+`argocd-oidc-sso`.
+
+External Secrets Operator resources for creating `argocd-oidc-sso` from AWS
+Systems Manager Parameter Store live in the Argo CD self-management path at
+`clusters/homelab/argocd/self-management/oidc-external-secret.yaml`. Keeping
+those CRD-backed resources out of this initial Helm release lets the bootstrap
+install Argo CD before External Secrets Operator is available.
 
 Required Parameter Store paths:
 
 | Path | Kubernetes key | Purpose |
 | --- | --- | --- |
-| `/homelab/argocd/saml/url` | `url` | Browser-facing Argo CD base URL registered with the IdP. |
-| `/homelab/argocd/saml/sso-url` | `ssoURL` | SAML IdP HTTP POST SSO URL. |
-| `/homelab/argocd/saml/ca-data` | `caData` | Base64-encoded PEM CA/signing certificate data for Dex SAML validation. |
-| `/homelab/argocd/saml/callback-url` | `callback` | Dex callback URL, normally `<url>/api/dex/callback`. |
-| `/homelab/argocd/saml/client-id` | `clientID` | SAML SP entity ID/client ID used as Dex `entityIssuer`. |
-| `/homelab/argocd/saml/client-secret` | `clientSecret` | IdP-issued client secret kept out of git. Dex SAML does not consume this field directly. |
+| `/homelab/argocd/oidc/url` | `url` | Browser-facing Argo CD base URL registered with the IdP. |
+| `/homelab/argocd/oidc/issuer` | `issuer` | OIDC issuer URL used for provider discovery. |
+| `/homelab/argocd/oidc/client-id` | `clientID` | OIDC client ID issued by the IdP. |
+| `/homelab/argocd/oidc/client-secret` | `clientSecret` | OIDC client secret kept out of git. |
+
+Register `<url>/api/dex/callback` as the IdP callback URL. Argo CD derives the
+Dex connector callback from its configured `url`; do not store a separate
+callback value in git or Parameter Store.
 
 The `terraform.source` value points directly at the Terragrunt catalog
 `helm-release` module pinned to version `0.3.0`. There are no repository-local
@@ -39,5 +46,5 @@ All desired-state inputs here are committed non-secret values. Do not add
 `get_env`, `TF_VAR_*`, shell-exported values, raw kubeconfigs, repository
 tokens, private keys, or certificate material to this stack. CI/CD may inject
 credentials at runtime; the desired state must remain visible in this file or
-the module defaults it calls. Keep SAML client secrets and IdP certificate
-material in AWS Parameter Store, not in this repository or Helm values.
+the module defaults it calls. Keep OIDC client secrets and IdP-specific values
+in AWS Parameter Store, not in this repository or Helm values.

--- a/IaC/bootstrap/argocd/terragrunt.hcl
+++ b/IaC/bootstrap/argocd/terragrunt.hcl
@@ -4,6 +4,10 @@ include "root" {
 
 locals {
   self_management_application_manifest = "${get_terragrunt_dir()}/../../../clusters/homelab/argocd/self-management/application.yaml"
+  saml_sso_secret_name                 = "argocd-saml-sso"
+  saml_sso_store_name                  = "argocd-ssm"
+  saml_sso_parameter_prefix            = "/homelab/argocd/saml"
+  saml_sso_admin_group                 = "argocd-admins"
 }
 
 terraform {
@@ -30,9 +34,37 @@ inputs = {
   values = [
     yamlencode({
       configs = {
+        cm = {
+          url          = format("$%s:url", local.saml_sso_secret_name)
+          "dex.config" = <<-EOT
+            connectors:
+              - type: saml
+                id: saml
+                name: SAML
+                config:
+                  ssoURL: ${format("$%s:ssoURL", local.saml_sso_secret_name)}
+                  caData: ${format("$%s:caData", local.saml_sso_secret_name)}
+                  redirectURI: ${format("$%s:callback", local.saml_sso_secret_name)}
+                  usernameAttr: email
+                  emailAttr: email
+                  groupsAttr: groups
+                  entityIssuer: ${format("$%s:clientID", local.saml_sso_secret_name)}
+          EOT
+        }
+
         params = {
           "server.insecure" = "true"
         }
+
+        rbac = {
+          "policy.default" = "role:readonly"
+          "policy.csv"     = "g, ${local.saml_sso_admin_group}, role:admin\n"
+          scopes           = "[groups, email]"
+        }
+      }
+
+      dex = {
+        enabled = true
       }
 
       server = {
@@ -40,6 +72,102 @@ inputs = {
           type = "ClusterIP"
         }
       }
+
+      extraObjects = [
+        {
+          apiVersion = "external-secrets.io/v1beta1"
+          kind       = "SecretStore"
+          metadata = {
+            name      = local.saml_sso_store_name
+            namespace = "argocd"
+            labels = {
+              "app.kubernetes.io/name"       = local.saml_sso_store_name
+              "app.kubernetes.io/part-of"    = "argocd"
+              "app.kubernetes.io/managed-by" = "terragrunt"
+            }
+          }
+          spec = {
+            provider = {
+              aws = {
+                service = "ParameterStore"
+                region  = "us-east-1"
+              }
+            }
+          }
+        },
+        {
+          apiVersion = "external-secrets.io/v1beta1"
+          kind       = "ExternalSecret"
+          metadata = {
+            name      = local.saml_sso_secret_name
+            namespace = "argocd"
+            labels = {
+              "app.kubernetes.io/name"       = local.saml_sso_secret_name
+              "app.kubernetes.io/part-of"    = "argocd"
+              "app.kubernetes.io/managed-by" = "terragrunt"
+            }
+          }
+          spec = {
+            refreshInterval = "1h"
+            secretStoreRef = {
+              kind = "SecretStore"
+              name = local.saml_sso_store_name
+            }
+            target = {
+              name           = local.saml_sso_secret_name
+              creationPolicy = "Owner"
+              template = {
+                type = "Opaque"
+                metadata = {
+                  labels = {
+                    "app.kubernetes.io/name"       = local.saml_sso_secret_name
+                    "app.kubernetes.io/part-of"    = "argocd"
+                    "app.kubernetes.io/managed-by" = "external-secrets"
+                  }
+                }
+              }
+            }
+            data = [
+              {
+                secretKey = "url"
+                remoteRef = {
+                  key = "${local.saml_sso_parameter_prefix}/url"
+                }
+              },
+              {
+                secretKey = "ssoURL"
+                remoteRef = {
+                  key = "${local.saml_sso_parameter_prefix}/sso-url"
+                }
+              },
+              {
+                secretKey = "caData"
+                remoteRef = {
+                  key = "${local.saml_sso_parameter_prefix}/ca-data"
+                }
+              },
+              {
+                secretKey = "callback"
+                remoteRef = {
+                  key = "${local.saml_sso_parameter_prefix}/callback-url"
+                }
+              },
+              {
+                secretKey = "clientID"
+                remoteRef = {
+                  key = "${local.saml_sso_parameter_prefix}/client-id"
+                }
+              },
+              {
+                secretKey = "clientSecret"
+                remoteRef = {
+                  key = "${local.saml_sso_parameter_prefix}/client-secret"
+                }
+              },
+            ]
+          }
+        },
+      ]
     })
   ]
 

--- a/IaC/bootstrap/argocd/terragrunt.hcl
+++ b/IaC/bootstrap/argocd/terragrunt.hcl
@@ -4,10 +4,8 @@ include "root" {
 
 locals {
   self_management_application_manifest = "${get_terragrunt_dir()}/../../../clusters/homelab/argocd/self-management/application.yaml"
-  saml_sso_secret_name                 = "argocd-saml-sso"
-  saml_sso_store_name                  = "argocd-ssm"
-  saml_sso_parameter_prefix            = "/homelab/argocd/saml"
-  saml_sso_admin_group                 = "argocd-admins"
+  oidc_sso_secret_name                 = "argocd-oidc-sso"
+  oidc_sso_admin_group                 = "argocd-admins"
 }
 
 terraform {
@@ -35,20 +33,22 @@ inputs = {
     yamlencode({
       configs = {
         cm = {
-          url          = format("$%s:url", local.saml_sso_secret_name)
+          url          = format("$%s:url", local.oidc_sso_secret_name)
           "dex.config" = <<-EOT
             connectors:
-              - type: saml
-                id: saml
-                name: SAML
+              - type: oidc
+                id: oidc
+                name: OIDC
                 config:
-                  ssoURL: ${format("$%s:ssoURL", local.saml_sso_secret_name)}
-                  caData: ${format("$%s:caData", local.saml_sso_secret_name)}
-                  redirectURI: ${format("$%s:callback", local.saml_sso_secret_name)}
-                  usernameAttr: email
-                  emailAttr: email
-                  groupsAttr: groups
-                  entityIssuer: ${format("$%s:clientID", local.saml_sso_secret_name)}
+                  issuer: ${format("$%s:issuer", local.oidc_sso_secret_name)}
+                  clientID: ${format("$%s:clientID", local.oidc_sso_secret_name)}
+                  clientSecret: ${format("$%s:clientSecret", local.oidc_sso_secret_name)}
+                  scopes:
+                    - openid
+                    - profile
+                    - email
+                    - groups
+                  insecureEnableGroups: true
           EOT
         }
 
@@ -58,7 +58,7 @@ inputs = {
 
         rbac = {
           "policy.default" = "role:readonly"
-          "policy.csv"     = "g, ${local.saml_sso_admin_group}, role:admin\n"
+          "policy.csv"     = "g, ${local.oidc_sso_admin_group}, role:admin\n"
           scopes           = "[groups, email]"
         }
       }
@@ -72,102 +72,6 @@ inputs = {
           type = "ClusterIP"
         }
       }
-
-      extraObjects = [
-        {
-          apiVersion = "external-secrets.io/v1beta1"
-          kind       = "SecretStore"
-          metadata = {
-            name      = local.saml_sso_store_name
-            namespace = "argocd"
-            labels = {
-              "app.kubernetes.io/name"       = local.saml_sso_store_name
-              "app.kubernetes.io/part-of"    = "argocd"
-              "app.kubernetes.io/managed-by" = "terragrunt"
-            }
-          }
-          spec = {
-            provider = {
-              aws = {
-                service = "ParameterStore"
-                region  = "us-east-1"
-              }
-            }
-          }
-        },
-        {
-          apiVersion = "external-secrets.io/v1beta1"
-          kind       = "ExternalSecret"
-          metadata = {
-            name      = local.saml_sso_secret_name
-            namespace = "argocd"
-            labels = {
-              "app.kubernetes.io/name"       = local.saml_sso_secret_name
-              "app.kubernetes.io/part-of"    = "argocd"
-              "app.kubernetes.io/managed-by" = "terragrunt"
-            }
-          }
-          spec = {
-            refreshInterval = "1h"
-            secretStoreRef = {
-              kind = "SecretStore"
-              name = local.saml_sso_store_name
-            }
-            target = {
-              name           = local.saml_sso_secret_name
-              creationPolicy = "Owner"
-              template = {
-                type = "Opaque"
-                metadata = {
-                  labels = {
-                    "app.kubernetes.io/name"       = local.saml_sso_secret_name
-                    "app.kubernetes.io/part-of"    = "argocd"
-                    "app.kubernetes.io/managed-by" = "external-secrets"
-                  }
-                }
-              }
-            }
-            data = [
-              {
-                secretKey = "url"
-                remoteRef = {
-                  key = "${local.saml_sso_parameter_prefix}/url"
-                }
-              },
-              {
-                secretKey = "ssoURL"
-                remoteRef = {
-                  key = "${local.saml_sso_parameter_prefix}/sso-url"
-                }
-              },
-              {
-                secretKey = "caData"
-                remoteRef = {
-                  key = "${local.saml_sso_parameter_prefix}/ca-data"
-                }
-              },
-              {
-                secretKey = "callback"
-                remoteRef = {
-                  key = "${local.saml_sso_parameter_prefix}/callback-url"
-                }
-              },
-              {
-                secretKey = "clientID"
-                remoteRef = {
-                  key = "${local.saml_sso_parameter_prefix}/client-id"
-                }
-              },
-              {
-                secretKey = "clientSecret"
-                remoteRef = {
-                  key = "${local.saml_sso_parameter_prefix}/client-secret"
-                }
-              },
-            ]
-          }
-        },
-      ]
     })
   ]
 

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -318,10 +318,10 @@ terragrunt apply
 Use `docs/argocd-bootstrap.md` for the full runbook, validation sequence,
 handoff rules, rollback path, and recovery notes. The initial bootstrap installs
 Argo CD in the `argocd` namespace, keeps the service internal, and creates the
-`argocd-self-management` Application in manual validation mode. Argo CD SAML SSO
-is configured through bundled Dex and reads its SSO settings from an
-External Secrets Operator-managed Kubernetes Secret backed by AWS Systems
-Manager Parameter Store paths under `/homelab/argocd/saml`.
+`argocd-self-management` Application in manual validation mode. Argo CD SSO is
+configured through bundled Dex with an upstream OIDC connector. The connector
+reads its settings from an External Secrets Operator-managed Kubernetes Secret
+backed by AWS Systems Manager Parameter Store paths under `/homelab/argocd/oidc`.
 
 Quick recovery summary:
 

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -318,7 +318,10 @@ terragrunt apply
 Use `docs/argocd-bootstrap.md` for the full runbook, validation sequence,
 handoff rules, rollback path, and recovery notes. The initial bootstrap installs
 Argo CD in the `argocd` namespace, keeps the service internal, and creates the
-`argocd-self-management` Application in manual validation mode.
+`argocd-self-management` Application in manual validation mode. Argo CD SAML SSO
+is configured through bundled Dex and reads its SSO settings from an
+External Secrets Operator-managed Kubernetes Secret backed by AWS Systems
+Manager Parameter Store paths under `/homelab/argocd/saml`.
 
 Quick recovery summary:
 

--- a/clusters/homelab/argocd/self-management/README.md
+++ b/clusters/homelab/argocd/self-management/README.md
@@ -14,3 +14,10 @@ Enable automated prune and self-heal only by editing repository desired state,
 reviewing the change, and applying it through the documented workflow. Do not
 patch the live Application as the permanent fix for source path, revision, or
 sync policy changes.
+
+This path also owns the External Secrets Operator resources that create the
+`argocd-oidc-sso` Kubernetes Secret from AWS Systems Manager Parameter Store.
+Keep those resources here instead of the Terragrunt bootstrap Helm values so a
+fresh cluster can install Argo CD before External Secrets CRDs exist. Sync
+`oidc-external-secret.yaml` only after External Secrets Operator is installed
+and allowed to read `/homelab/argocd/oidc/*` parameters in `us-east-1`.

--- a/clusters/homelab/argocd/self-management/kustomization.yaml
+++ b/clusters/homelab/argocd/self-management/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - application.yaml
+  - oidc-external-secret.yaml

--- a/clusters/homelab/argocd/self-management/oidc-external-secret.yaml
+++ b/clusters/homelab/argocd/self-management/oidc-external-secret.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: argocd-ssm
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: argocd-ssm
+    app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/managed-by: argocd
+    homelab.stuhlmuller.dev/cluster: homelab
+spec:
+  provider:
+    aws:
+      service: ParameterStore
+      region: us-east-1
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: argocd-oidc-sso
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: argocd-oidc-sso
+    app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/managed-by: argocd
+    homelab.stuhlmuller.dev/cluster: homelab
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: SecretStore
+    name: argocd-ssm
+  target:
+    name: argocd-oidc-sso
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      metadata:
+        labels:
+          app.kubernetes.io/name: argocd-oidc-sso
+          app.kubernetes.io/part-of: argocd
+          app.kubernetes.io/managed-by: external-secrets
+  data:
+    - secretKey: url
+      remoteRef:
+        key: /homelab/argocd/oidc/url
+    - secretKey: issuer
+      remoteRef:
+        key: /homelab/argocd/oidc/issuer
+    - secretKey: clientID
+      remoteRef:
+        key: /homelab/argocd/oidc/client-id
+    - secretKey: clientSecret
+      remoteRef:
+        key: /homelab/argocd/oidc/client-secret

--- a/docs/argocd-bootstrap.md
+++ b/docs/argocd-bootstrap.md
@@ -11,10 +11,40 @@ repository-owned Terragrunt stack at `IaC/bootstrap/argocd`.
   committed provider path `~/.kube/config`.
 - External credentials for S3 remote state and KMS encryption are available as
   credential material; they are not desired-state inputs.
+- External Secrets Operator is installed before enabling SAML SSO, and its AWS
+  provider can read Systems Manager Parameter Store in `us-east-1` without
+  committing AWS access keys to this repository.
 - The default branch `main` contains the Argo CD desired-state path before
   expecting the self-management Application to sync.
 - No raw repository token, kubeconfig, Talos secret, private key, or certificate
   material is committed.
+- AWS Parameter Store contains the SAML SSO contract described below before
+  expecting Dex login to succeed.
+
+## SAML SSO Secret Contract
+
+Argo CD uses the bundled Dex server for SSO. The bootstrap Helm values create an
+External Secrets Operator `SecretStore` named `argocd-ssm` and an
+`ExternalSecret` named `argocd-saml-sso` in the `argocd` namespace. The resulting
+Kubernetes Secret must keep the label
+`app.kubernetes.io/part-of: argocd` so Argo CD can resolve `$argocd-saml-sso:*`
+references from `argocd-cm`.
+
+Create these AWS Systems Manager Parameter Store entries before rollout:
+
+| Parameter | Secret key | Expected value |
+| --- | --- | --- |
+| `/homelab/argocd/saml/url` | `url` | Browser-facing Argo CD base URL registered with the SAML IdP. |
+| `/homelab/argocd/saml/sso-url` | `ssoURL` | SAML IdP HTTP POST SSO URL. |
+| `/homelab/argocd/saml/ca-data` | `caData` | Base64-encoded PEM CA/signing certificate data for Dex. |
+| `/homelab/argocd/saml/callback-url` | `callback` | Dex callback URL, normally `<url>/api/dex/callback`. |
+| `/homelab/argocd/saml/client-id` | `clientID` | SAML SP entity ID/client ID used as Dex `entityIssuer`. |
+| `/homelab/argocd/saml/client-secret` | `clientSecret` | IdP client secret stored outside git. Dex SAML does not consume this field directly. |
+
+Store `/homelab/argocd/saml/client-secret` as a SecureString. The other values
+may be String or SecureString depending on local policy. This change does not
+create an ingress or DNS record; the `url` and callback values must match a
+reviewed, reachable Argo CD endpoint.
 
 ## Validate Before Apply
 
@@ -35,6 +65,9 @@ Expected plan:
 
 - Installs or updates the `argocd` Helm release only through Terragrunt.
 - Keeps the Argo CD service internal with `ClusterIP`.
+- Configures Dex with a SAML connector and Argo CD RBAC defaults.
+- Creates the `argocd-saml-sso` ExternalSecret and the
+  `argocd-ssm` SecretStore without embedding secret values.
 - Applies `argocd-self-management` with the Terragrunt `after_hook` only after
   `applications.argoproj.io` is established.
 - Uses the Terragrunt catalog `helm-release` module pinned to `0.3.0`.
@@ -59,6 +92,9 @@ kubectl get namespace argocd
 kubectl -n argocd get pods
 kubectl -n argocd get applications.argoproj.io argocd-self-management
 kubectl -n argocd describe applications.argoproj.io argocd-self-management
+kubectl -n argocd get secretstores.external-secrets.io argocd-ssm
+kubectl -n argocd get externalsecrets.external-secrets.io argocd-saml-sso
+kubectl -n argocd get secret argocd-saml-sso
 ```
 
 Expected result within 10 minutes:
@@ -66,6 +102,8 @@ Expected result within 10 minutes:
 - The `argocd` namespace exists.
 - Argo CD pods are running or progressing normally.
 - `argocd-self-management` exists in the `argocd` namespace.
+- `argocd-saml-sso` reports as synced and creates a Kubernetes Secret labeled
+  as part of Argo CD.
 - The Application source points at
   `clusters/homelab/argocd/self-management` in this repository.
 
@@ -116,6 +154,19 @@ Missing credentials:
 2. Do not commit tokens, deploy keys, or private kubeconfigs.
 3. Commit only safe references, encrypted manifests, or contracts.
 
+SAML login fails:
+
+1. Inspect `kubectl -n argocd describe externalsecret argocd-saml-sso`.
+2. Confirm the External Secrets Operator controller can read AWS Parameter Store
+   in `us-east-1`.
+3. Confirm the `argocd-saml-sso` Kubernetes Secret exists and has the
+   `app.kubernetes.io/part-of: argocd` label.
+4. Confirm the IdP app has the same entity/client ID and callback URL as the
+   Parameter Store values.
+5. Inspect `kubectl -n argocd logs deploy/argocd-dex-server` for SAML
+   validation errors. Do not paste raw assertion, token, or secret values into
+   the repository.
+
 Partial install:
 
 1. Capture `kubectl -n argocd get all` and Helm release status.
@@ -139,10 +190,10 @@ Break-glass live change:
 ## Storage And Backup Impact
 
 This feature introduces no workload persistent volumes. Durable state is limited
-to S3 OpenTofu state and Kubernetes objects in the `argocd` namespace. Back up
-the remote state bucket according to the existing infrastructure policy and keep
-Argo CD runtime state recoverable from this repository plus external secret
-material.
+to S3 OpenTofu state, Kubernetes objects in the `argocd` namespace, and AWS
+Parameter Store values under `/homelab/argocd/saml`. Back up the remote state
+bucket according to the existing infrastructure policy and keep Argo CD runtime
+state recoverable from this repository plus external secret material.
 
 ## Validation Log
 
@@ -172,3 +223,9 @@ Validation results are recorded during implementation:
 - Secret/input scan: passed for raw secret patterns and forbidden desired-state
   environment input patterns across the bootstrap stack and self-management
   files.
+- SAML SSO update validation: `terragrunt hcl fmt --check`, `terragrunt
+  validate -no-color`, `terragrunt plan -no-color`, `kubectl kustomize
+  clusters/homelab/argocd/self-management`, `helm template` with the evaluated
+  Terragrunt values, `nix flake check`, and `git diff --check` passed. The plan
+  updates the existing `argocd` Helm release in place with `0 to add, 1 to
+  change, 0 to destroy`.

--- a/docs/argocd-bootstrap.md
+++ b/docs/argocd-bootstrap.md
@@ -11,40 +11,42 @@ repository-owned Terragrunt stack at `IaC/bootstrap/argocd`.
   committed provider path `~/.kube/config`.
 - External credentials for S3 remote state and KMS encryption are available as
   credential material; they are not desired-state inputs.
-- External Secrets Operator is installed before enabling SAML SSO, and its AWS
-  provider can read Systems Manager Parameter Store in `us-east-1` without
-  committing AWS access keys to this repository.
 - The default branch `main` contains the Argo CD desired-state path before
   expecting the self-management Application to sync.
 - No raw repository token, kubeconfig, Talos secret, private key, or certificate
   material is committed.
-- AWS Parameter Store contains the SAML SSO contract described below before
+- AWS Parameter Store contains the OIDC SSO contract described below before
   expecting Dex login to succeed.
 
-## SAML SSO Secret Contract
+## OIDC SSO Secret Contract
 
-Argo CD uses the bundled Dex server for SSO. The bootstrap Helm values create an
-External Secrets Operator `SecretStore` named `argocd-ssm` and an
-`ExternalSecret` named `argocd-saml-sso` in the `argocd` namespace. The resulting
-Kubernetes Secret must keep the label
-`app.kubernetes.io/part-of: argocd` so Argo CD can resolve `$argocd-saml-sso:*`
+Argo CD uses the bundled Dex server for SSO. Dex is configured with an upstream
+OpenID Connect connector. The connector references a Kubernetes Secret named
+`argocd-oidc-sso`, and that Secret must keep the label
+`app.kubernetes.io/part-of: argocd` so Argo CD can resolve `$argocd-oidc-sso:*`
 references from `argocd-cm`.
+
+The External Secrets Operator `SecretStore` and `ExternalSecret` that create
+`argocd-oidc-sso` from AWS Systems Manager Parameter Store live under
+`clusters/homelab/argocd/self-management`. They are intentionally outside the
+initial Terragrunt Helm bootstrap so a fresh cluster can install Argo CD before
+External Secrets CRDs exist. Install External Secrets Operator and give it
+read-only Parameter Store access before syncing the self-management path that
+contains `oidc-external-secret.yaml`.
 
 Create these AWS Systems Manager Parameter Store entries before rollout:
 
 | Parameter | Secret key | Expected value |
 | --- | --- | --- |
-| `/homelab/argocd/saml/url` | `url` | Browser-facing Argo CD base URL registered with the SAML IdP. |
-| `/homelab/argocd/saml/sso-url` | `ssoURL` | SAML IdP HTTP POST SSO URL. |
-| `/homelab/argocd/saml/ca-data` | `caData` | Base64-encoded PEM CA/signing certificate data for Dex. |
-| `/homelab/argocd/saml/callback-url` | `callback` | Dex callback URL, normally `<url>/api/dex/callback`. |
-| `/homelab/argocd/saml/client-id` | `clientID` | SAML SP entity ID/client ID used as Dex `entityIssuer`. |
-| `/homelab/argocd/saml/client-secret` | `clientSecret` | IdP client secret stored outside git. Dex SAML does not consume this field directly. |
+| `/homelab/argocd/oidc/url` | `url` | Browser-facing Argo CD base URL registered with the IdP. |
+| `/homelab/argocd/oidc/issuer` | `issuer` | OIDC issuer URL used for provider discovery. |
+| `/homelab/argocd/oidc/client-id` | `clientID` | OIDC client ID issued by the IdP. |
+| `/homelab/argocd/oidc/client-secret` | `clientSecret` | OIDC client secret stored outside git. |
 
-Store `/homelab/argocd/saml/client-secret` as a SecureString. The other values
+Store `/homelab/argocd/oidc/client-secret` as a SecureString. The other values
 may be String or SecureString depending on local policy. This change does not
-create an ingress or DNS record; the `url` and callback values must match a
-reviewed, reachable Argo CD endpoint.
+create an ingress or DNS record. Register `<url>/api/dex/callback` with the IdP;
+Argo CD derives that Dex connector callback from the configured `url`.
 
 ## Validate Before Apply
 
@@ -65,9 +67,9 @@ Expected plan:
 
 - Installs or updates the `argocd` Helm release only through Terragrunt.
 - Keeps the Argo CD service internal with `ClusterIP`.
-- Configures Dex with a SAML connector and Argo CD RBAC defaults.
-- Creates the `argocd-saml-sso` ExternalSecret and the
-  `argocd-ssm` SecretStore without embedding secret values.
+- Configures Dex with an OIDC connector and Argo CD RBAC defaults.
+- Does not render `SecretStore` or `ExternalSecret` resources in the Terragrunt
+  bootstrap Helm release.
 - Applies `argocd-self-management` with the Terragrunt `after_hook` only after
   `applications.argoproj.io` is established.
 - Uses the Terragrunt catalog `helm-release` module pinned to `0.3.0`.
@@ -92,9 +94,6 @@ kubectl get namespace argocd
 kubectl -n argocd get pods
 kubectl -n argocd get applications.argoproj.io argocd-self-management
 kubectl -n argocd describe applications.argoproj.io argocd-self-management
-kubectl -n argocd get secretstores.external-secrets.io argocd-ssm
-kubectl -n argocd get externalsecrets.external-secrets.io argocd-saml-sso
-kubectl -n argocd get secret argocd-saml-sso
 ```
 
 Expected result within 10 minutes:
@@ -102,10 +101,22 @@ Expected result within 10 minutes:
 - The `argocd` namespace exists.
 - Argo CD pods are running or progressing normally.
 - `argocd-self-management` exists in the `argocd` namespace.
-- `argocd-saml-sso` reports as synced and creates a Kubernetes Secret labeled
-  as part of Argo CD.
 - The Application source points at
   `clusters/homelab/argocd/self-management` in this repository.
+
+After External Secrets Operator is installed and the self-management path is
+synced, verify the OIDC secret bridge:
+
+```sh
+kubectl -n argocd get secretstores.external-secrets.io argocd-ssm
+kubectl -n argocd get externalsecrets.external-secrets.io argocd-oidc-sso
+kubectl -n argocd get secret argocd-oidc-sso
+```
+
+Expected OIDC result:
+
+- `argocd-oidc-sso` reports as synced.
+- The generated Kubernetes Secret is labeled as part of Argo CD.
 
 ## First Handoff
 
@@ -113,11 +124,8 @@ The first handoff is intentionally manual. Confirm the Application source path,
 target revision, and rendered manifests before enabling automated
 reconciliation.
 
-After validation, update repository desired state in both places:
+After validation, update repository desired state:
 
-- Add `automated.prune` and `automated.selfHeal` to the inline
-  `values[0].extraObjects[0].spec.syncPolicy` object in
-  `IaC/bootstrap/argocd/terragrunt.hcl`.
 - Uncomment or add the Application `syncPolicy.automated` block in
   `clusters/homelab/argocd/self-management/application.yaml`.
 
@@ -154,16 +162,16 @@ Missing credentials:
 2. Do not commit tokens, deploy keys, or private kubeconfigs.
 3. Commit only safe references, encrypted manifests, or contracts.
 
-SAML login fails:
+OIDC login fails:
 
-1. Inspect `kubectl -n argocd describe externalsecret argocd-saml-sso`.
+1. Inspect `kubectl -n argocd describe externalsecret argocd-oidc-sso`.
 2. Confirm the External Secrets Operator controller can read AWS Parameter Store
    in `us-east-1`.
-3. Confirm the `argocd-saml-sso` Kubernetes Secret exists and has the
+3. Confirm the `argocd-oidc-sso` Kubernetes Secret exists and has the
    `app.kubernetes.io/part-of: argocd` label.
-4. Confirm the IdP app has the same entity/client ID and callback URL as the
-   Parameter Store values.
-5. Inspect `kubectl -n argocd logs deploy/argocd-dex-server` for SAML
+4. Confirm the IdP app uses the same client ID as Parameter Store and has
+   `<url>/api/dex/callback` registered as the callback URL.
+5. Inspect `kubectl -n argocd logs deploy/argocd-dex-server` for OIDC
    validation errors. Do not paste raw assertion, token, or secret values into
    the repository.
 
@@ -191,7 +199,7 @@ Break-glass live change:
 
 This feature introduces no workload persistent volumes. Durable state is limited
 to S3 OpenTofu state, Kubernetes objects in the `argocd` namespace, and AWS
-Parameter Store values under `/homelab/argocd/saml`. Back up the remote state
+Parameter Store values under `/homelab/argocd/oidc`. Back up the remote state
 bucket according to the existing infrastructure policy and keep Argo CD runtime
 state recoverable from this repository plus external secret material.
 
@@ -223,7 +231,7 @@ Validation results are recorded during implementation:
 - Secret/input scan: passed for raw secret patterns and forbidden desired-state
   environment input patterns across the bootstrap stack and self-management
   files.
-- SAML SSO update validation: `terragrunt hcl fmt --check`, `terragrunt
+- OIDC SSO update validation: `terragrunt hcl fmt --check`, `terragrunt
   validate -no-color`, `terragrunt plan -no-color`, `kubectl kustomize
   clusters/homelab/argocd/self-management`, `helm template` with the evaluated
   Terragrunt values, `nix flake check`, and `git diff --check` passed. The plan


### PR DESCRIPTION
## Summary

Adds OIDC single sign-on configuration for Argo CD through the bundled Dex server while keeping provider-specific credential material out of the public repository.

The Argo CD bootstrap stack now renders Dex OIDC connector settings into `argocd-cm`, adds RBAC defaults for the `argocd-admins` group, and references an `argocd-oidc-sso` Kubernetes Secret through Argo CD's `$secret:key` syntax. External Secrets Operator resources that materialize that Secret from AWS Systems Manager Parameter Store live in Argo CD's self-management path instead of the initial Helm bootstrap.

## Issue

Argo CD previously bootstrapped with the internal service and local admin flow only. The first SSO draft used Dex's SAML connector and rendered External Secrets custom resources directly through the bootstrap Helm release.

## Cause And Effect

Dex documents its SAML connector as unmaintained and risky for production authentication, so relying on it for the primary login path would increase auth risk. Rendering `SecretStore` and `ExternalSecret` resources in the initial Helm release also meant a fresh cluster without External Secrets CRDs could fail before Argo CD itself came up.

## Root Cause

The initial SSO implementation combined two lifecycle boundaries: Argo CD's core Helm bootstrap and the later controller-managed secret bridge. It also selected SAML even though the upstream Dex guidance points users toward OIDC when the identity provider supports it.

## Fix

The bootstrap Helm values now configure Dex with an upstream OIDC connector using `issuer`, `clientID`, and `clientSecret` values from `argocd-oidc-sso`. The OIDC group scope is enabled so Argo CD RBAC can map `argocd-admins` to `role:admin`.

The External Secrets Operator `SecretStore` and `ExternalSecret` moved to `clusters/homelab/argocd/self-management/oidc-external-secret.yaml`. That keeps the first Terragrunt apply focused on installing Argo CD and registering the self-management Application, while the OIDC secret bridge is reconciled only after External Secrets Operator exists.

The runbook and onboarding docs now document the OIDC SSM paths under `/homelab/argocd/oidc`, the derived `/api/dex/callback` registration rule, the ESO handoff boundary, verification commands, and OIDC troubleshooting steps.

## Review Feedback Addressed

- Replaced Dex `type: saml` with Dex `type: oidc`.
- Removed `SecretStore` and `ExternalSecret` resources from the bootstrap Helm `extraObjects` path.

## Validation

- `terragrunt hcl fmt --check`
- `terragrunt validate -no-color`
- `terragrunt plan -no-color`
- `helm template` with evaluated Terragrunt values
- `kubectl kustomize clusters/homelab/argocd/self-management`
- `nix flake check`
- `git diff --check`
- Pre-commit hooks during signed commit, including Checkov Diff and Checkov Secrets
