### PR TITLE
Add QNAP NFS storage GitOps path

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -68,41 +68,42 @@ only safe references, encrypted values, templates, or contracts in git.
 ## Persistent Storage
 
 Shared persistent storage for Kubernetes workloads is provided by a QNAP NAS on
-the homelab LAN.
+the homelab LAN. The detailed setup and validation runbook lives in
+`docs/storage-nfs.md`.
 
 | System | Address | Protocol | Share | Intended use |
 | --- | --- | --- | --- | --- |
-| QNAP NAS | `10.1.0.2` | NFS | `homelab` | Backing storage for Kubernetes persistent volumes |
+| QNAP NAS | `10.1.0.2` | NFS | `/homelab` | Backing storage for Kubernetes persistent volumes |
 
 The NAS share is the cluster-level durable storage target. It is separate from
 Talos node persistence: each node should still boot from and keep Talos state on
 its internal system disk, while workload data that must survive pod rescheduling
-or node replacement should use the QNAP-backed storage class once that class is
-defined in Kubernetes.
+or node replacement should use the QNAP-backed `nfs-default` StorageClass.
 
 NAS-side expectations:
 
 - NFS service is enabled on the QNAP.
-- A shared folder or export named `homelab` exists.
+- A shared folder named `homelab` is exported as `/homelab`.
 - The export allows read/write access from the Talos node addresses
   `10.1.0.199`, `10.1.0.200`, `10.1.0.201`, and `10.1.0.202`, or from the
   narrower trusted node subnet if the node list changes.
+- The export uses `sys` security and squashes all users to the NAS `guest`
+  identity.
 - Access controls, UID/GID ownership, and squash behavior are documented beside
   any workload that depends on a specific filesystem identity.
 
-Kubernetes storage integration should be declared in git rather than configured
-by hand in the cluster. When a CSI driver, external provisioner, or static
-`PersistentVolume` is added, use these source values:
+Kubernetes storage integration is declared in git rather than configured by hand
+in the cluster. The self-management Argo CD path registers a manual
+`platform-storage` Application, and that parent creates the
+`nfs-subdir-external-provisioner` child Application:
 
 ```yaml
 server: 10.1.0.2
-share: homelab
+path: /homelab
+storageClass: nfs-default
+mountOptions:
+  - nfsvers=3
 ```
-
-Record the exact QNAP NFS export path in the storage manifest when it is wired
-into Kubernetes. Many examples use paths like `10.1.0.2:/homelab`, but QNAP can
-show a device-specific export path in its UI. Prefer the path reported by the
-NAS over an assumed path.
 
 Operator workstation checks:
 
@@ -113,14 +114,14 @@ showmount -e 10.1.0.2
 Expected evidence:
 
 ```text
-Export list for 10.1.0.2:
-<qnap-export-path-for-homelab>  <allowed-clients>
+Exports list on 10.1.0.2:
+/homelab 10.1.0.202 10.1.0.201 10.1.0.200 10.1.0.199
 ```
 
-Before making the QNAP-backed storage class the default, verify that a test PVC
-can be created, written, deleted, and recreated with the expected reclaim
-policy. Document backup and restore expectations before placing important
-stateful workloads on this storage.
+Before syncing stateful workloads, verify that a test PVC can be created,
+written, deleted, and recreated with the expected reclaim policy. Document
+backup and restore expectations before placing important stateful workloads on
+this storage.
 
 ## Required Control-Plane Config
 

--- a/clusters/homelab/argocd/self-management/README.md
+++ b/clusters/homelab/argocd/self-management/README.md
@@ -14,3 +14,8 @@ Enable automated prune and self-heal only by editing repository desired state,
 reviewing the change, and applying it through the documented workflow. Do not
 patch the live Application as the permanent fix for source path, revision, or
 sync policy changes.
+
+`platform-storage-application.yaml` registers the QNAP-backed NFS storage
+integration as a child Application. It is intentionally manual-sync so the NFS
+export and PVC write validation can be confirmed before stateful workloads use
+the default `nfs-default` StorageClass.

