### PR TITLE
feat: add tailscale exit node

### DIFF
--- a/clusters/homelab/apps/tailscale/README.md
+++ b/clusters/homelab/apps/tailscale/README.md
@@ -1,0 +1,59 @@
+# Tailscale Desired State
+
+This path owns the repo-managed Tailscale operator support resources that are
+applied alongside the upstream `tailscale-operator` Helm chart.
+
+## Runtime Secret
+
+`externalsecret.yaml` creates the `operator-oauth` Kubernetes Secret from AWS
+SSM Parameter Store. The Tailscale OAuth client must have the `Devices Core`,
+`Auth Keys`, and `Services` write scopes and must use `tag:k8s-operator`.
+
+## Homelab Exit Node
+
+`exit-node-connector.yaml` creates a cluster-scoped Tailscale `Connector` named
+`homelab-exit-node`. The operator creates one proxy device with hostname
+`homelab-exit-node`, tags it as `tag:k8s`, and advertises it as an exit node.
+
+Tailnet policy must allow the operator tag to own `tag:k8s`:
+
+```json
+"tagOwners": {
+  "tag:k8s-operator": [],
+  "tag:k8s": ["tag:k8s-operator"]
+}
+```
+
+To avoid manual approval after every recreation, auto-approve exit-node
+advertisement for `tag:k8s` in the Tailscale policy:
+
+```json
+"autoApprovers": {
+  "exitNode": ["tag:k8s"]
+}
+```
+
+If auto-approval is not configured, approve `homelab-exit-node` as an exit node
+from the Machines page in the Tailscale admin console after Argo CD syncs this
+app.
+
+## Validation
+
+Render desired state before applying:
+
+```sh
+kubectl kustomize clusters/homelab/apps/tailscale
+```
+
+After Argo CD syncs the `tailscale` Application:
+
+```sh
+kubectl get connector homelab-exit-node
+kubectl wait connector homelab-exit-node --for=condition=ConnectorReady=true --timeout=5m
+kubectl -n tailscale get statefulset,pod -l tailscale.com/parent-resource=homelab-exit-node
+```
+
+Expected result: the connector reports `ISEXITNODE` as `true`, the connector
+condition is ready, and one operator-managed proxy Pod is running in the
+`tailscale` namespace. Then select `homelab-exit-node` as the exit node from a
+tailnet client and confirm the client egress IP changes to the homelab network.

--- a/clusters/homelab/apps/tailscale/exit-node-connector.yaml
+++ b/clusters/homelab/apps/tailscale/exit-node-connector.yaml
@@ -1,0 +1,14 @@
+apiVersion: tailscale.com/v1alpha1
+kind: Connector
+metadata:
+  name: homelab-exit-node
+  labels:
+    app.kubernetes.io/name: homelab-exit-node
+    app.kubernetes.io/part-of: tailscale
+    homelab.stuhlmuller.dev/role: exit-node
+spec:
+  hostname: homelab-exit-node
+  tags:
+    - tag:k8s
+  replicas: 1
+  exitNode: true

--- a/clusters/homelab/apps/tailscale/kustomization.yaml
+++ b/clusters/homelab/apps/tailscale/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - externalsecret.yaml
-
+  - exit-node-connector.yaml

--- a/docs/networking-tailnet-ingress.md
+++ b/docs/networking-tailnet-ingress.md
@@ -36,6 +36,39 @@ Validation on 2026-05-24 found no enabled first-rollout Funnel routes. The
 Istio gateway and every VirtualService route manifest are annotated with
 `homelab.rst.io/public-funnel: "false"`.
 
+## Homelab VPN Exit Node
+
+Tailscale also provides the homelab VPN exit path. The `tailscale` Argo CD
+Application installs the upstream Tailscale Kubernetes Operator and applies the
+repo-owned `homelab-exit-node` `Connector` from
+`clusters/homelab/apps/tailscale/exit-node-connector.yaml`.
+
+The connector is cluster-scoped, creates one operator-managed proxy device, and
+advertises that device as a Tailscale exit node with hostname
+`homelab-exit-node` and tag `tag:k8s`. Tailnet clients can select that device as
+their exit node to route internet-bound traffic through the homelab cluster
+egress path.
+
+This repository cannot approve tailnet routes by itself. The tailnet policy must
+allow `tag:k8s-operator` to own `tag:k8s`, and either auto-approve exit-node
+advertisement for `tag:k8s` with `autoApprovers.exitNode`, or rely on an admin
+manually approving `homelab-exit-node` in the Tailscale Machines page after
+sync.
+
+Validate the exit node after Argo CD syncs Tailscale:
+
+```sh
+kubectl get connector homelab-exit-node
+kubectl wait connector homelab-exit-node --for=condition=ConnectorReady=true --timeout=5m
+kubectl -n tailscale get statefulset,pod -l tailscale.com/parent-resource=homelab-exit-node
+```
+
+Expected result: the connector reports exit-node status, its ready condition is
+true, and a single Tailscale proxy Pod is running. Then select
+`homelab-exit-node` on a client and verify the public egress IP changes to the
+homelab network. Keep local-network access enabled on clients that still need
+nearby LAN access while using the exit node.
+
 ## Future Funnel Webhook Exception Template
 
 Future public exposure must be limited to webhook paths and reviewed separately.


### PR DESCRIPTION
## Summary

This change completes the Tailscale VPN path for the homelab by adding an
operator-managed exit node. The existing Tailscale Argo CD Application already
installs the upstream Tailscale Kubernetes Operator and syncs the
`clusters/homelab/apps/tailscale` desired-state path; the missing piece was a
repo-owned `Connector` that tells the operator to create a tailnet device that
advertises exit-node capability.

Without the connector, the operator could support tailnet ingress services, but
there was no declarative cluster resource for clients to select as a VPN exit
node. That meant the homelab could not be rebuilt from Git alone into the
intended "use it as an exit node" shape.

## What Changed

The new `homelab-exit-node` `Connector` is cluster-scoped, tagged with
`tag:k8s`, uses the hostname `homelab-exit-node`, and sets `exitNode: true`.
It is included in the Tailscale app kustomization so Argo CD applies it
alongside the existing ExternalSecret for the operator OAuth credentials.

The Tailscale app path now has a README that documents the OAuth secret
contract, required tailnet tag ownership, optional `autoApprovers.exitNode`
policy, manual approval fallback, and post-sync validation commands. The
tailnet ingress runbook also now explains how the homelab VPN exit-node path
fits alongside the existing internal-only Tailscale/Istio ingress route.

This repository still does not approve tailnet routes by itself. A Tailscale
admin must either configure `autoApprovers.exitNode` for `tag:k8s` or approve
`homelab-exit-node` manually in the Machines page after Argo CD syncs the app.

## Validation

Validated locally with:

- `kubectl kustomize clusters/homelab/apps/tailscale`
- full kustomize render sweep across `clusters/homelab/apps`,
  `clusters/homelab/platform/storage`, and
  `clusters/homelab/argocd/self-management`
- `terragrunt hcl fmt --check`
- `git diff --check`
- focused secret scan over the Tailscale app path and updated networking docs

The signed commit was verified locally with `git log -1 --show-signature`.
