### PR TITLE
fix(grafana): unblock datasource provisioning

### DIFF
--- a/clusters/homelab/apps/grafana/values.yaml
+++ b/clusters/homelab/apps/grafana/values.yaml
@@ -64,7 +64,6 @@ datasources:
         jsonData:
           httpMethod: POST
           timeInterval: 30s
-          alertmanagerUid: alertmanager
 dashboardProviders:
   dashboardproviders.yaml:
     apiVersion: 1


### PR DESCRIPTION
Removes the Prometheus datasource alertmanagerUid reference that Grafana 12 rejects during startup before the Alertmanager datasource is available in the database. This keeps the Alertmanager datasource and contact point, while allowing the SSO-enabled Grafana pod to start. Validated with kubectl kustomize clusters/homelab/apps/grafana, helm template for grafana chart 10.5.15, git diff --check, and pre-commit.