### PR TITLE
ci: run conftest after terragrunt plan

### DIFF
--- a/.github/workflows/terragrunt-apply.yml
+++ b/.github/workflows/terragrunt-apply.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Run Static Checks
         run: nix develop --command bash scripts/ci/static-checks.sh
 
+      - name: Run Conftest Policies
+        run: nix develop --command bash scripts/ci/conftest-policies.sh
+
   terragrunt-apply:
     name: Terragrunt Apply
     needs:

--- a/.github/workflows/terragrunt-plan.yml
+++ b/.github/workflows/terragrunt-plan.yml
@@ -124,6 +124,10 @@ jobs:
           TERRAGRUNT_PLAN_MARKDOWN: ${{ runner.temp }}/terragrunt-plan.md
         run: bash scripts/ci/update-pr-plan-description.sh
 
+      - name: Run Conftest Policies
+        if: ${{ !cancelled() }}
+        run: nix develop --command bash scripts/ci/conftest-policies.sh
+
   fork-plan-skipped:
     name: Terragrunt Plan Skipped For Fork
     if: github.event.pull_request.head.repo.full_name != github.repository
@@ -133,5 +137,20 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Check Out Repository
+        # actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        # cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Explain Skip
         run: echo "Live Terragrunt plan is skipped for forked pull requests because it requires AWS, Tailscale, and Kubernetes secrets."
+
+      - name: Run Conftest Policies
+        run: nix develop --command bash scripts/ci/conftest-policies.sh

--- a/clusters/homelab/apps/openclaw/values.yaml
+++ b/clusters/homelab/apps/openclaw/values.yaml
@@ -6,7 +6,7 @@ controllers:
       identifier: openclaw
     pod:
       annotations:
-        homelab.rst.io/openclaw-discord-bot-token-ssm-version: "1"
+        homelab.rst.io/openclaw-discord-bot-token-ssm-version: "2"
     initContainers:
       bootstrap-config:
         image:

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -2,15 +2,19 @@
 
 This repository uses GitHub Actions for the review and rollout path:
 
-- `Terragrunt Plan` runs on pull requests. It always runs static checks,
-  Conftest policies, and Checkov. Trusted same-repository pull requests also
-  connect to the tailnet and run a live Terragrunt plan.
+- `Terragrunt Plan` runs on pull requests. It always runs static checks and
+  Checkov first. Trusted same-repository pull requests then connect to the
+  tailnet, run a live Terragrunt plan, and run Conftest policies after the plan
+  step. Forked pull requests run Conftest after the live plan skip notice.
 - `Terragrunt Apply` runs after changes land on `main` and can also be started
-  manually with `workflow_dispatch`. It repeats static checks before connecting
-  to the tailnet and applying the live Terragrunt stack.
+  manually with `workflow_dispatch`. It repeats static checks and Conftest
+  before connecting to the tailnet and applying the live Terragrunt phases in
+  order: Argo CD bootstrap, SSM parameter declarations, Entra application
+  registrations, Argo CD Application registrations, and Kubernetes secret
+  materialization.
 
 Forked pull requests never receive AWS, Tailscale, or Kubernetes secrets. They
-run the static checks only.
+run the static checks and Conftest only.
 
 ## Security Model
 
@@ -201,6 +205,7 @@ Run the same checks locally through the Nix shell:
 ```sh
 nix develop --command bash scripts/ci/static-checks.sh
 nix develop --command bash scripts/ci/terragrunt-plan.sh
+nix develop --command bash scripts/ci/conftest-policies.sh
 ```
 
 The PR plan script intentionally skips the privileged SSM declaration and
@@ -216,5 +221,7 @@ Only run apply after the same validation has passed and the change has been
 reviewed:
 
 ```sh
+nix develop --command bash scripts/ci/static-checks.sh
+nix develop --command bash scripts/ci/conftest-policies.sh
 nix develop --command bash scripts/ci/terragrunt-apply.sh
 ```

--- a/docs/knowledge-base/operations/change-log.md
+++ b/docs/knowledge-base/operations/change-log.md
@@ -10,6 +10,14 @@ Use [[templates/knowledge-update]] for new entries.
 
 ## Entries
 
+### 2026-05-25 - PR Conftest ordering
+
+- Split Conftest policy evaluation out of `scripts/ci/static-checks.sh` into
+  `scripts/ci/conftest-policies.sh`.
+- Updated the pull request Terragrunt Plan workflow so trusted same-repository
+  PRs run Conftest after the live Terragrunt plan step while forked PRs still
+  run Conftest without receiving live-plan secrets.
+
 ### 2026-05-25 - Enable Policy Bot replica
 
 - Changed Policy Bot from a credential-gated suspended Deployment to one desired

