### PR TITLE
fix: preserve runtime security audit hardening

### DIFF
--- a/clusters/homelab/apps/cert-manager/namespace.yaml
+++ b/clusters/homelab/apps/cert-manager/namespace.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/part-of: homelab
     pod-security.kubernetes.io/enforce: baseline
     pod-security.kubernetes.io/enforce-version: latest
-    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/audit: restricted
     pod-security.kubernetes.io/audit-version: latest
-    pod-security.kubernetes.io/warn: baseline
+    pod-security.kubernetes.io/warn: restricted
     pod-security.kubernetes.io/warn-version: latest

--- a/clusters/homelab/apps/deluge/values.yaml
+++ b/clusters/homelab/apps/deluge/values.yaml
@@ -5,6 +5,7 @@ controllers:
     serviceAccount:
       identifier: deluge
     pod:
+      automountServiceAccountToken: false
       annotations:
         homelab.rst.io/rollout-strategy: "recreate-singleton"
         homelab.rst.io/wireguard-address-mode: "ipv4-only"

--- a/clusters/homelab/apps/external-secrets/namespace.yaml
+++ b/clusters/homelab/apps/external-secrets/namespace.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/part-of: homelab
     pod-security.kubernetes.io/enforce: baseline
     pod-security.kubernetes.io/enforce-version: latest
-    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/audit: restricted
     pod-security.kubernetes.io/audit-version: latest
-    pod-security.kubernetes.io/warn: baseline
+    pod-security.kubernetes.io/warn: restricted
     pod-security.kubernetes.io/warn-version: latest

--- a/clusters/homelab/apps/istio/values.yaml
+++ b/clusters/homelab/apps/istio/values.yaml
@@ -10,6 +10,7 @@ pilot:
 meshConfig:
   accessLogFile: /dev/stdout
 service:
+  allocateLoadBalancerNodePorts: false
   annotations:
     homelab.rst.io/pod-security: tailscale-proxy-requires-privileged
     tailscale.com/hostname: homelab-istio

--- a/clusters/homelab/apps/litellm/namespace.yaml
+++ b/clusters/homelab/apps/litellm/namespace.yaml
@@ -8,7 +8,7 @@ metadata:
     istio.io/dataplane-mode: ambient
     pod-security.kubernetes.io/enforce: baseline
     pod-security.kubernetes.io/enforce-version: latest
-    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/audit: restricted
     pod-security.kubernetes.io/audit-version: latest
-    pod-security.kubernetes.io/warn: baseline
+    pod-security.kubernetes.io/warn: restricted
     pod-security.kubernetes.io/warn-version: latest

--- a/clusters/homelab/apps/n8n/namespace.yaml
+++ b/clusters/homelab/apps/n8n/namespace.yaml
@@ -8,7 +8,7 @@ metadata:
     istio.io/dataplane-mode: ambient
     pod-security.kubernetes.io/enforce: baseline
     pod-security.kubernetes.io/enforce-version: latest
-    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/audit: restricted
     pod-security.kubernetes.io/audit-version: latest
-    pod-security.kubernetes.io/warn: baseline
+    pod-security.kubernetes.io/warn: restricted
     pod-security.kubernetes.io/warn-version: latest

--- a/clusters/homelab/apps/n8n/values.yaml
+++ b/clusters/homelab/apps/n8n/values.yaml
@@ -4,6 +4,8 @@ controllers:
   n8n:
     serviceAccount:
       identifier: n8n
+    pod:
+      automountServiceAccountToken: false
     strategy: Recreate
     containers:
       app:

--- a/clusters/homelab/apps/openclaw/values.yaml
+++ b/clusters/homelab/apps/openclaw/values.yaml
@@ -5,6 +5,7 @@ controllers:
     serviceAccount:
       identifier: openclaw
     pod:
+      automountServiceAccountToken: false
       annotations:
         homelab.rst.io/openclaw-discord-bot-token-ssm-version: "2"
     initContainers:

--- a/clusters/homelab/apps/prometheus/namespace.yaml
+++ b/clusters/homelab/apps/prometheus/namespace.yaml
@@ -8,7 +8,7 @@ metadata:
     istio.io/dataplane-mode: ambient
     pod-security.kubernetes.io/enforce: baseline
     pod-security.kubernetes.io/enforce-version: latest
-    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/audit: restricted
     pod-security.kubernetes.io/audit-version: latest
-    pod-security.kubernetes.io/warn: baseline
+    pod-security.kubernetes.io/warn: restricted
     pod-security.kubernetes.io/warn-version: latest

--- a/clusters/homelab/apps/prowlarr/values.yaml
+++ b/clusters/homelab/apps/prowlarr/values.yaml
@@ -5,6 +5,7 @@ controllers:
     serviceAccount:
       identifier: prowlarr
     pod:
+      automountServiceAccountToken: false
       annotations:
         homelab.rst.io/mesh-mode: "tailnet-ingress"
     initContainers:

--- a/clusters/homelab/apps/radarr/values.yaml
+++ b/clusters/homelab/apps/radarr/values.yaml
@@ -5,6 +5,7 @@ controllers:
     serviceAccount:
       identifier: radarr
     pod:
+      automountServiceAccountToken: false
       annotations:
         homelab.rst.io/mesh-mode: "tailnet-ingress"
     initContainers:

--- a/clusters/homelab/apps/sonarr/values.yaml
+++ b/clusters/homelab/apps/sonarr/values.yaml
@@ -5,6 +5,7 @@ controllers:
     serviceAccount:
       identifier: sonarr
     pod:
