### PR TITLE
ci: route github runners through tailnet

### DIFF
--- a/.github/workflows/terragrunt-apply.yml
+++ b/.github/workflows/terragrunt-apply.yml
@@ -26,6 +26,7 @@ env:
   AWS_TERRAGRUNT_APPLY_ROLE_ARN: arn:aws:iam::716182248480:role/Github-Actions-IDP
   AWS_REGION: us-east-1
   KUBE_API_SERVER: 10.1.0.199
+  TAILSCALE_EXIT_NODE: homelab-exit-node
   TAILSCALE_VERSION: 1.98.3
 
 jobs:
@@ -95,13 +96,18 @@ jobs:
       - name: Accept Tailnet Subnet Routes
         run: sudo tailscale set --accept-routes=true
 
+      - name: Select Homelab Exit Node
+        run: sudo tailscale set --exit-node="${TAILSCALE_EXIT_NODE}"
+
       - name: Install Kubeconfig
         env:
           KUBE_CONFIG_B64: ${{ secrets.KUBE_CONFIG_B64 }}
         run: bash scripts/ci/install-kubeconfig.sh
 
       - name: Verify Kubernetes API Reachability
-        run: kubectl --request-timeout=15s version
+        run: |
+          ip route get "${KUBE_API_SERVER}"
+          kubectl --request-timeout=15s version
 
       - name: Run Terragrunt Apply
         run: nix develop --command bash scripts/ci/terragrunt-apply.sh

--- a/.github/workflows/terragrunt-plan.yml
+++ b/.github/workflows/terragrunt-plan.yml
@@ -27,6 +27,7 @@ concurrency:
 env:
   AWS_REGION: us-east-1
   KUBE_API_SERVER: 10.1.0.199
+  TAILSCALE_EXIT_NODE: homelab-exit-node
   TAILSCALE_VERSION: 1.98.3
 
 jobs:
@@ -97,13 +98,18 @@ jobs:
       - name: Accept Tailnet Subnet Routes
         run: sudo tailscale set --accept-routes=true
 
+      - name: Select Homelab Exit Node
+        run: sudo tailscale set --exit-node="${TAILSCALE_EXIT_NODE}"
+
       - name: Install Kubeconfig
         env:
           KUBE_CONFIG_B64: ${{ secrets.KUBE_CONFIG_B64 }}
         run: bash scripts/ci/install-kubeconfig.sh
 
       - name: Verify Kubernetes API Reachability
-        run: kubectl --request-timeout=15s version
+        run: |
+          ip route get "${KUBE_API_SERVER}"
+          kubectl --request-timeout=15s version
 
       - name: Run Terragrunt Plan
         run: nix develop --command bash scripts/ci/terragrunt-plan.sh

--- a/clusters/homelab/apps/tailscale/exit-node-connector.yaml
+++ b/clusters/homelab/apps/tailscale/exit-node-connector.yaml
@@ -13,3 +13,6 @@ spec:
   tags:
     - tag:k8s
   exitNode: true
+  subnetRouter:
+    advertiseRoutes:
+      - 10.1.0.199/32

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -35,6 +35,10 @@ run the static checks only.
   `tailscale set --accept-routes=true` so it can use the subnet route to the
   Kubernetes API endpoint without conflicting with the action's own login
   flags.
+- The workflow also selects the repo-owned `homelab-exit-node` connector as a
+  bootstrap path for the GitHub-hosted runner. The connector advertises a
+  narrower `10.1.0.199/32` route for the Kubernetes API; prefer that route once
+  it is approved in the tailnet.
 - Plans are not uploaded as artifacts because Terraform/OpenTofu plans can
   include sensitive state context.
 - Automatic PR plans intentionally skip `IaC/live/kubernetes-secrets` because
@@ -85,34 +89,50 @@ Use separate tags for plan and apply runners:
 Create one Tailscale auth key that tailnet lock can admit. The key should be
 ephemeral, pre-approved for tailnet lock, and restricted to the CI tags when the
 admin panel permits tag scoping. In the tailnet policy, grant those tags only
