### PR TITLE
fix: preserve argocd application drift defaults

### DIFF
--- a/IaC/modules/argocd-application-kubernetes/main.tf
+++ b/IaC/modules/argocd-application-kubernetes/main.tf
@@ -51,19 +51,30 @@ locals {
   )
 
   destination = {
-    name      = try(var.destination.name, null)
+    # The Kubernetes provider's CRD schema expects this key even when Argo CD uses server-based destinations.
+    name      = try(var.destination.name, null) != null ? var.destination.name : ""
     namespace = try(var.destination.namespace, null)
     server    = try(var.destination.server, null)
   }
 
-  computed_fields = var.computed_fields == null ? [] : var.computed_fields
+  default_computed_fields = concat(
+    [
+      "metadata.annotations",
+      "metadata.labels",
+      "spec.destination.name",
+    ],
+    [for index in range(length(local.sources)) : "spec.sources[${index}].path"]
+  )
+  computed_fields = var.computed_fields == null ? local.default_computed_fields : distinct(concat(local.default_computed_fields, var.computed_fields))
 
   sources = [
     for source in var.sources : merge(
       { repoURL = source.repo_url },
       try(source.chart, null) != null ? { chart = source.chart } : {},
       try(source.name, null) != null ? { name = source.name } : {},
-      try(source.path, null) != null ? { path = source.path } : {},
+      try(source.path, null) != null ? { path = source.path } : (
+        try(source.chart, null) != null || try(source.ref, null) != null || try(source.directory, null) != null ? { path = "." } : {}
+      ),
       try(source.ref, null) != null ? { ref = source.ref } : {},
       try(source.target_revision, null) != null ? { targetRevision = source.target_revision } : {},
       try(source.directory, null) != null ? {


### PR DESCRIPTION
Preserves the unlanded module WIP from /Users/themanofrod/.codex/worktrees/717f/homelab by replaying it onto current main. The Istio and media-postgres ignore-difference pieces from that worktree were already present in main, so this draft PR carries only the remaining shared-module changes.\n\nValidation:\n- git diff --check\n- tofu fmt -check IaC/modules/argocd-application-kubernetes/main.tf