### PR TITLE
feat: preserve deluge ambient mesh policy

### DIFF
--- a/clusters/homelab/apps/deluge/README.md
+++ b/clusters/homelab/apps/deluge/README.md
@@ -72,16 +72,22 @@ same restored config volume at the same time.
 
 ## Mesh Policy
 
-The `media` namespace is intentionally not enrolled in Istio ambient mode while
-the operator web UIs are exposed through the shared tailnet ingress gateway.
-The tailnet gateway must be able to proxy to Deluge, Radarr, Sonarr, and
-Prowlarr services without ambient HBONE resets, and the Deluge Pod cannot use
-sidecar injection because Gluetun owns the VPN network setup.
+The `media` namespace is enrolled in Istio ambient mode. Ambient is used instead
+of sidecar injection so Deluge's Gluetun-managed Pod network namespace does not
+also receive an Envoy sidecar.
 
-Keep media UI access on the Istio reverse proxy ingress path with
-`public-funnel=false` Tailscale annotations. Reintroduce ambient mesh only with a
-repo-owned waypoint or equivalent gateway policy that preserves HTTPS access to
-the `*.stinkyboi.com` operator addresses.
+Deluge has a workload-scoped `PeerAuthentication` that requires STRICT mTLS and
+an `AuthorizationPolicy` that allows only these media automation identities to
+reach Deluge's web/API port `8112`:
+
+- `media/radarr`
+- `media/sonarr`
+- `media/prowlarr`
+
+The Deluge tailnet `VirtualService` remains declared for reviewability, but this
+policy intentionally does not allow the Istio ingress gateway identity. Add that
+principal in the same policy only if operator UI access to Deluge is deliberately
+restored.
 
 ## Verification
 
@@ -92,10 +98,13 @@ kubectl -n media get externalsecret deluge-vpn
 kubectl -n media get secret deluge-vpn
 kubectl -n media get pod -l app.kubernetes.io/name=deluge
 kubectl -n media logs deploy/deluge -c gluetun
+kubectl -n media get peerauthentication deluge-strict-mtls
+kubectl -n media get authorizationpolicy deluge-allow-media-clients
 ```
 
 The ExternalSecret should be ready, the `deluge-vpn` Secret should exist, the
-Pod should be ready, and Gluetun logs should show a healthy WireGuard session.
+Pod should be ready, the mesh policy objects should exist, and Gluetun logs
+should show a healthy WireGuard session.
 This command should return success only while the VPN is healthy:
 
 ```sh

--- a/clusters/homelab/apps/deluge/kustomization.yaml
+++ b/clusters/homelab/apps/deluge/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - externalsecret.yaml
+  - mesh-policy.yaml
   - virtualservice.yaml

--- a/clusters/homelab/apps/deluge/mesh-policy.yaml
+++ b/clusters/homelab/apps/deluge/mesh-policy.yaml
@@ -1,0 +1,35 @@
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: deluge-strict-mtls
+  namespace: media
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: deluge
+      app.kubernetes.io/name: deluge
+  mtls:
+    mode: STRICT
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: deluge-allow-media-clients
+  namespace: media
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: deluge
+      app.kubernetes.io/name: deluge
+  action: ALLOW
+  rules:
+    - from:
+        - source:
+            serviceAccounts:
+              - radarr
+              - sonarr
+              - prowlarr
+      to:
+        - operation:
+            ports:
+              - "8112"

--- a/clusters/homelab/apps/deluge/namespace.yaml
+++ b/clusters/homelab/apps/deluge/namespace.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: media
     app.kubernetes.io/part-of: homelab
+    istio.io/dataplane-mode: ambient
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/enforce-version: latest
     pod-security.kubernetes.io/audit: privileged


### PR DESCRIPTION
Preserves the unlanded mesh-policy WIP from /Users/themanofrod/.codex/worktrees/887e/homelab by replaying the remaining pieces onto current main. Most Istio ambient plumbing and media service-account changes from that worktree were already present in main.\n\nImportant: this draft intentionally conflicts with the current Deluge README decision that keeps media out of ambient mode, so treat it as preservation/context until that architecture decision is revisited.\n\nValidation:\n- git diff --check\n- kubectl kustomize clusters/homelab/apps/deluge