### PR TITLE
fix(grafana): reconcile provisioned datasource uids

### DIFF
--- a/clusters/homelab/apps/grafana/values.yaml
+++ b/clusters/homelab/apps/grafana/values.yaml
@@ -44,6 +44,11 @@ persistence:
 datasources:
   datasources.yaml:
     apiVersion: 1
+    deleteDatasources:
+      - name: Prometheus
+        orgId: 1
+      - name: Alertmanager
+        orgId: 1
     datasources:
       - name: Alertmanager
         uid: alertmanager


### PR DESCRIPTION
Adds deleteDatasources for the provisioned Grafana Prometheus and Alertmanager datasources so startup can recreate them with the repo-owned UIDs before alert rules and dashboards reference those UIDs. This addresses the Grafana 12 startup failure: Datasource provisioning error: data source not found. Validated with kubectl kustomize clusters/homelab/apps/grafana, helm template for grafana chart 10.5.15, git diff --check, and pre-commit.