### PR TITLE
fix(deluge): configure port after startup

### DIFF
--- a/clusters/homelab/apps/deluge/README.md
+++ b/clusters/homelab/apps/deluge/README.md
@@ -22,8 +22,18 @@ network are intentionally configured for IPv6.
 
 The AirVPN forwarded port is not secret desired state. This deployment uses
 AirVPN forwarded port `5983`; set Deluge's incoming BitTorrent port to that same
-value in the Deluge UI. The setting is stored on the retained Deluge config PVC,
-so it should persist across Pod restarts without being copied into SSM.
+value. Configure it in `values.yaml` through `FIREWALL_VPN_INPUT_PORTS` and the
+shared `DELUGE_INCOMING_PORT` value. A `port-config` sidecar shares the Deluge
+config volume and applies:
+
+```sh
+deluge-console -c /config "config --set random_port false; config --set listen_ports (${DELUGE_INCOMING_PORT}, ${DELUGE_INCOMING_PORT})"
+```
+
+The sidecar retries while Deluge starts. If it cannot connect to Deluge and
+apply the port configuration, the sidecar stays unready instead of killing the
+main app container during startup. The Pod becomes ready only after Gluetun is
+healthy and the incoming port has been applied.
 
 ## Pod Security
 

--- a/clusters/homelab/apps/deluge/values.yaml
+++ b/clusters/homelab/apps/deluge/values.yaml
@@ -16,7 +16,7 @@ controllers:
           VPN_TYPE: wireguard
           FIREWALL: "on"
           FIREWALL_INPUT_PORTS: "8112"
-          FIREWALL_VPN_INPUT_PORTS: "5983"
+          FIREWALL_VPN_INPUT_PORTS: &delugeIncomingPort "5983"
           HEALTH_RESTART_VPN: "on"
         envFrom:
           - secretRef:
@@ -68,6 +68,42 @@ controllers:
           TZ: America/Los_Angeles
           PUID: "1000"
           PGID: "1000"
+      port-config:
+        image:
+          repository: lscr.io/linuxserver/deluge
+          tag: 2.1.1
+        env:
+          DELUGE_INCOMING_PORT: *delugeIncomingPort
+        command:
+          - /bin/sh
+          - -ec
+          - |
+            rm -f /tmp/deluge-port-configured
+            for attempt in $(seq 1 120); do
+              if timeout 10s deluge-console -c /config "config --set random_port false; config --set listen_ports (${DELUGE_INCOMING_PORT}, ${DELUGE_INCOMING_PORT})"; then
+                touch /tmp/deluge-port-configured
+                exec tail -f /dev/null
+              fi
+              sleep 2
+            done
+            echo "failed to configure Deluge listen port ${DELUGE_INCOMING_PORT}" >&2
+            exit 1
+        securityContext:
+          runAsGroup: 1000
+          runAsUser: 1000
+        probes:
+          readiness:
+            enabled: true
+            custom: true
+            spec:
+              exec:
+                command:
+                  - /bin/sh
+                  - -ec
+                  - test -f /tmp/deluge-port-configured
+              failureThreshold: 3
+              periodSeconds: 10
+              timeoutSeconds: 5
 service:
   app:
     controller: deluge
@@ -83,6 +119,8 @@ persistence:
     advancedMounts:
       deluge:
         app:
+          - path: /config
+        port-config:
           - path: /config
   downloads:
     enabled: true


### PR DESCRIPTION
## Summary
- replace the Deluge postStart port hook with a retrying port-config sidecar
- keep AirVPN forwarded port 5983 in values.yaml as shared config for Gluetun and Deluge
- update the Deluge VPN runbook to describe the sidecar readiness behavior

## Validation
- kubectl kustomize clusters/homelab/apps/deluge
- helm template deluge bjw-s-labs/app-template --version 4.4.0 --namespace media -f clusters/homelab/apps/deluge/values.yaml
- terragrunt hcl fmt --check
- git diff --check HEAD~1 HEAD