### PR TITLE
fix: preserve grafana provisioning rollout guard

### DIFF
--- a/clusters/homelab/apps/grafana/README.md
+++ b/clusters/homelab/apps/grafana/README.md
@@ -36,6 +36,12 @@ present. Local admin login remains available through `grafana-admin`.
   stable UIDs, enables a `ServiceMonitor` for Grafana metrics, mounts
   dashboards, configures Microsoft Entra SSO, and provisions Grafana-managed
   alerting resources.
+- The Helm release uses a `Recreate` deployment strategy because Grafana stores
+  SQLite state on a single PVC. Avoid overlapping old and new pods against the
+  same database during rollouts.
+- Datasource provisioning deletes the old `Prometheus` and `Alertmanager`
+  entries before recreating them with stable UIDs. This handles first-rollout
+  databases that already contain Grafana-generated datasource UIDs.
 - `dashboards/homelab-overview.json` is the default Homelab overview dashboard.
   `dashboards/argocd-overview.json` is the Argo CD GitOps operations
   dashboard. Kustomize packages both dashboards into the stable

--- a/clusters/homelab/apps/grafana/values.yaml
+++ b/clusters/homelab/apps/grafana/values.yaml
@@ -2,6 +2,8 @@ admin:
   existingSecret: grafana-admin
   userKey: username
   passwordKey: password
+deploymentStrategy:
+  type: Recreate
 extraSecretMounts:
   - name: grafana-azuread-sso
     secretName: grafana-azuread-sso
@@ -56,23 +58,28 @@ datasources:
         orgId: 1
       - name: Alertmanager
         orgId: 1
+    prune: true
     datasources:
       - name: Alertmanager
+        orgId: 1
         uid: alertmanager
         type: alertmanager
         access: proxy
         url: http://prometheus-kube-prometheus-alertmanager.monitoring:9093
         editable: false
+        version: 2
         jsonData:
           implementation: prometheus
           handleGrafanaManagedAlerts: false
       - name: Prometheus
+        orgId: 1
         uid: prometheus
         type: prometheus
         access: proxy
         url: http://prometheus-kube-prometheus-prometheus.monitoring:9090
         isDefault: true
         editable: false
+        version: 2
         jsonData:
           httpMethod: POST
           timeInterval: 30s


### PR DESCRIPTION
Preserves the surviving WIP from /Users/themanofrod/.codex/worktrees/1c61/homelab by replaying it onto current main. Existing main already had part of the datasource fix, so this draft PR carries forward the remaining Recreate/prune/versioning intent.\n\nValidation:\n- git diff --check