-the cluster API path they need. If the Kubernetes API is reached through a
-subnet router, keep the destination scoped to the API endpoint and port:
+the cluster API path they need.
+
+The repository-owned `homelab-exit-node` Connector is tagged `tag:k8s`, acts as
+the current bootstrap exit node, and advertises `10.1.0.199/32` as the
+dedicated Kubernetes API route. Auto-approve the narrow route for `tag:k8s`
+when possible, and use grants to keep CI access limited to the API endpoint and
+port:
 
 ```json
 {
+  "autoApprovers": {
+    "exitNode": ["tag:k8s"],
+    "routes": {
+      "10.1.0.199/32": ["tag:k8s"]
+    }
+  },
   "tagOwners": {
     "tag:github-actions-terragrunt-plan": ["autogroup:admin"],
-    "tag:github-actions-terragrunt-apply": ["autogroup:admin"]
+    "tag:github-actions-terragrunt-apply": ["autogroup:admin"],
+    "tag:k8s": ["tag:k8s-operator"]
   },
   "grants": [
     {
       "src": ["tag:github-actions-terragrunt-plan"],
-      "dst": ["10.1.0.199"],
-      "ip": ["tcp:6443"]
+      "dst": ["10.1.0.199/32"],
+      "ip": ["tcp:6443"],
+      "via": ["tag:k8s"]
     },
     {
       "src": ["tag:github-actions-terragrunt-apply"],
-      "dst": ["10.1.0.199"],
-      "ip": ["tcp:6443"]
+      "dst": ["10.1.0.199/32"],
+      "ip": ["tcp:6443"],
+      "via": ["tag:k8s"]
     }
   ]
 }
 ```
 
-Do not grant `tag:github-actions-terragrunt-*` broad tailnet or SSH access
-unless a later repository change documents the requirement. Rotate
-`TS_AUTH_KEY` on any failed or suspicious run, after runner image changes, and
-on a regular schedule.
+If the bootstrap exit-node fallback needs a broader `autogroup:internet` grant
+to be selectable, treat it as temporary and keep it limited to the two CI tags
+and the `tag:k8s` route path. Do not grant `tag:github-actions-terragrunt-*`
+broad tailnet or SSH access unless a later repository change documents the
+requirement. Rotate `TS_AUTH_KEY` on any failed or suspicious run, after runner
+image changes, and on a regular schedule.
 
 ## AWS Setup
 

--- a/docs/networking-tailnet-ingress.md
+++ b/docs/networking-tailnet-ingress.md
@@ -45,7 +45,7 @@ Prometheus is intentionally absent from the tailnet route inventory. Grafana is
 the reviewed metrics UI, and direct Prometheus ingress must not be restored
 without a documented authentication plan and rollback path.
 
-## Homelab VPN Exit Node
+## Homelab VPN Exit Node And API Route
 
 Tailscale also provides the homelab VPN exit path. The `tailscale` Argo CD
 Application installs the upstream Tailscale Kubernetes Operator and applies the
@@ -56,13 +56,14 @@ The connector is cluster-scoped, creates one operator-managed proxy device, and
 advertises that device as a Tailscale exit node with hostname
 `homelab-exit-node` and tag `tag:k8s`. Tailnet clients can select that device as
 their exit node to route internet-bound traffic through the homelab cluster
-egress path.
+egress path. It also advertises the single-host `10.1.0.199/32` route so CI/CD
+runners can reach the Kubernetes API without exposing the rest of the LAN.
 
 This repository cannot approve tailnet routes by itself. The tailnet policy must
 allow `tag:k8s-operator` to own `tag:k8s`, and either auto-approve exit-node
-advertisement for `tag:k8s` with `autoApprovers.exitNode`, or rely on an admin
-manually approving `homelab-exit-node` in the Tailscale Machines page after
-sync.
+and `10.1.0.199/32` route advertisement for `tag:k8s`, or rely on an admin
+manually approving `homelab-exit-node` and the advertised route in the Tailscale
+Machines page after sync.
 
 Validate the exit node after Argo CD syncs Tailscale:
 
@@ -72,11 +73,12 @@ kubectl wait connector homelab-exit-node --for=condition=ConnectorReady=true --t
 kubectl -n tailscale get statefulset,pod -l tailscale.com/parent-resource=homelab-exit-node
 ```
 
-Expected result: the connector reports exit-node status, its ready condition is
-true, and a single Tailscale proxy Pod is running. Then select
-`homelab-exit-node` on a client and verify the public egress IP changes to the
-homelab network. Keep local-network access enabled on clients that still need
-nearby LAN access while using the exit node.
+Expected result: the connector reports exit-node status and the
+`10.1.0.199/32` subnet route, its ready condition is true, and a single
+Tailscale proxy Pod is running. Then select `homelab-exit-node` on a client and
+verify the public egress IP changes to the homelab network. Keep local-network
+access enabled on clients that still need nearby LAN access while using the exit
+node.
 
 ## Future Funnel Webhook Exception Template
 


### PR DESCRIPTION
Follow-up to #254 after the first post-merge Terragrunt Apply reached Tailscale but timed out against the Kubernetes API. This adds explicit exit-node selection for the GitHub-hosted runner, advertises the narrower 10.1.0.199/32 Kubernetes API route from the repo-owned Tailscale Connector, and documents the tailnet grants/auto-approval expectations. Validated locally with nix develop --command bash scripts/ci/static-checks.sh.