### PR TITLE
fix: refresh image updater credentials on change

### DIFF
--- a/clusters/homelab/apps/argocd-image-updater/README.md
+++ b/clusters/homelab/apps/argocd-image-updater/README.md
@@ -11,6 +11,11 @@ declares directly in workload Helm values or raw manifests. It writes updates
 back to GitHub pull requests with the `argocd-image-updater-git` Secret instead
 of storing live-only Argo CD parameter overrides.
 
+`argocd-image-updater-git` uses `refreshPolicy: OnChange`. After replacing the
+GitHub App credential values in AWS SSM, bump
+`homelab.rst.io/github-app-credentials-ssm-version` on the ExternalSecret so
+External Secrets refreshes the in-cluster Secret without hand-editing it.
+
 Add a new workload image to `imageupdater.yaml` in the same PR that introduces
 the image, or keep the image pinned as `tag@sha256:digest` until it has an
 explicit Image Updater write-back target.

--- a/clusters/homelab/apps/argocd-image-updater/externalsecret.yaml
+++ b/clusters/homelab/apps/argocd-image-updater/externalsecret.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: argocd
   annotations:
     argocd.argoproj.io/sync-wave: "0"
+    homelab.rst.io/github-app-credentials-ssm-version: "2"
 spec:
   refreshPolicy: OnChange
   secretStoreRef:

--- a/docs/argocd-image-updater.md
+++ b/docs/argocd-image-updater.md
@@ -32,6 +32,10 @@ the normal review, CI, and Argo CD reconciliation path still applies.
 The write-back credential is the Kubernetes Secret
 `argocd/argocd-image-updater-git`, created by the ExternalSecret at
 `clusters/homelab/apps/argocd-image-updater/externalsecret.yaml`.
+The ExternalSecret uses `refreshPolicy: OnChange`. After replacing GitHub App
+values in SSM, bump the
+`homelab.rst.io/github-app-credentials-ssm-version` annotation so External
+Secrets reconciles the in-cluster Secret without direct edits.
 
 Required AWS SSM Parameter Store values:
 

--- a/docs/knowledge-base/architecture/secrets-and-identity.md
+++ b/docs/knowledge-base/architecture/secrets-and-identity.md
@@ -29,7 +29,9 @@ outside git.
 
 - Argo CD Image Updater uses the `argocd-image-updater-git` ExternalSecret for
   GitHub App credentials that open image update pull requests through Git
-  write-back. Its SSM contract is summarized in
+  write-back. It refreshes on ExternalSecret changes; bump the non-secret
+  `homelab.rst.io/github-app-credentials-ssm-version` annotation after SSM
+  credential replacement. Its SSM contract is summarized in
   [[runbooks/image-automation]] and [[runbooks/secrets-aws-ssm]].
 - Grafana Microsoft Entra SSO is managed through
   `IaC/live/azuread-applications/grafana`.

--- a/docs/knowledge-base/operations/change-log.md
+++ b/docs/knowledge-base/operations/change-log.md
@@ -38,6 +38,12 @@ Use [[templates/knowledge-update]] for new entries.
   and the local `TERRAGRUNT_PLAN_MARKDOWN` output path for reviewing rendered
   plans.
 
+### 2026-05-25 - Refresh Image Updater GitHub App credentials
+
+- Kept `argocd-image-updater-git` on `refreshPolicy: OnChange` and bumped the
+  non-secret GitHub App SSM version marker to `2` so External Secrets refreshes
+  the in-cluster write-back Secret from updated AWS SSM values.
+
 ### 2026-05-25 - Enable Image Updater pull requests
 
 - Replaced the annotation opt-in ImageUpdater policy with a managed-image

--- a/docs/knowledge-base/runbooks/image-automation.md
+++ b/docs/knowledge-base/runbooks/image-automation.md
@@ -32,7 +32,9 @@ Required AWS SSM parameters:
 - `/homelab/argocd-image-updater/github-app/private-key`
 
 The GitHub App needs repository contents write access and pull-request write
-access for `Stuhlmuller/homelab`.
+access for `Stuhlmuller/homelab`. The ExternalSecret uses `OnChange`; bump
+`homelab.rst.io/github-app-credentials-ssm-version` after credential
+replacement so External Secrets refreshes the Kubernetes Secret.
 
 ## Gate
 

--- a/docs/secrets-aws-ssm.md
+++ b/docs/secrets-aws-ssm.md
@@ -119,6 +119,9 @@ Argo CD Image Updater stores its GitHub App write-back credential in
 private key placeholders in SSM before relying on automated image update pull
 requests. The GitHub App needs repository contents write access and pull-request
 write access for `Stuhlmuller/homelab`; the private key must stay outside git.