--- a/docs/knowledge-base/operations/validation-gates.md
+++ b/docs/knowledge-base/operations/validation-gates.md
@@ -13,6 +13,7 @@ For most repo changes, start with:
 terragrunt hcl fmt --check
 terragrunt hcl validate
 nix develop --command bash scripts/ci/static-checks.sh
+nix develop --command bash scripts/ci/conftest-policies.sh
 git diff --check
 ```
 
@@ -60,6 +61,10 @@ Implicit stack validation:
 cd IaC/live/argocd-apps
 terragrunt run --all --parallelism 1 --source-update plan -no-color
 ```
+
+The pull request workflow runs `scripts/ci/conftest-policies.sh` after the live
+Terragrunt plan step for trusted same-repository PRs. Run the same order locally
+when reproducing PR gate behavior.
 
 ## Live Rollout Rule
 

--- a/docs/knowledge-base/runbooks/ci-cd.md
+++ b/docs/knowledge-base/runbooks/ci-cd.md
@@ -6,14 +6,15 @@ Source: `docs/ci-cd.md`
 
 ## Pipeline Shape
 
-- `Terragrunt Plan` runs on pull requests. It always runs static checks,
-  Conftest, and Checkov. Trusted same-repo PRs can join the tailnet and run a
-  live Terragrunt plan.
+- `Terragrunt Plan` runs on pull requests. It always runs static checks and
+  Checkov first. Trusted same-repo PRs can join the tailnet, run a live
+  Terragrunt plan, and then run Conftest. Forked PRs run Conftest after the
+  live plan skip notice.
 - `Terragrunt Apply` runs after merge to `main` and through
-  `workflow_dispatch`. It repeats static checks, joins the tailnet, and applies
-  the live Terragrunt phases in order: Argo CD bootstrap, SSM parameter
-  declarations, Entra application registrations, Argo CD Application
-  registrations, and Kubernetes secret materialization.
+  `workflow_dispatch`. It repeats static checks and Conftest, joins the
+  tailnet, and applies the live Terragrunt phases in order: Argo CD bootstrap,
+  SSM parameter declarations, Entra application registrations, Argo CD
+  Application registrations, and Kubernetes secret materialization.
 - Forked PRs never receive AWS, Tailscale, or Kubernetes secrets.
 
 ## Security Model
@@ -62,6 +63,7 @@ route to reach the Kubernetes API. Keep grants limited to TCP `6443`.
 ```sh
 nix develop --command bash scripts/ci/static-checks.sh
 nix develop --command bash scripts/ci/terragrunt-plan.sh
+nix develop --command bash scripts/ci/conftest-policies.sh
 nix develop --command bash scripts/ci/terragrunt-apply.sh
 ```
 

--- a/scripts/ci/conftest-policies.sh
+++ b/scripts/ci/conftest-policies.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "::group::Conftest policies"
+yaml_files=()
+while IFS= read -r yaml_file; do
+  yaml_files+=("$yaml_file")
+done < <(
+  find .github clusters \
+    \( -name '*.yaml' -o -name '*.yml' \) \
+    -not -path './.terragrunt-cache/*' \
+    -print 2>/dev/null | sort
+)
+
+if ((${#yaml_files[@]} > 0)); then
+  conftest test --policy policy --output github "${yaml_files[@]}"
+fi
+echo "::endgroup::"

--- a/scripts/ci/static-checks.sh
+++ b/scripts/ci/static-checks.sh
@@ -17,22 +17,6 @@ done < <(
 )
 echo "::endgroup::"
 
-echo "::group::Conftest policies"
-yaml_files=()
-while IFS= read -r yaml_file; do
-  yaml_files+=("$yaml_file")
-done < <(
-  find .github clusters \
-    \( -name '*.yaml' -o -name '*.yml' \) \
-    -not -path './.terragrunt-cache/*' \
-    -print 2>/dev/null | sort
-)
-
-if ((${#yaml_files[@]} > 0)); then
-  conftest test --policy policy --output github "${yaml_files[@]}"
-fi
-echo "::endgroup::"
-
 echo "::group::Image digest pins"
 tag_only_images="$(
   {


### PR DESCRIPTION
## Summary
- Split Conftest policy evaluation into `scripts/ci/conftest-policies.sh` so it can be run independently of the static preflight.
- Move Conftest in the pull request Terragrunt Plan workflow to after the live plan step for trusted same-repository PRs.
- Keep forked PRs on the same policy check path after the live-plan skip notice, without exposing live-plan secrets.
- Preserve Conftest in the apply workflow before production apply.
- Update the CI/CD docs, validation notes, and knowledge-base change log to match the new ordering.

## Testing
- Lint and formatting checks passed.
- `scripts/ci/conftest-policies.sh` passed locally.
- `scripts/ci/static-checks.sh` passed locally.