### PR TITLE
fix(deluge): verify configured port readiness

### DIFF
--- a/clusters/homelab/apps/deluge/README.md
+++ b/clusters/homelab/apps/deluge/README.md
@@ -30,10 +30,11 @@ config volume and applies:
 deluge-console -c /config "config --set random_port false; config --set listen_ports (${DELUGE_INCOMING_PORT}, ${DELUGE_INCOMING_PORT})"
 ```
 
-The sidecar retries while Deluge starts. If it cannot connect to Deluge and
-apply the port configuration, the sidecar stays unready instead of killing the
-main app container during startup. The Pod becomes ready only after Gluetun is
-healthy and the incoming port has been applied.
+The sidecar retries while Deluge starts and verifies that Deluge reports the
+configured `listen_ports` value. If it cannot connect to Deluge and apply the
+port configuration, the sidecar stays unready instead of killing the main app
+container during startup. The Pod becomes ready only after Gluetun is healthy
+and the incoming port has been applied.
 
 ## Pod Security
 

--- a/clusters/homelab/apps/deluge/values.yaml
+++ b/clusters/homelab/apps/deluge/values.yaml
@@ -79,8 +79,12 @@ controllers:
           - -ec
           - |
             rm -f /tmp/deluge-port-configured
+            expected="listen_ports: (${DELUGE_INCOMING_PORT}, ${DELUGE_INCOMING_PORT})"
             for attempt in $(seq 1 120); do
-              if timeout 10s deluge-console -c /config "config --set random_port false; config --set listen_ports (${DELUGE_INCOMING_PORT}, ${DELUGE_INCOMING_PORT})"; then
+              timeout 10s deluge-console -c /config "config --set random_port false; config --set listen_ports (${DELUGE_INCOMING_PORT}, ${DELUGE_INCOMING_PORT})" || true
+              listen_ports="$(timeout 10s deluge-console -c /config "config listen_ports" 2>&1 || true)"
+              printf "%s\n" "$listen_ports"
+              if printf "%s\n" "$listen_ports" | grep -F "$expected" >/dev/null; then
                 touch /tmp/deluge-port-configured
                 exec tail -f /dev/null
               fi


### PR DESCRIPTION
## Summary
- make the port-config sidecar verify Deluge's reported listen_ports value before marking itself ready
- handle deluge-console returning a non-zero status even after printing successful configuration output
- update the Deluge VPN runbook to describe output-based verification

## Validation
- helm template deluge bjw-s-labs/app-template --version 4.4.0 --namespace media -f clusters/homelab/apps/deluge/values.yaml
- kubectl kustomize clusters/homelab/apps/deluge
- terragrunt hcl fmt --check
- git diff --check