--- a/clusters/homelab/argocd/self-management/platform-storage-application.yaml
+++ b/clusters/homelab/argocd/self-management/platform-storage-application.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: platform-storage
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: platform-storage
+    app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/managed-by: argocd
+    homelab.stuhlmuller.dev/cluster: homelab
+  annotations:
+    homelab.stuhlmuller.dev/storage-backend: qnap-nfs
+    homelab.stuhlmuller.dev/rollout-gate: manual-sync
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/Stuhlmuller/homelab.git
+    path: clusters/homelab/platform/storage
+    targetRevision: main
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+      - ApplyOutOfSyncOnly=true

--- a/clusters/homelab/platform/storage/README.md
+++ b/clusters/homelab/platform/storage/README.md
@@ -1,0 +1,12 @@
+# Platform Storage
+
+This path owns the QNAP-backed NFS dynamic provisioner for the homelab cluster.
+The parent `platform-storage` Application is registered from Argo CD
+self-management as a manual rollout gate. When `platform-storage` is synced, it
+creates the child `nfs-subdir-external-provisioner` Application in the `argocd`
+namespace. The child Application installs the upstream Helm chart into the
+`storage` namespace and creates the default `nfs-default` StorageClass.
+
+The NAS-side setup is documented in `docs/storage-nfs.md`. Do not sync stateful
+workload Applications until the provisioner is healthy and the PVC write,
+delete, and recreate validation in that runbook has passed.

--- a/clusters/homelab/platform/storage/kustomization.yaml
+++ b/clusters/homelab/platform/storage/kustomization.yaml
@@ -2,5 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - application.yaml
-  - platform-storage-application.yaml
+  - nfs-subdir-external-provisioner-application.yaml

--- a/clusters/homelab/platform/storage/nfs-subdir-external-provisioner-application.yaml
+++ b/clusters/homelab/platform/storage/nfs-subdir-external-provisioner-application.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: nfs-subdir-external-provisioner
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: nfs-subdir-external-provisioner
+    app.kubernetes.io/part-of: platform-storage
+    app.kubernetes.io/managed-by: argocd
+    homelab.stuhlmuller.dev/cluster: homelab
+  annotations:
+    homelab.stuhlmuller.dev/storage-backend: qnap-nfs
+    homelab.stuhlmuller.dev/qnap-export: 10.1.0.2:/homelab
+spec:
+  project: default
+  source:
+    repoURL: https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner/
+    chart: nfs-subdir-external-provisioner
+    targetRevision: 4.0.18
+    helm:
+      releaseName: nfs-subdir-external-provisioner
+      values: |
+        nfs:
+          server: 10.1.0.2
+          path: /homelab
+          mountOptions:
+            - nfsvers=3
+          reclaimPolicy: Retain
+
+        storageClass:
+          create: true
+          name: nfs-default
+          provisionerName: k8s-sigs.io/qnap-nfs
+          defaultClass: true
+          allowVolumeExpansion: true
+          reclaimPolicy: Retain
+          archiveOnDelete: true
+          accessModes: ReadWriteMany
+          volumeBindingMode: Immediate
+
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            memory: 128Mi
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: storage
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ApplyOutOfSyncOnly=true

