### PR TITLE
fix(istio): ignore ztunnel defaulted env drift

### DIFF
--- a/IaC/live/argocd-apps/istio/terragrunt.hcl
+++ b/IaC/live/argocd-apps/istio/terragrunt.hcl
@@ -136,6 +136,10 @@ inputs = {
         "/metadata/annotations",
         "/spec/template/metadata/annotations",
       ]
+      jq_path_expressions = [
+        ".spec.template.spec.containers[] | select(.name == \"istio-proxy\").env[] | select(.valueFrom.fieldRef != null).valueFrom.fieldRef.apiVersion",
+        ".spec.template.spec.containers[] | select(.name == \"istio-proxy\").env[] | select(.valueFrom.resourceFieldRef != null).valueFrom.resourceFieldRef.divisor",
+      ]
     }
   ]
 


### PR DESCRIPTION
## Summary
- ignore Kubernetes-defaulted ztunnel env valueFrom fields in the Istio Argo CD Application
- keeps Argo sync focused on declarative chart drift instead of API-server defaults

## Validation
- terragrunt hcl fmt --check
- terragrunt --log-disable plan -no-color in IaC/live/argocd-apps/istio