### PR TITLE
ci: add terragrunt actions pipelines

### DIFF
--- a/.checkov.yaml
+++ b/.checkov.yaml
@@ -1,0 +1,8 @@
+quiet: true
+compact: true
+download-external-modules: false
+skip-path:
+  - .git
+  - .terragrunt-cache
+  - "**/.terragrunt-cache/**"
+  - "**/plan.out"

--- a/.github/workflows/terragrunt-apply.yml
+++ b/.github/workflows/terragrunt-apply.yml
@@ -88,10 +88,12 @@ jobs:
         # tailscale/github-action@v4
         uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8
         with:
-          args: --accept-routes=true
           authkey: ${{ secrets.TS_AUTH_KEY }}
           tags: tag:github-actions-terragrunt-apply
           version: ${{ env.TAILSCALE_VERSION }}
+
+      - name: Accept Tailnet Subnet Routes
+        run: sudo tailscale set --accept-routes=true
 
       - name: Install Kubeconfig
         env:

--- a/.github/workflows/terragrunt-apply.yml
+++ b/.github/workflows/terragrunt-apply.yml
@@ -1,0 +1,105 @@
+name: Terragrunt Apply
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/**"
+      - ".checkov.yaml"
+      - "IaC/**"
+      - "clusters/**"
+      - "docs/**"
+      - "flake.lock"
+      - "flake.nix"
+      - "policy/**"
+      - "scripts/**"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: terragrunt-apply-production
+  cancel-in-progress: false
+
+env:
+  AWS_TERRAGRUNT_APPLY_ROLE_ARN: arn:aws:iam::716182248480:role/Github-Actions-IDP
+  AWS_REGION: us-east-1
+  KUBE_API_SERVER: 10.1.0.199
+  TAILSCALE_VERSION: 1.98.3
+
+jobs:
+  static-policy:
+    name: Static Policy And Security Checks
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Check Out Repository
+        # actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        # cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Static Checks
+        run: nix develop --command bash scripts/ci/static-checks.sh
+
+  terragrunt-apply:
+    name: Terragrunt Apply
+    needs:
+      - static-policy
+    runs-on: ubuntu-24.04
+    environment:
+      name: homelab-production
+    permissions:
+      contents: read
+      id-token: write
+    timeout-minutes: 90
+    steps:
+      - name: Check Out Repository
+        # actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        # cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure AWS Credentials
+        # aws-actions/configure-aws-credentials@v6.1.1
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          mask-aws-account-id: true
+          role-session-name: homelab-terragrunt-apply-${{ github.run_id }}
+          role-to-assume: ${{ env.AWS_TERRAGRUNT_APPLY_ROLE_ARN }}
+          unset-current-credentials: true
+
+      - name: Connect To Tailnet
+        # tailscale/github-action@v4
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8
+        with:
+          authkey: ${{ secrets.TS_AUTH_KEY }}
+          ping: ${{ env.KUBE_API_SERVER }}
+          tags: tag:github-actions-terragrunt-apply
+          version: ${{ env.TAILSCALE_VERSION }}
+
+      - name: Install Kubeconfig
+        env:
+          KUBE_CONFIG_B64: ${{ secrets.KUBE_CONFIG_B64 }}
+        run: bash scripts/ci/install-kubeconfig.sh
+
+      - name: Verify Kubernetes API Reachability
+        run: kubectl --request-timeout=15s version
+
+      - name: Run Terragrunt Apply
+        run: nix develop --command bash scripts/ci/terragrunt-apply.sh

--- a/.github/workflows/terragrunt-apply.yml
+++ b/.github/workflows/terragrunt-apply.yml
@@ -88,6 +88,7 @@ jobs:
         # tailscale/github-action@v4
         uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8
         with:
+          args: --accept-routes=true
           authkey: ${{ secrets.TS_AUTH_KEY }}
           tags: tag:github-actions-terragrunt-apply
           version: ${{ env.TAILSCALE_VERSION }}

--- a/.github/workflows/terragrunt-apply.yml
+++ b/.github/workflows/terragrunt-apply.yml
@@ -89,7 +89,6 @@ jobs:
         uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8
         with:
           authkey: ${{ secrets.TS_AUTH_KEY }}
-          ping: ${{ env.KUBE_API_SERVER }}
           tags: tag:github-actions-terragrunt-apply
           version: ${{ env.TAILSCALE_VERSION }}
 

--- a/.github/workflows/terragrunt-plan.yml
+++ b/.github/workflows/terragrunt-plan.yml
@@ -91,7 +91,6 @@ jobs:
         uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8
         with:
           authkey: ${{ secrets.TS_AUTH_KEY }}
-          ping: ${{ env.KUBE_API_SERVER }}
           tags: tag:github-actions-terragrunt-plan
           version: ${{ env.TAILSCALE_VERSION }}
 

--- a/.github/workflows/terragrunt-plan.yml
+++ b/.github/workflows/terragrunt-plan.yml
@@ -90,6 +90,7 @@ jobs:
         # tailscale/github-action@v4
         uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8
         with:
+          args: --accept-routes=true
           authkey: ${{ secrets.TS_AUTH_KEY }}
           tags: tag:github-actions-terragrunt-plan
           version: ${{ env.TAILSCALE_VERSION }}

--- a/.github/workflows/terragrunt-plan.yml
+++ b/.github/workflows/terragrunt-plan.yml
@@ -1,0 +1,119 @@
+name: Terragrunt Plan
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+    paths:
+      - ".github/workflows/**"
+      - ".checkov.yaml"
+      - "IaC/**"
+      - "clusters/**"
+      - "docs/**"
+      - "flake.lock"
+      - "flake.nix"
+      - "policy/**"
+      - "scripts/**"
+
+permissions: {}
+
+concurrency:
+  group: terragrunt-plan-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  AWS_REGION: us-east-1
+  KUBE_API_SERVER: 10.1.0.199
+  TAILSCALE_VERSION: 1.98.3
+
+jobs:
+  static-policy:
+    name: Static Policy And Security Checks
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Check Out Repository
+        # actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        # cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Static Checks
+        run: nix develop --command bash scripts/ci/static-checks.sh
+
+  terragrunt-plan:
+    name: Terragrunt Plan
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    needs:
+      - static-policy
+    runs-on: ubuntu-24.04
+    environment:
+      name: homelab-plan
+    permissions:
+      contents: read
+      id-token: write
+    timeout-minutes: 60
+    steps:
+      - name: Check Out Repository
+        # actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        # cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure AWS Credentials
+        # aws-actions/configure-aws-credentials@v6.1.1
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          mask-aws-account-id: true
+          role-session-name: homelab-terragrunt-plan-${{ github.run_id }}
+          role-to-assume: ${{ vars.AWS_TERRAGRUNT_PLAN_ROLE_ARN }}
+          unset-current-credentials: true
+
+      - name: Connect To Tailnet
+        # tailscale/github-action@v4
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8
+        with:
+          authkey: ${{ secrets.TS_AUTH_KEY }}
+          ping: ${{ env.KUBE_API_SERVER }}
+          tags: tag:github-actions-terragrunt-plan
+          version: ${{ env.TAILSCALE_VERSION }}
+
+      - name: Install Kubeconfig
+        env:
+          KUBE_CONFIG_B64: ${{ secrets.KUBE_CONFIG_B64 }}
+        run: bash scripts/ci/install-kubeconfig.sh
+
+      - name: Verify Kubernetes API Reachability
+        run: kubectl --request-timeout=15s version
+
+      - name: Run Terragrunt Plan
+        run: nix develop --command bash scripts/ci/terragrunt-plan.sh
+
+  fork-plan-skipped:
+    name: Terragrunt Plan Skipped For Fork
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    needs:
+      - static-policy
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Explain Skip
+        run: echo "Live Terragrunt plan is skipped for forked pull requests because it requires AWS, Tailscale, and Kubernetes secrets."

--- a/.github/workflows/terragrunt-plan.yml
+++ b/.github/workflows/terragrunt-plan.yml
@@ -90,10 +90,12 @@ jobs:
         # tailscale/github-action@v4
         uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8
         with:
-          args: --accept-routes=true
           authkey: ${{ secrets.TS_AUTH_KEY }}
           tags: tag:github-actions-terragrunt-plan
           version: ${{ env.TAILSCALE_VERSION }}
+
+      - name: Accept Tailnet Subnet Routes
+        run: sudo tailscale set --accept-routes=true
 
       - name: Install Kubeconfig
         env:

--- a/.github/workflows/terragrunt-plan.yml
+++ b/.github/workflows/terragrunt-plan.yml
@@ -83,7 +83,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           mask-aws-account-id: true
           role-session-name: homelab-terragrunt-plan-${{ github.run_id }}
-          role-to-assume: ${{ vars.AWS_TERRAGRUNT_PLAN_ROLE_ARN }}
+          role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME_HOMELAB }}
           unset-current-credentials: true
 
       - name: Connect To Tailnet

--- a/clusters/homelab/apps/deluge/namespace.yaml
+++ b/clusters/homelab/apps/deluge/namespace.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: media
+  annotations:
+    homelab.rst.io/privileged-namespace-justification: Deluge VPN Pods require /dev/net/tun access for WireGuard.
   labels:
     app.kubernetes.io/name: media
     app.kubernetes.io/part-of: homelab

--- a/clusters/homelab/apps/istio/namespace.yaml
+++ b/clusters/homelab/apps/istio/namespace.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: istio-system
+  annotations:
+    homelab.rst.io/privileged-namespace-justification: Tailnet ingress proxy workloads require privileged network access.
   labels:
     app.kubernetes.io/name: istio-system
     app.kubernetes.io/part-of: homelab

--- a/clusters/homelab/apps/tailscale/namespace.yaml
+++ b/clusters/homelab/apps/tailscale/namespace.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: tailscale
+  annotations:
+    homelab.rst.io/privileged-namespace-justification: Tailscale operator proxy Pods require privileged network access.
   labels:
     app.kubernetes.io/name: tailscale
     app.kubernetes.io/part-of: homelab

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -1,0 +1,156 @@
+# CI/CD Pipeline
+
+This repository uses GitHub Actions for the review and rollout path:
+
+- `Terragrunt Plan` runs on pull requests. It always runs static checks,
+  Conftest policies, and Checkov. Trusted same-repository pull requests also
+  connect to the tailnet and run a live Terragrunt plan.
+- `Terragrunt Apply` runs after changes land on `main` and can also be started
+  manually with `workflow_dispatch`. It repeats static checks before connecting
+  to the tailnet and applying the live Terragrunt stack.
+
+Forked pull requests never receive AWS, Tailscale, or Kubernetes secrets. They
+run the static checks only.
+
+## Security Model
+
+- Workflows use `pull_request` and `push`; they do not use
+  `pull_request_target`.
+- External GitHub Actions are pinned to full commit SHAs and checked by
+  Conftest.
+- GitHub token permissions default to none. Jobs opt in to `contents: read`,
+  and only the live Terragrunt jobs request `id-token: write`.
+- AWS access uses GitHub OIDC and short-lived role sessions. Do not add static
+  AWS access keys to this repository.
+- Tailscale access uses an auth key because this tailnet has tailnet lock
+  enabled and the federated identity path is not available for these runners.
+  Keep the key ephemeral, reusable only if operationally required, pre-approved
+  for tailnet lock, and scoped to the CI tags documented below.
+- The kubeconfig is injected only from GitHub environment secrets and written to
+  `$HOME/.kube/config` with mode `0600`.
+- Plans are not uploaded as artifacts because Terraform/OpenTofu plans can
+  include sensitive state context.
+- Automatic PR plans intentionally skip `IaC/live/kubernetes-secrets` because
+  that unit reads decrypted AWS SSM parameters. The protected post-merge apply
+  runs the full `IaC/live` stack.
+
+References:
+
+- [Tailscale GitHub Action](https://tailscale.com/docs/integrations/github/github-action)
+- [Tailscale grants syntax](https://tailscale.com/docs/reference/syntax/grants)
+- [GitHub OIDC with AWS](https://docs.github.com/en/actions/how-tos/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services)
+- [Conftest](https://www.conftest.dev/)
+- [Checkov GitHub Actions integration](https://www.checkov.io/4.Integrations/GitHub%20Actions.html)
+
+## GitHub Configuration
+
+Create two GitHub environments:
+
+- `homelab-plan`: used by same-repository pull request plans. Keep this
+  unapproved if trusted branch authors should get automatic plans, or add
+  reviewers if every live plan should require a human gate.
+- `homelab-production`: used by post-merge applies. Require reviewers and limit
+  deployment branches to `main`.
+
+Add these secrets to both environments. Repository-level secrets also work, but
+environment secrets are preferred so production credentials can have approval
+rules and tighter rotation:
+
+| Secret | Purpose |
+|--------|---------|
+| `TS_AUTH_KEY` | Tailscale auth key allowed by tailnet lock and scoped to the CI runner tags. |
+| `KUBE_CONFIG_B64` | Base64-encoded kubeconfig for the homelab cluster. |
+
+Add these environment variables:
+
+| Variable | Environment | Purpose |
+|----------|-------------|---------|
+| `AWS_TERRAGRUNT_PLAN_ROLE_ARN` | `homelab-plan` | AWS role used by PR plans. |
+| `AWS_TERRAGRUNT_APPLY_ROLE_ARN` | workflow env | Pinned to `arn:aws:iam::716182248480:role/Github-Actions-IDP` for post-merge applies. |
+
+## Tailscale Setup
+
+Use separate tags for plan and apply runners:
+
+- `tag:github-actions-terragrunt-plan`
+- `tag:github-actions-terragrunt-apply`
+
+Create one Tailscale auth key that tailnet lock can admit. The key should be
+ephemeral, pre-approved for tailnet lock, and restricted to the CI tags when the
+admin panel permits tag scoping. In the tailnet policy, grant those tags only
+the cluster API path they need. If the Kubernetes API is reached through a
+subnet router, keep the destination scoped to the API endpoint and port:
+
+```json
+{
+  "tagOwners": {
+    "tag:github-actions-terragrunt-plan": ["autogroup:admin"],
+    "tag:github-actions-terragrunt-apply": ["autogroup:admin"]
+  },
+  "grants": [
+    {
+      "src": ["tag:github-actions-terragrunt-plan"],
+      "dst": ["10.1.0.199"],
+      "ip": ["tcp:6443"]
+    },
+    {
+      "src": ["tag:github-actions-terragrunt-apply"],
+      "dst": ["10.1.0.199"],
+      "ip": ["tcp:6443"]
+    }
+  ]
+}
+```
+
+Do not grant `tag:github-actions-terragrunt-*` broad tailnet or SSH access
+unless a later repository change documents the requirement. Rotate
+`TS_AUTH_KEY` on any failed or suspicious run, after runner image changes, and
+on a regular schedule.
+
+## AWS Setup
+
+Use separate IAM roles for plan and apply. Both roles should trust GitHub OIDC
+only for this repository and the expected environment subject:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::<account-id>:oidc-provider/token.actions.githubusercontent.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+          "token.actions.githubusercontent.com:sub": "repo:Stuhlmuller/homelab:environment:homelab-production"
+        }
+      }
+    }
+  ]
+}
+```
+
+Use `repo:Stuhlmuller/homelab:environment:homelab-plan` for the plan role.
+The plan role should have the narrowest read access that lets OpenTofu refresh
+state and create state lock files. The apply workflow assumes
+`arn:aws:iam::716182248480:role/Github-Actions-IDP`; that role needs the write
+permissions for the resources represented under `IaC/`.
+
+## Local Equivalents
+
+Run the same checks locally through the Nix shell:
+
+```sh
+nix develop --command bash scripts/ci/static-checks.sh
+nix develop --command bash scripts/ci/terragrunt-plan.sh
+```
+
+Only run apply after the same validation has passed and the change has been
+reviewed:
+
+```sh
+nix develop --command bash scripts/ci/terragrunt-apply.sh
+```

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -65,7 +65,7 @@ Add these environment variables:
 
 | Variable | Environment | Purpose |
 |----------|-------------|---------|
-| `AWS_TERRAGRUNT_PLAN_ROLE_ARN` | `homelab-plan` | AWS role used by PR plans. |
+| `AWS_ROLE_TO_ASSUME_HOMELAB` | repository or `homelab-plan` | AWS role used by PR plans. |
 | `AWS_TERRAGRUNT_APPLY_ROLE_ARN` | workflow env | Pinned to `arn:aws:iam::716182248480:role/Github-Actions-IDP` for post-merge applies. |
 
 ## Tailscale Setup

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -28,6 +28,9 @@ run the static checks only.
   for tailnet lock, and scoped to the CI tags documented below.
 - The kubeconfig is injected only from GitHub environment secrets and written to
   `$HOME/.kube/config` with mode `0600`.
+- The workflow does not use the Tailscale action's built-in `ping` input for
+  subnet-routed cluster addresses. Kubernetes reachability is verified with
+  `kubectl --request-timeout=15s version` after kubeconfig installation.
 - Plans are not uploaded as artifacts because Terraform/OpenTofu plans can
   include sensitive state context.
 - Automatic PR plans intentionally skip `IaC/live/kubernetes-secrets` because

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -31,6 +31,8 @@ run the static checks only.
 - The workflow does not use the Tailscale action's built-in `ping` input for
   subnet-routed cluster addresses. Kubernetes reachability is verified with
   `kubectl --request-timeout=15s version` after kubeconfig installation.
+- The Tailscale client starts with `--accept-routes=true` so it can use the
+  subnet route to the Kubernetes API endpoint.
 - Plans are not uploaded as artifacts because Terraform/OpenTofu plans can
   include sensitive state context.
 - Automatic PR plans intentionally skip `IaC/live/kubernetes-secrets` because

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -31,8 +31,10 @@ run the static checks only.
 - The workflow does not use the Tailscale action's built-in `ping` input for
   subnet-routed cluster addresses. Kubernetes reachability is verified with
   `kubectl --request-timeout=15s version` after kubeconfig installation.
-- The Tailscale client starts with `--accept-routes=true` so it can use the
-  subnet route to the Kubernetes API endpoint.
+- After the Tailscale client authenticates, the workflow runs
+  `tailscale set --accept-routes=true` so it can use the subnet route to the
+  Kubernetes API endpoint without conflicting with the action's own login
+  flags.
 - Plans are not uploaded as artifacts because Terraform/OpenTofu plans can
   include sensitive state context.
 - Automatic PR plans intentionally skip `IaC/live/kubernetes-secrets` because

--- a/docs/validation-runbook.md
+++ b/docs/validation-runbook.md
@@ -3,10 +3,16 @@
 Run these checks before any live mutation. Record output or a short summary in
 the PR.
 
+GitHub Actions now runs the same validation path for pull requests and
+post-merge applies. See `docs/ci-cd.md` for required GitHub environment
+secrets, Tailscale identity setup, and AWS OIDC role boundaries.
+
 ## Pre-Mutation Checks
 
 ```sh
 terragrunt hcl fmt
+terragrunt hcl validate
+nix develop --command bash scripts/ci/static-checks.sh
 cd IaC/live/aws-ssm-parameters
 terragrunt plan
 cd IaC/live/argocd-apps

--- a/flake.nix
+++ b/flake.nix
@@ -24,17 +24,22 @@
           pkgs = import nixpkgs {
             inherit system;
           };
+          basePackages = with pkgs; [
+            awscli2
+            conftest
+            kubectl
+            opentofu
+            ripgrep
+            talosctl
+            terragrunt
+          ];
+          checkovPackages = pkgs.lib.optionals (system != "x86_64-darwin") [
+            pkgs.checkov
+          ];
         in
         {
           default = pkgs.mkShell {
-            packages = with pkgs; [
-              awscli2
-              kubectl
-              opentofu
-              ripgrep
-              talosctl
-              terragrunt
-            ];
+            packages = basePackages ++ checkovPackages;
           };
         }
       );

--- a/policy/kubernetes.rego
+++ b/policy/kubernetes.rego
@@ -1,0 +1,66 @@
+package main
+
+import rego.v1
+
+homelab_repo_urls := {
+	"https://github.com/Stuhlmuller/homelab.git",
+	"git@github.com:Stuhlmuller/homelab.git",
+}
+
+deny contains msg if {
+	input.kind == "Secret"
+	name := object.get(object.get(input, "metadata", {}), "name", "<unknown>")
+	msg := sprintf("raw Kubernetes Secret %q must not be committed; use ExternalSecret, encrypted secret material, or a CI-injected secret path", [name])
+}
+
+deny contains msg if {
+	input.kind == "Namespace"
+	metadata := object.get(input, "metadata", {})
+	labels := object.get(metadata, "labels", {})
+	labels["pod-security.kubernetes.io/enforce"] == "privileged"
+	annotations := object.get(metadata, "annotations", {})
+	not has_nonempty_annotation(annotations, "homelab.rst.io/privileged-namespace-justification")
+	name := object.get(metadata, "name", "<unknown>")
+	msg := sprintf("privileged namespace %q must document why privileged Pod Security is required", [name])
+}
+
+deny contains msg if {
+	metadata := object.get(input, "metadata", {})
+	annotations := object.get(metadata, "annotations", {})
+	truthy(object.get(annotations, "homelab.rst.io/public-funnel", "false"))
+	not truthy(object.get(annotations, "homelab.rst.io/public-funnel-reviewed", "false"))
+	kind := object.get(input, "kind", "<unknown>")
+	name := object.get(metadata, "name", "<unknown>")
+	msg := sprintf("%s %q enables Tailscale Funnel without homelab.rst.io/public-funnel-reviewed=true", [kind, name])
+}
+
+deny contains msg if {
+	input.kind == "Application"
+	spec := object.get(input, "spec", {})
+	source := object.get(spec, "source", {})
+	source.repoURL in homelab_repo_urls
+	object.get(source, "targetRevision", "") != "main"
+	name := object.get(object.get(input, "metadata", {}), "name", "<unknown>")
+	msg := sprintf("Application %q must target the homelab repository default branch main", [name])
+}
+
+deny contains msg if {
+	input.kind == "Application"
+	spec := object.get(input, "spec", {})
+	sources := object.get(spec, "sources", [])
+	some index
+	source := sources[index]
+	source.repoURL in homelab_repo_urls
+	object.get(source, "targetRevision", "") != "main"
+	name := object.get(object.get(input, "metadata", {}), "name", "<unknown>")
+	msg := sprintf("Application %q source %d must target the homelab repository default branch main", [name, index])
+}
+
+has_nonempty_annotation(annotations, key) if {
+	value := object.get(annotations, key, "")
+	count(trim(value, " ")) > 0
+}
+
+truthy(value) if {
+	lower(sprintf("%v", [value])) == "true"
+}

--- a/policy/workflows.rego
+++ b/policy/workflows.rego
@@ -1,0 +1,58 @@
+package main
+
+import rego.v1
+
+deny contains msg if {
+	events := workflow_events
+	has_event(events, "pull_request_target")
+	name := object.get(input, "name", "<unnamed workflow>")
+	msg := sprintf("workflow %q must not use pull_request_target for infrastructure checks", [name])
+}
+
+deny contains msg if {
+	jobs := object.get(input, "jobs", {})
+	some job_name, job in jobs
+	uses := object.get(job, "uses", "")
+	uses != ""
+	external_action_reference(uses)
+	not sha_pinned(uses)
+	msg := sprintf("reusable workflow job %q must pin external workflow references to a full commit SHA", [job_name])
+}
+
+deny contains msg if {
+	jobs := object.get(input, "jobs", {})
+	some job_name, job in jobs
+	steps := object.get(job, "steps", [])
+	some index
+	step := steps[index]
+	uses := object.get(step, "uses", "")
+	uses != ""
+	external_action_reference(uses)
+	not sha_pinned(uses)
+	msg := sprintf("workflow job %q step %d must pin external action references to a full commit SHA", [job_name, index])
+}
+
+workflow_events := object.get(input, "on", object.get(input, true, {}))
+
+has_event(events, event) if {
+	events == event
+}
+
+has_event(events, event) if {
+	is_array(events)
+	events[_] == event
+}
+
+has_event(events, event) if {
+	is_object(events)
+	events[event]
+}
+
+external_action_reference(uses) if {
+	not startswith(uses, "./")
+	not startswith(uses, "docker://")
+}
+
+sha_pinned(uses) if {
+	regex.match("^[^@]+@[0-9a-f]{40}$", uses)
+}

--- a/scripts/ci/install-kubeconfig.sh
+++ b/scripts/ci/install-kubeconfig.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${KUBE_CONFIG_B64:?KUBE_CONFIG_B64 must contain the base64-encoded kubeconfig}"
+
+install -m 0700 -d "$HOME/.kube"
+printf '%s' "$KUBE_CONFIG_B64" | base64 --decode >"$HOME/.kube/config"
+chmod 0600 "$HOME/.kube/config"

--- a/scripts/ci/static-checks.sh
+++ b/scripts/ci/static-checks.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "::group::Terragrunt HCL"
+terragrunt hcl fmt --check
+terragrunt hcl validate
+echo "::endgroup::"
+
+echo "::group::Kustomize overlays"
+while IFS= read -r overlay; do
+  echo "rendering ${overlay}"
+  kubectl kustomize "$overlay" >/dev/null
+done < <(
+  find clusters/homelab/argocd clusters/homelab/apps clusters/homelab/platform \
+    -name kustomization.yaml \
+    -exec dirname {} \; | sort
+)
+echo "::endgroup::"
+
+echo "::group::Conftest policies"
+mapfile -t yaml_files < <(
+  find .github clusters \
+    \( -name '*.yaml' -o -name '*.yml' \) \
+    -not -path './.terragrunt-cache/*' \
+    -print 2>/dev/null | sort
+)
+
+if ((${#yaml_files[@]} > 0)); then
+  conftest test --policy policy --output github "${yaml_files[@]}"
+fi
+echo "::endgroup::"
+
+echo "::group::Checkov"
+if command -v checkov >/dev/null 2>&1; then
+  checkov --config-file .checkov.yaml --framework terraform --directory IaC/modules
+  checkov --config-file .checkov.yaml --framework kubernetes --directory clusters
+  checkov --config-file .checkov.yaml --framework secrets --directory .
+elif [[ "${CI:-}" == "true" ]]; then
+  echo "checkov is required in CI but was not found in PATH" >&2
+  exit 1
+else
+  echo "::warning::checkov is not available in this local shell; GitHub Actions still enforces Checkov on Linux."
+fi
+echo "::endgroup::"
+
+echo "::group::Whitespace"
+git diff --check
+echo "::endgroup::"

--- a/scripts/ci/terragrunt-apply.sh
+++ b/scripts/ci/terragrunt-apply.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "::group::Argo CD bootstrap apply"
+(
+  cd IaC/bootstrap/argocd
+  terragrunt --log-disable apply -no-color -auto-approve
+)
+echo "::endgroup::"
+
+echo "::group::Live stack apply"
+(
+  cd IaC/live
+  terragrunt run --all apply -no-color -auto-approve
+)
+echo "::endgroup::"

--- a/scripts/ci/terragrunt-plan.sh
+++ b/scripts/ci/terragrunt-plan.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "::group::Argo CD bootstrap plan"
+(
+  cd IaC/bootstrap/argocd
+  terragrunt --log-disable plan -no-color
+)
+echo "::endgroup::"
+
+echo "::group::AWS SSM parameter declaration plan"
+(
+  cd IaC/live/aws-ssm-parameters
+  terragrunt --log-disable plan -no-color
+)
+echo "::endgroup::"
+
+echo "::group::Argo CD Application registration plan"
+(
+  cd IaC/live/argocd-apps
+  terragrunt run --all plan -no-color
+)
+echo "::endgroup::"
+
+echo "IaC/live/kubernetes-secrets is intentionally excluded from PR plans because it reads decrypted SSM parameters."


### PR DESCRIPTION
## Summary
- add pull request Terragrunt plan and post-merge Terragrunt apply workflows
- configure AWS OIDC, Tailscale auth-key access, kubeconfig injection, Checkov, and Conftest gates
- document CI/CD setup and add local scripts that mirror the workflows

## Validation
- nix flake check --no-build --all-systems
- nix develop --command bash scripts/ci/static-checks.sh
- bash -n scripts/ci/install-kubeconfig.sh scripts/ci/static-checks.sh scripts/ci/terragrunt-plan.sh scripts/ci/terragrunt-apply.sh
- git diff --check HEAD~1..HEAD