--- a/docs/storage-nfs.md
+++ b/docs/storage-nfs.md
@@ -1,0 +1,151 @@
+# NFS Storage
+
+Stateful apps use a default QNAP-backed NFS StorageClass named `nfs-default`
+unless an app-specific exception is documented here.
+
+## NAS Configuration
+
+| Setting | Value |
+| --- | --- |
+| NAS | QNAP TS-451+ |
+| NAS address | `10.1.0.2` |
+| QTS version at setup | `5.2.9.3451` |
+| Storage pool | `Storage Pool 1` |
+| Pool layout | RAID 5 across four 2 TB disks |
+| Snapshot reserve | 10% |
+| Kubernetes volume | `Homelab (System)` |
+| Kubernetes shared folder | `homelab` |
+| NFS export path | `/homelab` |
+
+NFS is enabled from QTS at Control Panel > Network & File Services >
+Win/Mac/NFS/WebDAV > NFS Service. The current NAS configuration enables
+NFSv2/NFSv3, and Kubernetes mounts the export with `nfsvers=3`.
+
+The `homelab` shared folder grants NFS read/write access only to the Talos node
+addresses:
+
+| Node | Address | Access |
+| --- | --- | --- |
+| `acer` | `10.1.0.199` | read/write |
+| `zimaboard-0` | `10.1.0.200` | read/write |
+| `zimaboard-1` | `10.1.0.201` | read/write |
+| `zimaboard-2` | `10.1.0.202` | read/write |
+
+The QNAP NFS rules use `sys` security and squash all users to the NAS `guest`
+identity. This keeps client-side UIDs from becoming trusted NAS identities and
+works with the provisioner-created per-PVC directories. If a workload needs a
+specific POSIX owner or mode, document that beside the workload before changing
+the NAS export behavior.
+
+Verify the export path and allow-list from an operator workstation:
+
+```sh
+showmount -e 10.1.0.2
+```
+
+Expected result:
+
+```text
+Exports list on 10.1.0.2:
+/homelab 10.1.0.202 10.1.0.201 10.1.0.200 10.1.0.199
+```
+
+## GitOps Desired State
+
+`clusters/homelab/argocd/self-management/platform-storage-application.yaml`
+registers the parent `platform-storage` Application. That parent points at
+`clusters/homelab/platform/storage` and remains a manual rollout gate.
+
+`clusters/homelab/platform/storage/nfs-subdir-external-provisioner-application.yaml`
+creates a child Argo CD Application for the upstream
+`nfs-subdir-external-provisioner` Helm chart. The child Application creates the
+default StorageClass used by stateful workloads.
+
+Important settings:
+
+| Setting | Value | Reason |
+| --- | --- | --- |
+| Helm chart | `nfs-subdir-external-provisioner` `4.0.18` | Dynamic subdirectory provisioning on the QNAP export |
+| Namespace | `storage` | Keeps storage controller resources out of app namespaces |
+| `nfs.server` | `10.1.0.2` | QNAP NAS address |
+| `nfs.path` | `/homelab` | Export path verified with `showmount` |
+| `nfs.mountOptions` | `nfsvers=3` | Matches the enabled QNAP NFS service |
+| StorageClass | `nfs-default` | Stable class name for homelab PVCs |
+| `defaultClass` | `true` | Allows ordinary PVCs to bind without per-app overrides |
+| `provisionerName` | `k8s-sigs.io/qnap-nfs` | Stable provisioner identity |
+| `accessModes` | `ReadWriteMany` | NFS can support multi-node mounts |
+| `reclaimPolicy` | `Retain` | Protects workload data from accidental PVC deletion |
+| `allowVolumeExpansion` | `true` | Allows planned PVC growth |
+
+Sync `platform-storage` only after the QNAP export is visible, then let the
+child provisioner Application auto-sync.
+
+## Validation
+
+Before syncing `argocd-self-management`, render the self-management app tree:
+
+```sh
+kubectl kustomize clusters/homelab/argocd/self-management
+```
+
+Before syncing `platform-storage`, render the storage desired state:
+
+```sh
+kubectl kustomize clusters/homelab/platform/storage
+```
+
+After syncing `platform-storage`, verify the child app and StorageClass:
+
+```sh
+kubectl -n argocd get application platform-storage nfs-subdir-external-provisioner
+kubectl -n storage get deploy,pod
+kubectl get storageclass nfs-default
+```
+
+Create a temporary PVC and pod that writes a file, delete the pod, recreate it
+on another node if possible, and confirm the file is still present before
+syncing stateful workloads.
+
+Example PVC:
+
+```yaml
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: example-nfs-default
+  namespace: default
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: nfs-default
+  resources:
+    requests:
+      storage: 10Gi
+```
+
+## Backup Coverage
+
+NFS backup coverage is a hard rollout gate. Persistent apps should remain
+manual-sync until each app has acceptable backup and restore coverage.
+
+| App | Data classes | StorageClass | Backup expectation | Restore expectation | Rollback data behavior |
+|-----|--------------|--------------|--------------------|---------------------|------------------------|
+| prometheus | metrics | `nfs-default` | NFS backup or metrics retention acceptance | Restore PVC or accept documented metrics loss | Preserve PVC unless explicitly deleting metrics |
+| grafana | dashboards, config | `nfs-default` | NFS backup plus dashboard export when possible | Restore PVC and re-sync dashboards | Preserve PVC |
+| deluge | config, downloads | `nfs-default` | NFS backup for config and download paths | Restore config/download PVCs before app sync | Preserve PVCs |
+| radarr | config, media refs | `nfs-default` | NFS backup for config and shared media references | Restore config PVC and verify media mount refs | Preserve PVC |
+| sonarr | config, media refs | `nfs-default` | NFS backup for config and shared media references | Restore config PVC and verify media mount refs | Preserve PVC |
+| litellm | model routing, optional DB/config | `nfs-default` | NFS backup for config store or DB PVC | Restore PVC before exposing gateway | Snapshot first, preserve PVC |
+| openclaw | config, runtime state | `nfs-default` | NFS backup for runtime state | Restore PVC and verify LiteLLM connectivity | Preserve PVC |
+| tines | automation history, config | `nfs-default` | NFS backup plus app export when available | Restore PVC before worker/web sync | Snapshot first, preserve PVC |
+
+## Validation Notes
+
+- Read-only `showmount -e 10.1.0.2` verified `/homelab` is exported only to
+  `10.1.0.199`, `10.1.0.200`, `10.1.0.201`, and `10.1.0.202`.
+- The live `nfs-subdir-external-provisioner` Application was verified healthy
+  on 2026-05-24.
+- A temporary PVC smoke test on 2026-05-24 dynamically provisioned storage,
+  mounted it into a pod, wrote `smoke.txt`, read it back, and then removed the
+  temporary PVC, pod, and smoke-test StorageClass.


