### PR TITLE
ci: serialize Terragrunt PR plans

### DIFF
--- a/.github/workflows/terragrunt-plan.yml
+++ b/.github/workflows/terragrunt-plan.yml
@@ -55,6 +55,11 @@ jobs:
   terragrunt-plan:
     name: Terragrunt Plan
     if: github.event.pull_request.head.repo.full_name == github.repository
+    # The plan reads shared OpenTofu state, so only one trusted PR plan should
+    # hold the backend lock at a time.
+    concurrency:
+      group: terragrunt-plan-live-state
+      cancel-in-progress: false
     needs:
       - static-policy
     runs-on: ubuntu-24.04

--- a/docs/knowledge-base/operations/change-log.md
+++ b/docs/knowledge-base/operations/change-log.md
@@ -10,6 +10,14 @@ Use [[templates/knowledge-update]] for new entries.
 
 ## Entries
 
+### 2026-05-26 - Serialize trusted Terragrunt PR plans
+
+- Added a shared concurrency gate to the trusted PR `Terragrunt Plan` job so
+  simultaneous Renovate branches queue before reading the shared OpenTofu S3
+  backend state.
+- Documented that queued Terragrunt PR plans are expected when another trusted
+  PR is already holding the live-state lock lane.
+
 ### 2026-05-25 - PR Conftest ordering
 
 - Split Conftest policy evaluation out of `scripts/ci/static-checks.sh` into

--- a/docs/knowledge-base/operations/validation-gates.md
+++ b/docs/knowledge-base/operations/validation-gates.md
@@ -66,6 +66,11 @@ The pull request workflow runs `scripts/ci/conftest-policies.sh` after the live
 Terragrunt plan step for trusted same-repository PRs. Run the same order locally
 when reproducing PR gate behavior.
 
+The trusted GitHub Actions PR plan job is serialized with a shared concurrency
+group because it reads the same OpenTofu S3 backend state across pull requests.
+Do not treat a queued PR plan as unhealthy; it is waiting for the live-state
+lock lane.
+
 ## Live Rollout Rule
 
 Do not mutate live cluster, Talos, cloud, Argo CD, or secret-manager state until


### PR DESCRIPTION
## Summary
- Add a shared job-level concurrency gate for trusted Terragrunt PR plans so simultaneous Renovate branches queue before touching shared OpenTofu S3 state.
- Document the queued-plan behavior in the knowledge-base validation gates and change log.

## Validation
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/terragrunt-plan.yml"); puts "terragrunt-plan.yml parses"'`
- `nix develop --command bash scripts/ci/static-checks.sh`