### PR TITLE
fix(deluge): allow vpn sidecar pod security

### DIFF
--- a/clusters/homelab/apps/deluge/README.md
+++ b/clusters/homelab/apps/deluge/README.md
@@ -32,6 +32,13 @@ The hook retries while Deluge starts. If it cannot connect to Deluge and apply
 the port configuration, Kubernetes restarts the app container instead of leaving
 the Pod ready with an unknown listening port.
 
+## Pod Security
+
+Gluetun needs `NET_ADMIN` and `/dev/net/tun` to create the WireGuard tunnel.
+The `media` namespace is labeled for privileged Pod Security admission by this
+app path so Kubernetes can admit the Deluge VPN Pod. Keep privileged workloads
+in this namespace limited to repo-reviewed media automation.
+
 ## Verification
 
 After SSM values are replaced and Argo CD syncs Deluge:

--- a/clusters/homelab/apps/deluge/kustomization.yaml
+++ b/clusters/homelab/apps/deluge/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - namespace.yaml
   - externalsecret.yaml
   - virtualservice.yaml

--- a/clusters/homelab/apps/deluge/namespace.yaml
+++ b/clusters/homelab/apps/deluge/namespace.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: media
+  labels:
+    app.kubernetes.io/name: media
+    app.kubernetes.io/part-of: homelab
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/warn-version: latest


### PR DESCRIPTION
## Summary
- add a repo-managed media Namespace manifest with privileged Pod Security labels
- include the namespace in the Deluge app overlay so Gluetun can use NET_ADMIN and /dev/net/tun
- document the Pod Security requirement in the Deluge VPN runbook

## Validation
- kubectl kustomize clusters/homelab/apps/deluge
- helm template deluge bjw-s-labs/app-template --version 4.4.0 --namespace media -f clusters/homelab/apps/deluge/values.yaml
- terragrunt hcl fmt --check
- git diff --check
- pre-commit hooks during signed commit

## Rollout context
The Deluge VPN rollout reached Argo CD but Kubernetes rejected the new ReplicaSet under Pod Security baseline because Gluetun requires NET_ADMIN and /dev/net/tun.