+The ExternalSecret uses `refreshPolicy: OnChange`; bump
+`homelab.rst.io/github-app-credentials-ssm-version` after SSM value replacement
+so External Secrets refreshes the Kubernetes Secret.
 
 ## Microsoft Entra SSO Bootstrap
 


### PR DESCRIPTION
## Summary

This PR keeps the Argo CD Image Updater GitHub App credential ExternalSecret on `refreshPolicy: OnChange` and bumps a non-secret SSM version marker to `2` so External Secrets refreshes the in-cluster write-back Secret from the GitHub App values that were replaced in AWS SSM.

## Issue

`argocd-image-updater` was healthy at the Argo CD Application level, but its managed ImageUpdater reconciliation still failed write-back because the Kubernetes Secret continued to contain the original `REPLACE_ME` placeholder values. The SSM parameters had been updated, but the ExternalSecret was intentionally configured with `OnChange`, so direct SSM value changes did not automatically rewrite the Kubernetes Secret.

## Root Cause And Effect

The Image Updater controller reads `argocd-image-updater-git` when it needs to push image-update branches and open pull requests. With stale placeholder values in that Secret, reconciliation could discover candidate image updates but failed when attempting GitHub App authentication. Keeping the refresh declarative avoids manual Kubernetes Secret edits, but it needs a repo-owned change to trigger External Secrets.

## Fix

The ExternalSecret now carries `homelab.rst.io/github-app-credentials-ssm-version: "2"` while staying on `refreshPolicy: OnChange`. The Image Updater runbook, SSM secret contract docs, app README, and knowledge-base notes now explain that future GitHub App credential rotations should bump this marker after replacing the SSM values.

## Validation

- `kubectl kustomize clusters/homelab/apps/argocd-image-updater`
- `git diff --check`
- `kubectl --request-timeout=10s diff -k clusters/homelab/apps/argocd-image-updater`
- `terragrunt --log-disable plan -no-color` in `IaC/live/argocd-apps/argocd-image-updater`
- `terragrunt --log-disable apply -no-color plan.out` in `IaC/live/argocd-apps/argocd-image-updater`
- Commit hooks: trailing whitespace, end-of-file, large files, YAML, codespell, Checkov Diff, Checkov Secrets

Note: the focused Terragrunt apply reconciled the Argo CD Application registration. The ExternalSecret marker itself will be applied by Argo CD after this PR reaches `main`, because the Application source intentionally tracks `main`.


<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `d19d1e9bfa9dd095cbe4486eedd103bd2a0b88e1`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

<details>
<summary>Argo CD bootstrap</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: argocd-image-updater</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      ~ object   = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
                # (8 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
~~~~

</details>

<details>
<summary>Argo CD Application: cert-manager</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      ~ object   = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
                # (8 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
~~~~

</details>

<details>
<summary>Argo CD Application: deluge</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      ~ object   = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
                # (8 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
~~~~

</details>

<details>
<summary>Argo CD Application: descheduler</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      ~ object   = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
                # (8 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
~~~~

</details>

<details>
<summary>Argo CD Application: external-secrets</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      ~ object   = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
                # (8 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
~~~~

</details>

<details>
<summary>Argo CD Application: grafana</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      ~ object   = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
                # (8 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
~~~~

</details>

<details>
<summary>Argo CD Application: hummingbot</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      ~ object   = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
                # (8 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
~~~~

</details>

<details>
<summary>Argo CD Application: istio</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      ~ object   = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
                # (8 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
~~~~

</details>

<details>
<summary>Argo CD Application: litellm</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      ~ object   = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
                # (8 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
~~~~

</details>

<details>
<summary>Argo CD Application: media-postgres</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      ~ object   = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
                # (8 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
~~~~

</details>

<details>
<summary>Argo CD Application: n8n</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      ~ object   = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
                # (8 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
~~~~

</details>

<details>
<summary>Argo CD Application: openclaw</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      ~ object   = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
                # (8 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
~~~~

</details>

<details>
<summary>Argo CD Application: platform-dns</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      ~ object   = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
                # (8 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
~~~~

</details>

<details>
<summary>Argo CD Application: platform-storage</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      ~ object   = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
                # (8 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
~~~~

</details>

<details>
<summary>Argo CD Application: policy-bot</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      ~ object   = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
                # (8 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
~~~~

</details>

<details>
<summary>Argo CD Application: prometheus</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      ~ object   = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
                # (8 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
~~~~

</details>

<details>
<summary>Argo CD Application: prowlarr</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      ~ object   = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
                # (8 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
~~~~

</details>

<details>
<summary>Argo CD Application: radarr</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      ~ object   = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
                # (8 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
~~~~

</details>

<details>
<summary>Argo CD Application: sonarr</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      ~ object   = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
                # (8 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
~~~~

</details>

<details>
<summary>Argo CD Application: tailscale</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      ~ object   = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
                # (8 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
~~~~

</details>


<!-- terragrunt-plan:end -->