+      automountServiceAccountToken: false
       annotations:
         homelab.rst.io/mesh-mode: "tailnet-ingress"
     initContainers:

--- a/clusters/homelab/argocd/self-management/namespace.yaml
+++ b/clusters/homelab/argocd/self-management/namespace.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/part-of: homelab
     pod-security.kubernetes.io/enforce: baseline
     pod-security.kubernetes.io/enforce-version: latest
-    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/audit: restricted
     pod-security.kubernetes.io/audit-version: latest
-    pod-security.kubernetes.io/warn: baseline
+    pod-security.kubernetes.io/warn: restricted
     pod-security.kubernetes.io/warn-version: latest

--- a/clusters/homelab/platform/storage/namespace.yaml
+++ b/clusters/homelab/platform/storage/namespace.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/part-of: homelab
     pod-security.kubernetes.io/enforce: baseline
     pod-security.kubernetes.io/enforce-version: latest
-    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/audit: restricted
     pod-security.kubernetes.io/audit-version: latest
-    pod-security.kubernetes.io/warn: baseline
+    pod-security.kubernetes.io/warn: restricted
     pod-security.kubernetes.io/warn-version: latest

--- a/docs/knowledge-base/operations/change-log.md
+++ b/docs/knowledge-base/operations/change-log.md
@@ -114,6 +114,13 @@ Use [[templates/knowledge-update]] for new entries.
 - Recorded the `refreshPolicy: OnChange` follow-up so SSM repairs are rolled
   through a repo-owned ExternalSecret change and Argo CD sync.
 
+### 2026-05-25 - Preserve runtime security audit WIP
+
+- Preserved namespace Pod Security hardening so non-privileged namespaces keep
+  `baseline` enforcement while warning and auditing against `restricted`.
+- Preserved service-account token and Istio LoadBalancer node-port hardening
+  notes from the audit worktree for review in a dedicated draft PR.
+
 ### 2026-05-25 - Enable Policy Bot replica
 
 - Changed Policy Bot from a credential-gated suspended Deployment to one desired

--- a/docs/networking-tailnet-ingress.md
+++ b/docs/networking-tailnet-ingress.md
@@ -50,6 +50,13 @@ VirtualService remains annotated with `homelab.rst.io/public-funnel: "false"`.
 Every other Istio gateway and VirtualService route manifest remains
 tailnet-only.
 
+The Istio ingressgateway Service is a Tailscale `LoadBalancer` and sets
+`allocateLoadBalancerNodePorts: false` so the gateway is not exposed through
+high NodePorts on every Talos node. A 2026-05-25 read-only scan found existing
+NodePorts from the earlier Service revision. After Argo CD syncs this desired
+state, verify those ports are gone with `kubectl -n istio-system get svc
+istio-ingressgateway -o yaml` and a focused node-port scan.
+
 Prometheus is intentionally absent from the tailnet route inventory. Grafana is
 the reviewed metrics UI, and direct Prometheus ingress must not be restored
 without a documented authentication plan and rollback path.

--- a/docs/runtime-isolation.md
+++ b/docs/runtime-isolation.md
@@ -24,7 +24,9 @@ Current enforced controls are therefore:
 Non-privileged runtime namespaces use the `baseline` Pod Security profile so
 new workloads cannot silently add privileged containers, host networking,
 hostPath mounts, or other host-level access. Move a namespace to `privileged`
-only with the documented justification and owner below.
+only with the documented justification and owner below. These namespaces warn
+and audit against the stricter `restricted` profile so future chart changes
+surface before becoming production assumptions.
 
 ## Istio Ambient Service Access
 
@@ -104,6 +106,13 @@ These namespaces are explicitly kept at the Pod Security `baseline` profile:
 Do not broaden privileged admission for convenience. If another workload needs
 privileged mode, add the reason, owner, rollback note, and safer alternatives in
 the same PR as the manifest change.
+
+Security audit note from 2026-05-25: `media` is broader than ideal because
+Sonarr, Radarr, Prowlarr, and media PostgreSQL share the namespace with the
+Deluge VPN Pod that needs `/dev/net/tun`. Do not add more privileged workloads
+to `media`. The long-term hardening path is to move Deluge and its shared
+downloads contract into a dedicated privileged namespace or replace the VPN
+pattern with one that does not require privileged namespace admission.
 
 ## Network Policy Placeholder
 

--- a/docs/storage-nfs.md
+++ b/docs/storage-nfs.md
@@ -20,8 +20,14 @@ unless an app-specific exception is documented here.
 | Media NFS export path | `/media` |
 
 NFS is enabled from QTS at Control Panel > Network & File Services >
-Win/Mac/NFS/WebDAV > NFS Service. The current NAS configuration enables
-NFSv2/NFSv3, and Kubernetes mounts the export with `nfsvers=3`.
+Win/Mac/NFS/WebDAV > NFS Service. Kubernetes mounts the export with
+`nfsvers=3`.
+
+Security audit note from 2026-05-25: read-only `rpcinfo -p 10.1.0.2` showed
+the NAS advertising both NFSv2 and NFSv3. Kubernetes does not need NFSv2.
+Disable NFSv2 in QTS after confirming no non-Kubernetes clients depend on it,
+then re-run `rpcinfo -p 10.1.0.2` and confirm only the required NFS version is
+advertised.
 
 The `homelab` shared folder grants NFS read/write access only to the Talos node
 addresses. The `Media` shared folder must use the same node allow-list before
