### PR TITLE
feat(deluge): route torrent traffic through vpn

### DIFF
--- a/IaC/live/argocd-apps/deluge/terragrunt.hcl
+++ b/IaC/live/argocd-apps/deluge/terragrunt.hcl
@@ -8,6 +8,7 @@ terraform {
 
 dependencies {
   paths = [
+    "../external-secrets",
     "../cert-manager",
     "../istio",
     "../tailscale",

--- a/IaC/live/aws-ssm-parameters/terragrunt.hcl
+++ b/IaC/live/aws-ssm-parameters/terragrunt.hcl
@@ -86,6 +86,18 @@ inputs = {
       description   = "LiteLLM OpenAI provider API key."
       initial_value = local.placeholder
     }
+    "/homelab/deluge/vpn/wireguard-private-key" = {
+      description   = "Deluge AirVPN WireGuard private key."
+      initial_value = local.placeholder
+    }
+    "/homelab/deluge/vpn/wireguard-preshared-key" = {
+      description   = "Deluge AirVPN WireGuard pre-shared key."
+      initial_value = local.placeholder
+    }
+    "/homelab/deluge/vpn/wireguard-addresses" = {
+      description   = "Deluge AirVPN WireGuard interface address CIDR."
+      initial_value = local.placeholder
+    }
     "/homelab/openclaw/app-secret" = {
       description   = "OpenClaw application secret."
       initial_value = local.placeholder

--- a/clusters/homelab/apps/deluge/README.md
+++ b/clusters/homelab/apps/deluge/README.md
@@ -1,0 +1,55 @@
+# Deluge VPN
+
+Deluge is intentionally coupled to Gluetun. The `gluetun` container is a
+restartable init sidecar, so Kubernetes starts it before the Deluge application
+container and keeps it running for the lifetime of the Pod. If the VPN secret is
+missing, the WireGuard values are invalid, or the Gluetun healthcheck cannot
+pass, Deluge must not become ready.
+
+## Secret Contract
+
+The `deluge-vpn` ExternalSecret reads AirVPN WireGuard values from AWS SSM
+Parameter Store:
+
+| SSM parameter | WireGuard config field |
+|---------------|------------------------|
+| `/homelab/deluge/vpn/wireguard-private-key` | `PrivateKey` |
+| `/homelab/deluge/vpn/wireguard-preshared-key` | peer `PresharedKey` |
+| `/homelab/deluge/vpn/wireguard-addresses` | interface `Address` |
+
+Use only the IPv4 CIDR in `WIREGUARD_ADDRESSES` unless the cluster and Pod
+network are intentionally configured for IPv6.
+
+The AirVPN forwarded port is not secret desired state. This deployment uses
+AirVPN forwarded port `5983`; set Deluge's incoming BitTorrent port to that same
+value. The app container runs a startup hook that applies:
+
+```sh
+deluge-console -c /config "config --set random_port false; config --set listen_ports (5983, 5983)"
+```
+
+The hook retries while Deluge starts. If it cannot connect to Deluge and apply
+the port configuration, Kubernetes restarts the app container instead of leaving
+the Pod ready with an unknown listening port.
+
+## Verification
+
+After SSM values are replaced and Argo CD syncs Deluge:
+
+```sh
+kubectl -n media get externalsecret deluge-vpn
+kubectl -n media get secret deluge-vpn
+kubectl -n media get pod -l app.kubernetes.io/name=deluge
+kubectl -n media logs deploy/deluge -c gluetun
+```
+
+The ExternalSecret should be ready, the `deluge-vpn` Secret should exist, the
+Pod should be ready, and Gluetun logs should show a healthy WireGuard session.
+This command should return success only while the VPN is healthy:
+
+```sh
+kubectl -n media exec deploy/deluge -c gluetun -- /gluetun-entrypoint healthcheck
+```
+
+If Gluetun is unhealthy, Deluge should lose readiness and torrent traffic should
+fail closed instead of bypassing the VPN.

--- a/clusters/homelab/apps/deluge/externalsecret.yaml
+++ b/clusters/homelab/apps/deluge/externalsecret.yaml
@@ -1,0 +1,33 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: deluge-vpn
+  namespace: media
+spec:
+  refreshPolicy: OnChange
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: aws-ssm
+  target:
+    name: deluge-vpn
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: WIREGUARD_PRIVATE_KEY
+      remoteRef:
+        key: /homelab/deluge/vpn/wireguard-private-key
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+    - secretKey: WIREGUARD_PRESHARED_KEY
+      remoteRef:
+        key: /homelab/deluge/vpn/wireguard-preshared-key
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+    - secretKey: WIREGUARD_ADDRESSES
+      remoteRef:
+        key: /homelab/deluge/vpn/wireguard-addresses
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None

--- a/clusters/homelab/apps/deluge/kustomization.yaml
+++ b/clusters/homelab/apps/deluge/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - externalsecret.yaml
   - virtualservice.yaml

--- a/clusters/homelab/apps/deluge/values.yaml
+++ b/clusters/homelab/apps/deluge/values.yaml
@@ -1,5 +1,60 @@
 controllers:
   deluge:
+    initContainers:
+      gluetun:
+        image:
+          repository: ghcr.io/qdm12/gluetun
+          tag: v3.41.1
+        restartPolicy: Always
+        env:
+          TZ: America/Los_Angeles
+          VPN_SERVICE_PROVIDER: airvpn
+          VPN_TYPE: wireguard
+          FIREWALL: "on"
+          FIREWALL_INPUT_PORTS: "8112"
+          FIREWALL_VPN_INPUT_PORTS: "5983"
+          HEALTH_RESTART_VPN: "on"
+        envFrom:
+          - secretRef:
+              name: deluge-vpn
+        securityContext:
+          capabilities:
+            add:
+              - NET_ADMIN
+        probes:
+          startup:
+            enabled: true
+            custom: true
+            spec:
+              exec:
+                command:
+                  - /gluetun-entrypoint
+                  - healthcheck
+              failureThreshold: 36
+              periodSeconds: 5
+              timeoutSeconds: 5
+          readiness:
+            enabled: true
+            custom: true
+            spec:
+              exec:
+                command:
+                  - /gluetun-entrypoint
+                  - healthcheck
+              failureThreshold: 3
+              periodSeconds: 10
+              timeoutSeconds: 5
+          liveness:
+            enabled: true
+            custom: true
+            spec:
+              exec:
+                command:
+                  - /gluetun-entrypoint
+                  - healthcheck
+              failureThreshold: 3
+              periodSeconds: 30
+              timeoutSeconds: 5
     containers:
       app:
         image:
@@ -9,27 +64,51 @@ controllers:
           TZ: America/Los_Angeles
           PUID: "1000"
           PGID: "1000"
+        lifecycle:
+          postStart:
+            exec:
+              command:
+                - /bin/sh
+                - -ec
+                - |
+                  for attempt in $(seq 1 60); do
+                    if deluge-console -c /config "config --set random_port false; config --set listen_ports (5983, 5983)"; then
+                      exit 0
+                    fi
+                    sleep 2
+                  done
+                  exit 1
 service:
   app:
     controller: deluge
     ports:
       http:
         port: 8112
-      bittorrent:
-        port: 6881
 persistence:
   config:
     enabled: true
     storageClass: nfs-default
     size: 5Gi
     accessMode: ReadWriteOnce
-    globalMounts:
-      - path: /config
+    advancedMounts:
+      deluge:
+        app:
+          - path: /config
   downloads:
     enabled: true
     storageClass: nfs-default
     size: 200Gi
     accessMode: ReadWriteMany
-    globalMounts:
-      - path: /downloads
-
+    advancedMounts:
+      deluge:
+        app:
+          - path: /downloads
+  tun:
+    enabled: true
+    type: hostPath
+    hostPath: /dev/net/tun
+    hostPathType: CharDevice
+    advancedMounts:
+      deluge:
+        gluetun:
+          - path: /dev/net/tun

--- a/docs/secrets-aws-ssm.md
+++ b/docs/secrets-aws-ssm.md
@@ -61,6 +61,7 @@ stack because Terraform manages the Kubernetes Secret.
 | tailscale | `tailscale-oauth` | `operator-oauth` | `/homelab/tailscale/oauth-client-id`, `/homelab/tailscale/oauth-client-secret` |
 | grafana | `grafana-admin` | `grafana-admin` | `/homelab/grafana/admin-user`, `/homelab/grafana/admin-password` |
 | litellm | `litellm-provider-keys` | `litellm-provider-keys` | `/homelab/litellm/master-key`, `/homelab/litellm/openai-api-key` |
+| deluge | `deluge-vpn` | `deluge-vpn` | `/homelab/deluge/vpn/wireguard-private-key`, `/homelab/deluge/vpn/wireguard-preshared-key`, `/homelab/deluge/vpn/wireguard-addresses` |
 | openclaw | `openclaw-secrets` | `openclaw-secrets` | `/homelab/openclaw/app-secret`, `/homelab/openclaw/litellm-token` |
 | tines | `tines-secrets` | `tines-secrets` | `/homelab/tines/app-secret`, `/homelab/tines/admin-password` |
 
@@ -70,6 +71,7 @@ token itself in git. The cert-manager ExternalSecret refreshes this value every
 five minutes so DNS-01 token rotations converge quickly without hand-editing the
 Kubernetes Secret.
 
-Deluge, Prowlarr, Radarr, and Sonarr do not store their application passwords
-or API keys in SSM. Their configuration lives on the persistent `/config`
-volumes and is managed through each app after first login.
+Deluge stores only VPN WireGuard material in SSM. Deluge, Prowlarr, Radarr, and
+Sonarr do not store their application passwords or API keys in SSM. Their
+configuration lives on the persistent `/config` volumes and is managed through
+each app after first login.


### PR DESCRIPTION
## Summary
- add Deluge VPN ExternalSecret contract backed by AWS SSM parameters
- run Deluge behind a Gluetun WireGuard sidecar with fail-closed health probes
- configure Deluge incoming BitTorrent port 5983 at container startup

## Validation
- helm template deluge bjw-s-labs/app-template --version 4.4.0 --namespace media -f clusters/homelab/apps/deluge/values.yaml
- kubectl kustomize clusters/homelab/apps/deluge
- terragrunt hcl fmt --check
- terragrunt hcl validate
- terragrunt --log-disable plan -no-color (IaC/live/aws-ssm-parameters)
- terragrunt --log-disable plan -no-color (IaC/live/argocd-apps/deluge)
- nix flake check
- git diff --check
- pre-commit hooks during signed commit

## Rollout
- SSM parameters were already created and updated with runtime values outside git.
- Applied the SSM stack plan: 0 added, 0 changed, 0 destroyed.
- Applied the Deluge Argo CD Application Terragrunt plan: 0 added, 1 changed, 0 destroyed.