### PR DESCRIPTION
## Summary

This adds the QNAP-backed NFS storage setup to the `main` GitOps path so the live Kubernetes storage configuration is represented in the repository instead of only existing as a manual cluster change.

The cluster now has a QNAP NAS export at `10.1.0.2:/homelab`, and Kubernetes is using `nfs-subdir-external-provisioner` to provide a default `nfs-default` StorageClass. Without this PR, the live cluster can keep using the manually applied provisioner, but a future Argo CD reconciliation or rebuild from `main` would not know how to recreate that storage layer.

## Root Cause

The NFS-backed StorageClass was created while validating the QNAP setup, but `main` only had the initial Argo CD self-management bootstrap. It did not yet include a durable platform storage Application, the NFS provisioner child Application, or the runbook documenting the NAS-side export and validation steps.

## Changes

- Registers a manual-sync `platform-storage` Argo CD Application from the self-management kustomization.
- Adds `clusters/homelab/platform/storage` as the desired-state home for the NFS storage integration.
- Adds an `nfs-subdir-external-provisioner` child Application using chart version `4.0.18`.
- Configures the provisioner for QNAP NFS at `10.1.0.2:/homelab` with `nfsvers=3`.
- Creates the default `nfs-default` StorageClass with `ReadWriteMany`, `Retain`, and expansion support.
- Documents the QNAP NAS configuration, allowed node IPs, validation commands, smoke-test evidence, and backup gate in `docs/storage-nfs.md`.
- Updates `ONBOARDING.md` to point to the concrete storage runbook and current export settings.

## Validation

- `kubectl kustomize clusters/homelab/argocd/self-management`
- `kubectl kustomize clusters/homelab/platform/storage`
- `yamllint clusters/homelab/argocd/self-management clusters/homelab/platform/storage`
- `kubectl apply --dry-run=server -k clusters/homelab/argocd/self-management`
- `kubectl apply --dry-run=server -k clusters/homelab/platform/storage`
- `git diff --cached --check`
- Pre-commit hook suite during commit:
  - trim trailing whitespace
  - fix end of files
  - check yaml
  - codespell
  - Checkov Diff
  - Checkov Secrets

Live validation before this PR also confirmed that `showmount -e 10.1.0.2` exports `/homelab` only to the Talos node IPs, the Argo CD child Application is Healthy/Synced, `nfs-default` exists as the default StorageClass, and a temporary PVC smoke test could write and read data through the QNAP-backed provisioner.