@@ -80,7 +86,7 @@ Important settings:
 | Namespace | `storage` | Keeps storage controller resources out of app namespaces |
 | `nfs.server` | `10.1.0.2` | QNAP NAS address |
 | `nfs.path` | `/homelab` | Export path verified with `showmount` |
-| `nfs.mountOptions` | `nfsvers=3` | Matches the enabled QNAP NFS service |
+| `nfs.mountOptions` | `nfsvers=3` | Matches the Kubernetes-supported NAS NFS mode |
 | StorageClass | `nfs-default` | Stable class name for homelab PVCs |
 | `defaultClass` | `true` | Allows ordinary PVCs to bind without per-app overrides |
 | `provisionerName` | `k8s-sigs.io/qnap-nfs` | Stable provisioner identity |
@@ -200,3 +206,7 @@ app has acceptable backup and restore coverage.
 - A temporary PVC smoke test on 2026-05-24 dynamically provisioned storage,
   mounted it into a pod, wrote `smoke.txt`, read it back, and then removed the
   temporary PVC, pod, and smoke-test StorageClass.
+- Read-only QNAP checks on 2026-05-25 confirmed `/homelab` remains exported
+  only to `10.1.0.199`, `10.1.0.200`, `10.1.0.201`, and `10.1.0.202`. The same
+  audit found NFSv2 still advertised through RPC; disable it in QTS because the
+  Kubernetes StorageClass mounts with NFSv3.

--- a/docs/talos-control-plane-maintenance.md
+++ b/docs/talos-control-plane-maintenance.md
@@ -21,6 +21,16 @@ The parent audit reported:
 Treat `10.1.0.216` as stale. It may still appear in live service-account issuer
 discovery until the control-plane machine config is corrected and applied.
 
+Security refresh on 2026-05-25:
+
+- Kubernetes `v1.34.1` is still on a supported upstream minor, but upstream
+  `1.34` has newer patch releases. Plan a Kubernetes patch upgrade after
+  reading the current `1.34` changelog.
+- Talos `v1.11.3` is behind the current Talos security baseline. Sidero's
+  CVE-2026-31431 guidance recommends upgrading clusters to Talos `1.12.7` or
+  newer, or `1.13.0` or newer. Treat a Talos minor upgrade as a separate
+  maintenance change with validated machine config and a node-by-node rollout.
+
 ## Desired Service-Account Issuer State
 
 The desired service-account issuer is the canonical Kubernetes API endpoint:
@@ -166,8 +176,8 @@ baseline from the parent audit is Talos `v1.11.3` and Kubernetes `v1.34.1`.
    kubectl get nodes -o wide
    ```
 
-   Then check the Talos support matrix, Talos release notes, and Kubernetes
-   release notes for the selected target versions.
+   Then check the Talos support matrix, Talos release notes, Talos security
+   guidance, and Kubernetes release notes for the selected target versions.
 
 2. Choose targets:
 

--- a/policy/kubernetes.rego
+++ b/policy/kubernetes.rego
@@ -7,10 +7,29 @@ homelab_repo_urls := {
 	"git@github.com:Stuhlmuller/homelab.git",
 }
 
+required_pod_security_labels := {
+	"pod-security.kubernetes.io/enforce",
+	"pod-security.kubernetes.io/enforce-version",
+	"pod-security.kubernetes.io/audit",
+	"pod-security.kubernetes.io/audit-version",
+	"pod-security.kubernetes.io/warn",
+	"pod-security.kubernetes.io/warn-version",
+}
+
 deny contains msg if {
 	input.kind == "Secret"
 	name := object.get(object.get(input, "metadata", {}), "name", "<unknown>")
 	msg := sprintf("raw Kubernetes Secret %q must not be committed; use ExternalSecret, encrypted secret material, or a CI-injected secret path", [name])
+}
+
+deny contains msg if {
+	input.kind == "Namespace"
+	metadata := object.get(input, "metadata", {})
+	labels := object.get(metadata, "labels", {})
+	some key in required_pod_security_labels
+	not has_nonempty_label(labels, key)
+	name := object.get(metadata, "name", "<unknown>")
+	msg := sprintf("namespace %q must set %s", [name, key])
 }
 
 deny contains msg if {
@@ -58,6 +77,11 @@ deny contains msg if {
 
 has_nonempty_annotation(annotations, key) if {
 	value := object.get(annotations, key, "")
+	count(trim(value, " ")) > 0
+}
+
+has_nonempty_label(labels, key) if {
+	value := object.get(labels, key, "")
 	count(trim(value, " ")) > 0
 }
 


### PR DESCRIPTION
Preserves the unlanded security-audit WIP from /Users/themanofrod/.codex/worktrees/0d18/homelab by replaying it onto current main. Already-landed namespace kustomization wiring was not duplicated.\n\nValidation:\n- git diff --check\n- opa fmt --diff policy/kubernetes.rego\n- kubectl kustomize for cert-manager, deluge, external-secrets, litellm, n8n, prometheus, argocd self-management, and platform storage

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `bf072aac34999061294bff31e757e2dcec9eae1c`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

<details>
<summary>Argo CD bootstrap</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: argocd-image-updater</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      + computed_fields = [
          + "metadata.annotations",
          + "metadata.labels",
          + "spec.destination.name",
          + "spec.sources[0].path",
          + "spec.sources[1].path",
          + "spec.sources[2].path",
        ]
      ~ manifest        = {
          ~ spec       = {
              ~ destination = {
                  ~ name      = null -> ""
                    # (2 unchanged attributes hidden)
                }
              ~ sources     = [
                  ~ {
                      + path           = "."
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      + path           = "."
                        # (4 unchanged attributes hidden)
                    },
                    {
                        kustomize      = {}
                        path           = "clusters/homelab/apps/argocd-image-updater"
                        repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                        targetRevision = "main"
                    },
                ]
                # (3 unchanged attributes hidden)
            }
            # (3 unchanged attributes hidden)
        }
      ~ object          = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
              ~ sources              = [
                  ~ {
                        name           = null
                      + path           = (known after apply)
                        # (8 unchanged attributes hidden)
                    },
                  ~ {
                        name           = null
                      + path           = (known after apply)
                        # (8 unchanged attributes hidden)
                    },
                    {
                        chart          = null
                        directory      = {
                            exclude = null
                            include = null
                            jsonnet = {
                                extVars = null
                                libs    = null
                                tlas    = null
                            }
                            recurse = null
                        }
                        helm           = {
                            apiVersions             = null
                            fileParameters          = null
                            ignoreMissingValueFiles = null
                            kubeVersion             = null
                            namespace               = null
                            parameters              = null
                            passCredentials         = null
                            releaseName             = null
                            skipCrds                = null
                            skipSchemaValidation    = null
                            skipTests               = null
                            valueFiles              = null
                            values                  = null
                            valuesObject            = null
                            version                 = null
                        }
                        kustomize      = {
                            apiVersions               = null
                            commonAnnotations         = null
                            commonAnnotationsEnvsubst = null
                            commonLabels              = null
                            components                = null
                            forceCommonAnnotations    = null
                            forceCommonLabels         = null
                            ignoreMissingComponents   = null
                            images                    = null
                            kubeVersion               = null
                            labelIncludeTemplates     = null
                            labelWithoutSelector      = null
                            namePrefix                = null
                            nameSuffix                = null
                            namespace                 = null
                            patches                   = null
                            replicas                  = null
                            version                   = null
                        }
                        name           = null
                        path           = "clusters/homelab/apps/argocd-image-updater"
                        plugin         = {
                            env        = null
                            name       = null
                            parameters = null
                        }
                        ref            = null
                        repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                        targetRevision = "main"
                    },
                ]
                # (7 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Changes to Outputs:
  ~ manifest  = {
      ~ spec       = {
          ~ destination = {
              ~ name      = null -> ""
                # (2 unchanged attributes hidden)
            }
          ~ sources     = [
              ~ {
                  + path           = "."
                    # (4 unchanged attributes hidden)
                },
              ~ {
                  + path           = "."
                    # (4 unchanged attributes hidden)
                },
                {
                    kustomize      = {}
                    path           = "clusters/homelab/apps/argocd-image-updater"
                    repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                    targetRevision = "main"
                },
            ]
            # (3 unchanged attributes hidden)
        }
        # (3 unchanged attributes hidden)
    }
~~~~

</details>

<details>
<summary>Argo CD Application: cert-manager</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      + computed_fields = [
          + "metadata.annotations",
          + "metadata.labels",
          + "spec.destination.name",
          + "spec.sources[0].path",
          + "spec.sources[1].path",
          + "spec.sources[2].path",
        ]
      ~ manifest        = {
          ~ spec       = {
              ~ destination = {
                  ~ name      = null -> ""
                    # (2 unchanged attributes hidden)
                }
              ~ sources     = [
                  ~ {
                      + path           = "."
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      + path           = "."
                        # (4 unchanged attributes hidden)
                    },
                    {
                        kustomize      = {}
                        path           = "clusters/homelab/apps/cert-manager"
                        repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                        targetRevision = "main"
                    },
                ]
                # (2 unchanged attributes hidden)
            }
            # (3 unchanged attributes hidden)
        }
      ~ object          = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
              ~ sources              = [
                  ~ {
                        name           = null
                      + path           = (known after apply)
                        # (8 unchanged attributes hidden)
                    },
                  ~ {
                        name           = null
                      + path           = (known after apply)
                        # (8 unchanged attributes hidden)
                    },
                    {
                        chart          = null
                        directory      = {
                            exclude = null
                            include = null
                            jsonnet = {
                                extVars = null
                                libs    = null
                                tlas    = null
                            }
                            recurse = null
                        }
                        helm           = {
                            apiVersions             = null
                            fileParameters          = null
                            ignoreMissingValueFiles = null
                            kubeVersion             = null
                            namespace               = null
                            parameters              = null
                            passCredentials         = null
                            releaseName             = null
                            skipCrds                = null
                            skipSchemaValidation    = null
                            skipTests               = null
                            valueFiles              = null
                            values                  = null
                            valuesObject            = null
                            version                 = null
                        }
                        kustomize      = {
                            apiVersions               = null
                            commonAnnotations         = null
                            commonAnnotationsEnvsubst = null
                            commonLabels              = null
                            components                = null
                            forceCommonAnnotations    = null
                            forceCommonLabels         = null
                            ignoreMissingComponents   = null
                            images                    = null
                            kubeVersion               = null
                            labelIncludeTemplates     = null
                            labelWithoutSelector      = null
                            namePrefix                = null
                            nameSuffix                = null
                            namespace                 = null
                            patches                   = null
                            replicas                  = null
                            version                   = null
                        }
                        name           = null
                        path           = "clusters/homelab/apps/cert-manager"
                        plugin         = {
                            env        = null
                            name       = null
                            parameters = null
                        }
                        ref            = null
                        repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                        targetRevision = "main"
                    },
                ]
                # (7 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Changes to Outputs:
  ~ manifest  = {
      ~ spec       = {
          ~ destination = {
              ~ name      = null -> ""
                # (2 unchanged attributes hidden)
            }
          ~ sources     = [
              ~ {
                  + path           = "."
                    # (4 unchanged attributes hidden)
                },
              ~ {
                  + path           = "."
                    # (4 unchanged attributes hidden)
                },
                {
                    kustomize      = {}
                    path           = "clusters/homelab/apps/cert-manager"
                    repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                    targetRevision = "main"
                },
            ]
            # (2 unchanged attributes hidden)
        }
        # (3 unchanged attributes hidden)
    }
~~~~

</details>

<details>
<summary>Argo CD Application: deluge</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      + computed_fields = [
          + "metadata.annotations",
          + "metadata.labels",
          + "spec.destination.name",
          + "spec.sources[0].path",
          + "spec.sources[1].path",
          + "spec.sources[2].path",
        ]
      ~ manifest        = {
          ~ spec       = {
              ~ destination = {
                  ~ name      = null -> ""
                    # (2 unchanged attributes hidden)
                }
              ~ sources     = [
                  ~ {
                      + path           = "."
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      + path           = "."
                        # (4 unchanged attributes hidden)
                    },
                    {
                        kustomize      = {}
                        path           = "clusters/homelab/apps/deluge"
                        repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                        targetRevision = "main"
                    },
                ]
                # (3 unchanged attributes hidden)
            }
            # (3 unchanged attributes hidden)
        }
      ~ object          = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
              ~ sources              = [
                  ~ {
                        name           = null
                      + path           = (known after apply)
                        # (8 unchanged attributes hidden)
                    },
                  ~ {
                        name           = null
                      + path           = (known after apply)
                        # (8 unchanged attributes hidden)
                    },
                    {
                        chart          = null
                        directory      = {
                            exclude = null
                            include = null
                            jsonnet = {
                                extVars = null
                                libs    = null
                                tlas    = null
                            }
                            recurse = null
                        }
                        helm           = {
                            apiVersions             = null
                            fileParameters          = null
                            ignoreMissingValueFiles = null
                            kubeVersion             = null
                            namespace               = null
                            parameters              = null
                            passCredentials         = null
                            releaseName             = null
                            skipCrds                = null
                            skipSchemaValidation    = null
                            skipTests               = null
                            valueFiles              = null
                            values                  = null
                            valuesObject            = null
                            version                 = null
                        }
                        kustomize      = {
                            apiVersions               = null
                            commonAnnotations         = null
                            commonAnnotationsEnvsubst = null
                            commonLabels              = null
                            components                = null
                            forceCommonAnnotations    = null
                            forceCommonLabels         = null
                            ignoreMissingComponents   = null
                            images                    = null
                            kubeVersion               = null
                            labelIncludeTemplates     = null
                            labelWithoutSelector      = null
                            namePrefix                = null
                            nameSuffix                = null
                            namespace                 = null
                            patches                   = null
                            replicas                  = null
                            version                   = null
                        }
                        name           = null
                        path           = "clusters/homelab/apps/deluge"
                        plugin         = {
                            env        = null
                            name       = null
                            parameters = null
                        }
                        ref            = null
                        repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                        targetRevision = "main"
                    },
                ]
                # (7 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Changes to Outputs:
  ~ manifest  = {
      ~ spec       = {
          ~ destination = {
              ~ name      = null -> ""
                # (2 unchanged attributes hidden)
            }
          ~ sources     = [
              ~ {
                  + path           = "."
                    # (4 unchanged attributes hidden)
                },
              ~ {
                  + path           = "."
                    # (4 unchanged attributes hidden)
                },
                {
                    kustomize      = {}
                    path           = "clusters/homelab/apps/deluge"
                    repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                    targetRevision = "main"
                },
            ]
            # (3 unchanged attributes hidden)
        }
        # (3 unchanged attributes hidden)
    }
~~~~

</details>

<details>
<summary>Argo CD Application: descheduler</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      + computed_fields = [
          + "metadata.annotations",
          + "metadata.labels",
          + "spec.destination.name",
          + "spec.sources[0].path",
          + "spec.sources[1].path",
          + "spec.sources[2].path",
        ]
      ~ manifest        = {
          ~ spec       = {
              ~ destination = {
                  ~ name      = null -> ""
                    # (2 unchanged attributes hidden)
                }
              ~ sources     = [
                  ~ {
                      + path           = "."
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      + path           = "."
                        # (4 unchanged attributes hidden)
                    },
                    {
                        kustomize      = {}
                        path           = "clusters/homelab/apps/descheduler"
                        repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                        targetRevision = "main"
                    },
                ]
                # (2 unchanged attributes hidden)
            }
            # (3 unchanged attributes hidden)
        }
      ~ object          = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
              ~ sources              = [
                  ~ {
                        name           = null
                      + path           = (known after apply)
                        # (8 unchanged attributes hidden)
                    },
                  ~ {
                        name           = null
                      + path           = (known after apply)
                        # (8 unchanged attributes hidden)
                    },
                    {
                        chart          = null
                        directory      = {
                            exclude = null
                            include = null
                            jsonnet = {
                                extVars = null
                                libs    = null
                                tlas    = null
                            }
                            recurse = null
                        }
                        helm           = {
                            apiVersions             = null
                            fileParameters          = null
                            ignoreMissingValueFiles = null
                            kubeVersion             = null
                            namespace               = null
                            parameters              = null
                            passCredentials         = null
                            releaseName             = null
                            skipCrds                = null
                            skipSchemaValidation    = null
                            skipTests               = null
                            valueFiles              = null
                            values                  = null
                            valuesObject            = null
                            version                 = null
                        }
                        kustomize      = {
                            apiVersions               = null
                            commonAnnotations         = null
                            commonAnnotationsEnvsubst = null
                            commonLabels              = null
                            components                = null
                            forceCommonAnnotations    = null
                            forceCommonLabels         = null
                            ignoreMissingComponents   = null
                            images                    = null
                            kubeVersion               = null
                            labelIncludeTemplates     = null
                            labelWithoutSelector      = null
                            namePrefix                = null
                            nameSuffix                = null
                            namespace                 = null
                            patches                   = null
                            replicas                  = null
                            version                   = null
                        }
                        name           = null
                        path           = "clusters/homelab/apps/descheduler"
                        plugin         = {
                            env        = null
                            name       = null
                            parameters = null
                        }
                        ref            = null
                        repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                        targetRevision = "main"
                    },
                ]
                # (7 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Changes to Outputs:
  ~ manifest  = {
      ~ spec       = {
          ~ destination = {
              ~ name      = null -> ""
                # (2 unchanged attributes hidden)
            }
          ~ sources     = [
              ~ {
                  + path           = "."
                    # (4 unchanged attributes hidden)
                },
              ~ {
                  + path           = "."
                    # (4 unchanged attributes hidden)
                },
                {
                    kustomize      = {}
                    path           = "clusters/homelab/apps/descheduler"
                    repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                    targetRevision = "main"
                },
            ]
            # (2 unchanged attributes hidden)
        }
        # (3 unchanged attributes hidden)
    }
~~~~

</details>

<details>
<summary>Argo CD Application: external-secrets</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      + computed_fields = [
          + "metadata.annotations",
          + "metadata.labels",
          + "spec.destination.name",
          + "spec.sources[0].path",
          + "spec.sources[1].path",
          + "spec.sources[2].path",
        ]
      ~ manifest        = {
          ~ spec       = {
              ~ destination = {
                  ~ name      = null -> ""
                    # (2 unchanged attributes hidden)
                }
              ~ sources     = [
                  ~ {
                      + path           = "."
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      + path           = "."
                        # (4 unchanged attributes hidden)
                    },
                    {
                        kustomize      = {}
                        path           = "clusters/homelab/apps/external-secrets"
                        repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                        targetRevision = "main"
                    },
                ]
                # (3 unchanged attributes hidden)
            }
            # (3 unchanged attributes hidden)
        }
      ~ object          = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
              ~ sources              = [
                  ~ {
                        name           = null
                      + path           = (known after apply)
                        # (8 unchanged attributes hidden)
                    },
                  ~ {
                        name           = null
                      + path           = (known after apply)
                        # (8 unchanged attributes hidden)
                    },
                    {
                        chart          = null
                        directory      = {
                            exclude = null
                            include = null
                            jsonnet = {
                                extVars = null
                                libs    = null
                                tlas    = null
                            }
                            recurse = null
                        }
                        helm           = {
                            apiVersions             = null
                            fileParameters          = null
                            ignoreMissingValueFiles = null
                            kubeVersion             = null
                            namespace               = null
                            parameters              = null
                            passCredentials         = null
                            releaseName             = null
                            skipCrds                = null
                            skipSchemaValidation    = null
                            skipTests               = null
                            valueFiles              = null
                            values                  = null
                            valuesObject            = null
                            version                 = null
                        }
                        kustomize      = {
                            apiVersions               = null
                            commonAnnotations         = null
                            commonAnnotationsEnvsubst = null
                            commonLabels              = null
                            components                = null
                            forceCommonAnnotations    = null
                            forceCommonLabels         = null
                            ignoreMissingComponents   = null
                            images                    = null
                            kubeVersion               = null
                            labelIncludeTemplates     = null
                            labelWithoutSelector      = null
                            namePrefix                = null
                            nameSuffix                = null
                            namespace                 = null
                            patches                   = null
                            replicas                  = null
                            version                   = null
                        }
                        name           = null
                        path           = "clusters/homelab/apps/external-secrets"
                        plugin         = {
                            env        = null
                            name       = null
                            parameters = null
                        }
                        ref            = null
                        repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                        targetRevision = "main"
                    },
                ]
                # (7 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Changes to Outputs:
  ~ manifest  = {
      ~ spec       = {
          ~ destination = {
              ~ name      = null -> ""
                # (2 unchanged attributes hidden)
            }
          ~ sources     = [
              ~ {
                  + path           = "."
                    # (4 unchanged attributes hidden)
                },
              ~ {
                  + path           = "."
                    # (4 unchanged attributes hidden)
                },
                {
                    kustomize      = {}
                    path           = "clusters/homelab/apps/external-secrets"
                    repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                    targetRevision = "main"
                },
            ]
            # (3 unchanged attributes hidden)
        }
        # (3 unchanged attributes hidden)
    }
~~~~

</details>

<details>
<summary>Argo CD Application: grafana</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      + computed_fields = [
          + "metadata.annotations",
          + "metadata.labels",
          + "spec.destination.name",
          + "spec.sources[0].path",
          + "spec.sources[1].path",
          + "spec.sources[2].path",
        ]
      ~ manifest        = {
          ~ spec       = {
              ~ destination = {
                  ~ name      = null -> ""
                    # (2 unchanged attributes hidden)
                }
              ~ sources     = [
                  ~ {
                      + path           = "."
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      + path           = "."
                        # (4 unchanged attributes hidden)
                    },
                    {
                        kustomize      = {}
                        path           = "clusters/homelab/apps/grafana"
                        repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                        targetRevision = "main"
                    },
                ]
                # (3 unchanged attributes hidden)
            }
            # (3 unchanged attributes hidden)
        }
      ~ object          = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
              ~ sources              = [
                  ~ {
                        name           = null
                      + path           = (known after apply)
                        # (8 unchanged attributes hidden)
                    },
                  ~ {
                        name           = null
                      + path           = (known after apply)
                        # (8 unchanged attributes hidden)
                    },
                    {
                        chart          = null
                        directory      = {
                            exclude = null
                            include = null
                            jsonnet = {
                                extVars = null
                                libs    = null
                                tlas    = null
                            }
                            recurse = null
                        }
                        helm           = {
                            apiVersions             = null
                            fileParameters          = null
                            ignoreMissingValueFiles = null
                            kubeVersion             = null
                            namespace               = null
                            parameters              = null
                            passCredentials         = null
                            releaseName             = null
                            skipCrds                = null
                            skipSchemaValidation    = null
                            skipTests               = null
                            valueFiles              = null
                            values                  = null
                            valuesObject            = null
                            version                 = null
                        }
                        kustomize      = {
                            apiVersions               = null
                            commonAnnotations         = null
                            commonAnnotationsEnvsubst = null
                            commonLabels              = null
                            components                = null
                            forceCommonAnnotations    = null
                            forceCommonLabels         = null
                            ignoreMissingComponents   = null
                            images                    = null
                            kubeVersion               = null
                            labelIncludeTemplates     = null
                            labelWithoutSelector      = null
                            namePrefix                = null
                            nameSuffix                = null
                            namespace                 = null
                            patches                   = null
                            replicas                  = null
                            version                   = null
                        }
                        name           = null
                        path           = "clusters/homelab/apps/grafana"
                        plugin         = {
                            env        = null
                            name       = null
                            parameters = null
                        }
                        ref            = null
                        repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                        targetRevision = "main"
                    },
                ]
                # (7 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Changes to Outputs:
  ~ manifest  = {
      ~ spec       = {
          ~ destination = {
              ~ name      = null -> ""
                # (2 unchanged attributes hidden)
            }
          ~ sources     = [
              ~ {
                  + path           = "."
                    # (4 unchanged attributes hidden)
                },
              ~ {
                  + path           = "."
                    # (4 unchanged attributes hidden)
                },
                {
                    kustomize      = {}
                    path           = "clusters/homelab/apps/grafana"
                    repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                    targetRevision = "main"
                },
            ]
            # (3 unchanged attributes hidden)
        }
        # (3 unchanged attributes hidden)
    }
~~~~

</details>

<details>
<summary>Argo CD Application: hummingbot</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      + computed_fields = [
          + "metadata.annotations",
          + "metadata.labels",
          + "spec.destination.name",
          + "spec.sources[0].path",
        ]
      ~ manifest        = {
          ~ spec       = {
              ~ destination = {
                  ~ name      = null -> ""
                    # (2 unchanged attributes hidden)
                }
                # (4 unchanged attributes hidden)
            }
            # (3 unchanged attributes hidden)
        }
      ~ object          = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
                # (8 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Changes to Outputs:
  ~ manifest  = {
      ~ spec       = {
          ~ destination = {
              ~ name      = null -> ""
                # (2 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }
        # (3 unchanged attributes hidden)
    }
~~~~

</details>

<details>
<summary>Argo CD Application: istio</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      + computed_fields = [
          + "metadata.annotations",
          + "metadata.labels",
          + "spec.destination.name",
          + "spec.sources[0].path",
          + "spec.sources[1].path",
          + "spec.sources[2].path",
          + "spec.sources[3].path",
          + "spec.sources[4].path",
          + "spec.sources[5].path",
          + "spec.sources[6].path",
        ]
      ~ manifest        = {
          ~ spec       = {
              ~ destination       = {
                  ~ name      = null -> ""
                    # (2 unchanged attributes hidden)
                }
              ~ sources           = [
                  ~ {
                      + path           = "."
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      + path           = "."
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      + path           = "."
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      + path           = "."
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      + path           = "."
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      + path           = "."
                        # (4 unchanged attributes hidden)
                    },
                    {
                        kustomize      = {}
                        path           = "clusters/homelab/apps/istio"
                        repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                        targetRevision = "main"
                    },
                ]
                # (4 unchanged attributes hidden)
            }
            # (3 unchanged attributes hidden)
        }
      ~ object          = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
              ~ sources              = [
                  ~ {
                        name           = null
                      + path           = (known after apply)
                        # (8 unchanged attributes hidden)
                    },
                  ~ {
                        name           = null
                      + path           = (known after apply)
                        # (8 unchanged attributes hidden)
                    },
                  ~ {
                        name           = null
                      + path           = (known after apply)
                        # (8 unchanged attributes hidden)
                    },
                  ~ {
                        name           = null
                      + path           = (known after apply)
                        # (8 unchanged attributes hidden)
                    },
                  ~ {
                        name           = null
                      + path           = (known after apply)
                        # (8 unchanged attributes hidden)
                    },
                  ~ {
                        name           = null
                      + path           = (known after apply)
                        # (8 unchanged attributes hidden)
                    },
                    {
                        chart          = null
                        directory      = {
                            exclude = null
                            include = null
                            jsonnet = {
                                extVars = null
                                libs    = null
                                tlas    = null
                            }
                            recurse = null
                        }
                        helm           = {
                            apiVersions             = null
                            fileParameters          = null
                            ignoreMissingValueFiles = null
                            kubeVersion             = null
                            namespace               = null
                            parameters              = null
                            passCredentials         = null
                            releaseName             = null
                            skipCrds                = null
                            skipSchemaValidation    = null
                            skipTests               = null
                            valueFiles              = null
                            values                  = null
                            valuesObject            = null
                            version                 = null
                        }
                        kustomize      = {
                            apiVersions               = null
                            commonAnnotations         = null
                            commonAnnotationsEnvsubst = null
                            commonLabels              = null
                            components                = null
                            forceCommonAnnotations    = null
                            forceCommonLabels         = null
                            ignoreMissingComponents   = null
                            images                    = null
                            kubeVersion               = null
                            labelIncludeTemplates     = null
                            labelWithoutSelector      = null
                            namePrefix                = null
                            nameSuffix                = null
                            namespace                 = null
                            patches                   = null
                            replicas                  = null
                            version                   = null
                        }
                        name           = null
                        path           = "clusters/homelab/apps/istio"
                        plugin         = {
                            env        = null
                            name       = null
                            parameters = null
                        }
                        ref            = null
                        repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                        targetRevision = "main"
                    },
                ]
                # (7 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Changes to Outputs:
  ~ manifest  = {
      ~ spec       = {
          ~ destination       = {
              ~ name      = null -> ""
                # (2 unchanged attributes hidden)
            }
          ~ sources           = [
              ~ {
                  + path           = "."
                    # (4 unchanged attributes hidden)
                },
              ~ {
                  + path           = "."
                    # (4 unchanged attributes hidden)
                },
              ~ {
                  + path           = "."
                    # (4 unchanged attributes hidden)
                },
              ~ {
                  + path           = "."
                    # (4 unchanged attributes hidden)
                },
              ~ {
                  + path           = "."
                    # (4 unchanged attributes hidden)
                },
              ~ {
                  + path           = "."
                    # (4 unchanged attributes hidden)
                },
                {
                    kustomize      = {}
                    path           = "clusters/homelab/apps/istio"
                    repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                    targetRevision = "main"
                },
            ]
            # (4 unchanged attributes hidden)
        }
        # (3 unchanged attributes hidden)
    }
~~~~

</details>

<details>
<summary>Argo CD Application: litellm</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      + computed_fields = [
          + "metadata.annotations",
          + "metadata.labels",
          + "spec.destination.name",
          + "spec.sources[0].path",
          + "spec.sources[1].path",
          + "spec.sources[2].path",
        ]
      ~ manifest        = {
          ~ spec       = {
              ~ destination = {
                  ~ name      = null -> ""
                    # (2 unchanged attributes hidden)
                }
              ~ sources     = [
                  ~ {
                      + path           = "."
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      + path           = "."
                        # (4 unchanged attributes hidden)
                    },
                    {
                        kustomize      = {}
                        path           = "clusters/homelab/apps/litellm"
                        repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                        targetRevision = "main"
                    },
                ]
                # (3 unchanged attributes hidden)
            }
            # (3 unchanged attributes hidden)
        }
      ~ object          = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
              ~ sources              = [
                  ~ {
                        name           = null
                      + path           = (known after apply)
                        # (8 unchanged attributes hidden)
                    },
                  ~ {
                        name           = null
                      + path           = (known after apply)
                        # (8 unchanged attributes hidden)
                    },
                    {
                        chart          = null
                        directory      = {
                            exclude = null
                            include = null
                            jsonnet = {
                                extVars = null
                                libs    = null
                                tlas    = null
                            }
                            recurse = null
                        }
                        helm           = {
                            apiVersions             = null
                            fileParameters          = null
                            ignoreMissingValueFiles = null
                            kubeVersion             = null
                            namespace               = null
                            parameters              = null
                            passCredentials         = null
                            releaseName             = null
                            skipCrds                = null
                            skipSchemaValidation    = null
                            skipTests               = null
                            valueFiles              = null
                            values                  = null
                            valuesObject            = null
                            version                 = null
                        }
                        kustomize      = {
                            apiVersions               = null
                            commonAnnotations         = null
                            commonAnnotationsEnvsubst = null
                            commonLabels              = null
                            components                = null
                            forceCommonAnnotations    = null
                            forceCommonLabels         = null
                            ignoreMissingComponents   = null
                            images                    = null
                            kubeVersion               = null
                            labelIncludeTemplates     = null
                            labelWithoutSelector      = null
                            namePrefix                = null
                            nameSuffix                = null
                            namespace                 = null
                            patches                   = null
                            replicas                  = null
                            version                   = null
                        }
                        name           = null
                        path           = "clusters/homelab/apps/litellm"
                        plugin         = {
                            env        = null
                            name       = null
                            parameters = null
                        }
                        ref            = null
                        repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                        targetRevision = "main"
                    },
                ]
                # (7 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Changes to Outputs:
  ~ manifest  = {
      ~ spec       = {
          ~ destination = {
              ~ name      = null -> ""
  

> Plan output was truncated to keep the pull request description within GitHub limits. Re-run `nix develop --command bash scripts/ci/terragrunt-plan.sh` locally for the full saved plan output.

<!-- terragrunt-plan:end -->
