### PR TITLE
feat: add Kiali mesh UI

### DIFF
--- a/IaC/live/argocd-apps/kiali/.terraform.lock.hcl
+++ b/IaC/live/argocd-apps/kiali/.terraform.lock.hcl
@@ -1,0 +1,41 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/helm" {
+  version = "3.1.1"
+  hashes = [
+    "h1:brfn5YltnzexsfqpWKw+5gS9U/m77e0An3hZQamlEZk=",
+    "zh:09b38905e234c2e0b185332819614224660050b7e4b25e9e858b593ab01adafe",
+    "zh:09fed1b19b8bcded169fb76304e06c5b1216d5ceba92948c23384f34ddbf1fac",
+    "zh:2e0af220f3fe79048d82f6de91752ba9929c215819d3de4f82ccb473bcd9e5df",
+    "zh:5fe8657cbf6aca769b9565a4fb4605d7b441c2c558d915b067c0adf6f77c58d4",
+    "zh:713943f797be3a4c6fc6bb5f1306c4f74762bfaa663f98fd8b4c49d28ee54ecf",
+    "zh:b426458c0bbad64f9000c11af7e74a24ce9e0adb3037c05dadf80c0c3e757931",
+    "zh:c0664866280a42156484a48f6c461d0ddb2d212da9b6e930c721ef577ab75270",
+    "zh:e4f9d0ebb70d63d8ac3ccee00a4d8cdb15b97aaa390f95ed65921e9d0f65bfa0",
+    "zh:f6fe7ecfafc344f4e6aecacf5ae12ac73b94389b9679dcd0f04fc5ff45bdc066",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/kubernetes" {
+  version     = "3.1.0"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:0M9Nu8YersHl84pfFTRiW5UfmoxQC3xKJ+Zkt5WjEv8=",
+    "zh:06f1310b47ff31593766b4b664a508276e57f911c9e0237c6cb197a590e2d799",
+    "zh:54aad7284e03c49996477f777c20b75ad12acbd68e80e86ecd1bd1ae6cfa5bea",
+    "zh:5ad86522ff9343ac8a2b8b595ba7280de82966dd6feb6aa87b6b9103b694bf82",
+    "zh:6506c8356b82f8c03f937efc68eee7a4ded1c77791552b530d3edf245ea97df4",
+    "zh:6dab1c6eb3cb5c1738e1ca8c2c54e3ca30ef3a83dd3453491edbe2ff525e1392",
+    "zh:754a9aef6d8456bae74bc2ab5a62c4c2146f0d79c4a817abe9d93567d1df26ef",
+    "zh:75689548a4731f2f9f9ebe5fef971f3ee1464f1a0c4505f86ee1ef07cc228a0e",
+    "zh:7e25f27dcbf73c5c83e9ee38a6e8110a8f889c902fc907e01a0820148d12604a",
+    "zh:a080838edc0ebec1b556432fb1fde310effaa5ba5f504d105abbe6762e2acf07",
+    "zh:a448d00988e100e201453b98d0098959c9b8e5dd34fbb33fe45793de0ae3d90e",
+    "zh:d4b4da8b49e86d8dec76a147e9f9f1b541fa59607236c4e62105205edff5fc14",
+    "zh:e712b9f90d9e29fa67990ef67cb9391db408414fb4c2261bc7522ecfba740fc0",
+    "zh:e8c6b874b9e8f03411f1fb38d6273bec8037a007b32d11fd75b18f8befcbde03",
+    "zh:f505fa05dee07f3d904208b9b9b8b13fd386093ae8243f2d7ce131f279310268",
+    "zh:fc3c74b661a1c86b3dd78b0f3bd9256123f6b270c3627975a6f9dc231bf7a59c",
+  ]
+}

--- a/IaC/live/argocd-apps/kiali/terragrunt.hcl
+++ b/IaC/live/argocd-apps/kiali/terragrunt.hcl
@@ -1,0 +1,95 @@
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "../../../modules/argocd-application-kubernetes"
+}
+
+dependencies {
+  paths = [
+    "../istio",
+    "../tailscale",
+    "../prometheus",
+    "../grafana"
+  ]
+}
+
+locals {
+  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
+  target_revision = "main"
+}
+
+inputs = {
+  metadata = {
+    name      = "kiali"
+    namespace = "argocd"
+    labels = {
+      "app.kubernetes.io/managed-by" = "terragrunt"
+      "app.kubernetes.io/part-of"    = "homelab"
+    }
+  }
+
+  project = "homelab"
+
+  destination = {
+    server    = "https://kubernetes.default.svc"
+    namespace = "istio-system"
+  }
+
+  sources = [
+    {
+      repo_url        = "https://kiali.org/helm-charts"
+      chart           = "kiali-operator"
+      target_revision = "2.26.0"
+      helm = {
+        release_name = "kiali-operator"
+        value_files  = ["$values/clusters/homelab/apps/kiali/values.yaml"]
+      }
+    },
+    {
+      repo_url        = local.repo_url
+      target_revision = local.target_revision
+      ref             = "values"
+      directory = {
+        include = ".argocd-values-ref-placeholder.yaml"
+      }
+    },
+    {
+      repo_url        = local.repo_url
+      target_revision = local.target_revision
+      path            = "clusters/homelab/apps/kiali"
+      kustomize       = {}
+    }
+  ]
+
+  sync_policy = {
+    automated = {
+      prune     = true
+      self_heal = true
+    }
+    sync_options = [
+      "CreateNamespace=true",
+      "ServerSideApply=true"
+    ]
+    retry = {
+      limit = "5"
+      backoff = {
+        duration     = "30s"
+        factor       = "2"
+        max_duration = "2m"
+      }
+    }
+  }
+
+  info = [
+    {
+      name  = "ingress"
+      value = "docs/networking-tailnet-ingress.md"
+    },
+    {
+      name  = "auth"
+      value = "anonymous read-only; tailnet-only"
+    }
+  ]
+}

--- a/clusters/homelab/apps/grafana/authorizationpolicy.yaml
+++ b/clusters/homelab/apps/grafana/authorizationpolicy.yaml
@@ -13,4 +13,5 @@ spec:
         - source:
             principals:
               - cluster.local/ns/istio-system/sa/istio-ingressgateway
+              - cluster.local/ns/monitoring/sa/kiali-service-account
               - cluster.local/ns/monitoring/sa/prometheus-kube-prometheus-prometheus

--- a/clusters/homelab/apps/kiali/README.md
+++ b/clusters/homelab/apps/kiali/README.md
@@ -1,0 +1,58 @@
+# Kiali
+
+Kiali is the read-only Istio mesh UI for this homelab. It is installed through
+the official `kiali-operator` Helm chart and managed by the `kiali` Argo CD
+Application registered from `IaC/live/argocd-apps/kiali`.
+
+The operator runs from the chart release namespace, while the Kiali custom
+resource deploys the Kiali server into `monitoring`. The Kiali CR sets
+`istio_namespace: istio-system` so Kiali watches the existing Istio control
+plane while using the monitoring namespace's existing observability boundary.
+
+## Access
+
+Kiali is exposed at:
+
+```text
+https://kiali.stinkyboi.com
+```
+
+The route uses the shared `istio-system/tailnet-gateway` and is annotated with
+`homelab.rst.io/public-funnel: "false"`. Do not add a public Funnel route for
+Kiali.
+
+Kiali uses `auth.strategy: anonymous` and `deployment.view_only_mode: true`.
+This keeps the UI immediately usable from the tailnet without granting write
+operations through Kiali. If this becomes a broader operator surface, replace
+anonymous access with OIDC-backed authentication in a separate change.
+
+## Dependencies
+
+Kiali depends on:
+
+- Istio for mesh resources and status.
+- Tailscale and the shared tailnet gateway for private HTTPS access.
+- Prometheus for graph and health metrics.
+- Grafana for dashboard links.
+
+The monitoring AuthorizationPolicies allow the Kiali service account to query
+Prometheus and Grafana. Kiali has no persistent storage requirement.
+
+## Validation
+
+After Argo CD syncs the application:
+
+```sh
+argocd app get kiali
+kubectl -n monitoring get kiali kiali
+kubectl -n monitoring get deploy,svc kiali
+curl -I https://kiali.stinkyboi.com
+```
+
+Expected result: the Argo CD Application is `Synced` and `Healthy`, the Kiali
+custom resource reports a successful reconciliation, the Deployment and Service
+exist in `monitoring`, and the tailnet HTTPS route returns a Kiali response.
+
+Rollback by reverting the `kiali` Application registration and this desired
+state path, then syncing Argo CD. Let the Kiali CR delete cleanly before
+removing the operator chart so the operator can remove its managed resources.

--- a/clusters/homelab/apps/kiali/kustomization.yaml
+++ b/clusters/homelab/apps/kiali/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - virtualservice.yaml

--- a/clusters/homelab/apps/kiali/values.yaml
+++ b/clusters/homelab/apps/kiali/values.yaml
@@ -1,0 +1,46 @@
+metrics:
+  enabled: true
+
+debug:
+  enabled: false
+
+onlyViewOnlyMode: true
+allowAdHocKialiNamespace: false
+allowAdHocKialiImage: false
+allowAdHocOSSMConsoleImage: false
+allowAdHocContainers: false
+allowSecurityContextOverride: false
+
+cr:
+  create: true
+  namespace: monitoring
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+  spec:
+    istio_namespace: istio-system
+    auth:
+      strategy: anonymous
+    deployment:
+      namespace: monitoring
+      cluster_wide_access: true
+      service_type: ClusterIP
+      view_only_mode: true
+      resources:
+        requests:
+          cpu: 25m
+          memory: 128Mi
+        limits:
+          memory: 512Mi
+    external_services:
+      grafana:
+        enabled: true
+        external_url: https://grafana.stinkyboi.com
+        internal_url: http://grafana.monitoring.svc.cluster.local
+      prometheus:
+        enabled: true
+        url: http://prometheus-kube-prometheus-prometheus.monitoring.svc.cluster.local:9090
+    server:
+      web_fqdn: kiali.stinkyboi.com
+      web_port: "443"
+      web_root: /
+      web_schema: https

--- a/clusters/homelab/apps/kiali/virtualservice.yaml
+++ b/clusters/homelab/apps/kiali/virtualservice.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: kiali-tailnet
+  namespace: monitoring
+  annotations:
+    homelab.rst.io/public-funnel: "false"
+spec:
+  hosts:
+    - kiali.stinkyboi.com
+  gateways:
+    - istio-system/tailnet-gateway
+  http:
+    - route:
+        - destination:
+            host: kiali.monitoring.svc.cluster.local
+            port:
+              number: 20001

--- a/clusters/homelab/apps/prometheus/authorizationpolicy.yaml
+++ b/clusters/homelab/apps/prometheus/authorizationpolicy.yaml
@@ -14,6 +14,7 @@ spec:
         - source:
             principals:
               - cluster.local/ns/monitoring/sa/grafana
+              - cluster.local/ns/monitoring/sa/kiali-service-account
               - cluster.local/ns/monitoring/sa/prometheus-kube-prometheus-prometheus
 ---
 apiVersion: security.istio.io/v1

--- a/clusters/homelab/argocd/self-management/appproject.yaml
+++ b/clusters/homelab/argocd/self-management/appproject.yaml
@@ -16,6 +16,7 @@ spec:
     - https://charts.jetstack.io
     - https://grafana.github.io/helm-charts
     - https://istio-release.storage.googleapis.com/charts
+    - https://kiali.org/helm-charts
     - https://kubernetes-sigs.github.io/descheduler
     - https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner/
     - https://pkgs.tailscale.com/helmcharts

--- a/docs/argocd-app-onboarding.md
+++ b/docs/argocd-app-onboarding.md
@@ -1,6 +1,6 @@
 # Argo CD App Onboarding
 
-This feature registers 17 requested homelab applications plus supporting
+This feature registers 18 requested homelab applications plus supporting
 Applications for shared platform dependencies. `platform-dns` owns CoreDNS
 resolver policy, `platform-storage` owns the QNAP-backed NFS provisioner and
 default StorageClass desired state, and `media-postgres` owns the shared
@@ -21,6 +21,7 @@ counted as requested workloads.
 | tailscale | requested | `tailscale` | `clusters/homelab/apps/tailscale` | `IaC/live/argocd-apps/tailscale` | Yes | external-secrets, istio |
 | prometheus | requested | `monitoring` | `clusters/homelab/apps/prometheus` | `IaC/live/argocd-apps/prometheus` | Yes | external-secrets, platform-storage |
 | grafana | requested | `monitoring` | `clusters/homelab/apps/grafana` | `IaC/live/argocd-apps/grafana` | Yes | external-secrets, cert-manager, istio, tailscale, prometheus, platform-storage |
+| kiali | requested | `monitoring` | `clusters/homelab/apps/kiali` | `IaC/live/argocd-apps/kiali` | Yes | istio, tailscale, prometheus, grafana |
 | descheduler | requested | `kube-system` | `clusters/homelab/apps/descheduler` | `IaC/live/argocd-apps/descheduler` | Yes | prometheus |
 | deluge | requested | `media` | `clusters/homelab/apps/deluge` | `IaC/live/argocd-apps/deluge` | Yes | cert-manager, istio, tailscale, platform-storage |
 | prowlarr | requested | `media` | `clusters/homelab/apps/prowlarr` | `IaC/live/argocd-apps/prowlarr` | Yes | cert-manager, istio, media-postgres, tailscale, platform-storage |

--- a/docs/knowledge-base/operations/change-log.md
+++ b/docs/knowledge-base/operations/change-log.md
@@ -64,6 +64,15 @@ Use [[templates/knowledge-update]] for new entries.
 - Updated OpenClaw operator docs and app notes so Codex OAuth remains
   PVC-backed runtime state instead of an SSM secret or committed API key.
 
+### 2026-05-26 - Add Kiali mesh UI
+
+- Added the `kiali` Argo CD Application and desired state using the official
+  Kiali operator Helm chart.
+- Exposed Kiali at `https://kiali.stinkyboi.com` through the tailnet-only Istio
+  gateway with anonymous read-only access.
+- Updated monitoring AuthorizationPolicies so Kiali can query Grafana and
+  Prometheus without opening direct Prometheus ingress.
+
 ### 2026-05-26 - Serialize trusted Terragrunt PR plans
 
 - Added a shared concurrency gate to the trusted PR `Terragrunt Plan` job so

--- a/docs/knowledge-base/runbooks/argocd-app-onboarding.md
+++ b/docs/knowledge-base/runbooks/argocd-app-onboarding.md
@@ -15,9 +15,10 @@ registration and sources the repository-local
 under `clusters/homelab/apps/<app>` or `clusters/homelab/platform/<service>`.
 
 The current app onboarding runbook includes the requested apps plus support
-Applications. OctoBot is the current finance namespace app; Hummingbot remains
-as a retired PVC-only Application for rollback data, and Freqtrade is
-historical unless a future change reintroduces it.
+Applications. Kiali is the read-only Istio mesh UI, and OctoBot is the current
+finance namespace app. Hummingbot remains as a retired PVC-only Application for
+rollback data, and Freqtrade is historical unless a future change reintroduces
+it.
 
 ## Support Applications
 

--- a/docs/knowledge-base/runbooks/rollback.md
+++ b/docs/knowledge-base/runbooks/rollback.md
@@ -21,15 +21,16 @@ handling is clear.
 8. media-postgres
 9. LiteLLM
 10. Deluge
-11. Grafana
-12. Descheduler
-13. Prometheus
-14. platform-storage
-15. Tailscale
-16. Istio
-17. cert-manager
-18. external-secrets
-19. platform-dns
+11. Kiali
+12. Grafana
+13. Descheduler
+14. Prometheus
+15. platform-storage
+16. Tailscale
+17. Istio
+18. cert-manager
+19. external-secrets
+20. platform-dns
 
 ## Persistent Data
 
@@ -43,6 +44,9 @@ PVC unless intentionally rebuilding from backups.
 
 Policy Bot is stateless. Roll back its public exposure by removing
 `policy-bot-hook-funnel` first.
+
+Kiali is stateless. Remove the Kiali CR before removing the operator chart so
+the operator can clean up its managed server resources.
 
 ## Break-Glass
 

--- a/docs/knowledge-base/runbooks/tailnet-ingress.md
+++ b/docs/knowledge-base/runbooks/tailnet-ingress.md
@@ -15,11 +15,12 @@ address from tailnet clients. DNS is not managed by this repo yet.
 
 ## Current Route Rules
 
-- Argo CD, Grafana, Deluge, Prowlarr, Radarr, Sonarr, LiteLLM, OpenClaw, n8n,
-  Policy Bot UI, and OctoBot UI are tailnet-only.
+- Argo CD, Grafana, Kiali, Deluge, Prowlarr, Radarr, Sonarr, LiteLLM,
+  OpenClaw, n8n, Policy Bot UI, and OctoBot UI are tailnet-only.
 - Policy Bot GitHub webhook is the reviewed public Funnel exception:
   `https://policy-bot-hook.<tailnet-name>.ts.net/api/github/hook`.
-- Prometheus is intentionally not exposed; Grafana is the metrics UI.
+- Prometheus is intentionally not exposed; Grafana is the metrics UI and Kiali
+  is the read-only mesh UI.
 - OctoBot exposes only `https://octobot.stinkyboi.com` through the tailnet
   gateway. Its exchange credentials and strategy state live on PVC-backed
   runtime configuration, not in public repository files.

--- a/docs/knowledge-base/runbooks/validation.md
+++ b/docs/knowledge-base/runbooks/validation.md
@@ -19,7 +19,7 @@ cd IaC/live/argocd-apps
 terragrunt run --all plan -no-color
 ```
 
-Expected app-registration plan currently references 17 requested Argo CD
+Expected app-registration plan currently references 18 requested Argo CD
 Applications plus `platform-dns`, `platform-storage`, and `media-postgres`.
 
 ## Render And Diff
@@ -49,7 +49,8 @@ placeholders.
 
 Upstream apps must be registered, synced, and healthy before dependent apps are
 considered available. Check `external-secrets`, `cert-manager`, `istio`,
-`tailscale`, `argocd-image-updater`, `platform-dns`, and `platform-storage`.
+`tailscale`, `argocd-image-updater`, `kiali`, `platform-dns`, and
+`platform-storage`.
 
 Policy Bot has extra route checks: the tailnet UI should redirect to auth, the
 public webhook should return `400` for an unsigned empty request, and the

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -56,6 +56,14 @@ Grafana is the reviewed metrics UI. It uses Microsoft Entra SSO from
 datasources, Homelab and Argo CD dashboards, and Grafana-managed alerts from
 repo-owned values. Discord webhook URL comes from SSM through External Secrets.
 
+## Kiali
+
+Kiali is the reviewed read-only Istio mesh UI at
+`https://kiali.stinkyboi.com`. The `kiali` Argo CD Application installs the
+official Kiali operator chart and creates a Kiali CR in `monitoring` with
+anonymous access plus `view_only_mode: true`. Monitoring AuthorizationPolicies
+allow `kiali-service-account` to query Grafana and Prometheus.
+
 ## OctoBot
 
 OctoBot is the finance namespace trading bot with a real web UI. It runs from

--- a/docs/knowledge-base/workloads/inventory.md
+++ b/docs/knowledge-base/workloads/inventory.md
@@ -32,6 +32,7 @@ trading workload.
 | `tailscale` | `tailscale` | `clusters/homelab/apps/tailscale` | `IaC/live/argocd-apps/tailscale` | controller state only | external-secrets, istio |
 | `prometheus` | `monitoring` | `clusters/homelab/apps/prometheus` | `IaC/live/argocd-apps/prometheus` | persistent metrics and Argo CD scrape config | external-secrets, platform-storage |
 | `grafana` | `monitoring` | `clusters/homelab/apps/grafana` | `IaC/live/argocd-apps/grafana` | persistent config, dashboards, alert rules, and Discord alerting webhook secret | external-secrets, cert-manager, istio, tailscale, prometheus, platform-storage |
+| `kiali` | `monitoring` | `clusters/homelab/apps/kiali` | `IaC/live/argocd-apps/kiali` | controller state only; read-only mesh UI | istio, tailscale, prometheus, grafana |
 | `descheduler` | `kube-system` | `clusters/homelab/apps/descheduler` | `IaC/live/argocd-apps/descheduler` | controller state only | prometheus |
 | `deluge` | `media` | `clusters/homelab/apps/deluge` | `IaC/live/argocd-apps/deluge` | persistent config on `nfs-default`; shared downloads on QNAP `/media` | cert-manager, istio, tailscale, platform-storage |
 | `prowlarr` | `media` | `clusters/homelab/apps/prowlarr` | `IaC/live/argocd-apps/prowlarr` | persistent config and PostgreSQL databases | cert-manager, istio, media-postgres, tailscale, platform-storage |

--- a/docs/networking-tailnet-ingress.md
+++ b/docs/networking-tailnet-ingress.md
@@ -22,6 +22,7 @@ that must be added through a separate Terragrunt/OpenTofu entry point.
 |-----|------------------|---------------|
 | argocd | `https://argocd.stinkyboi.com` | disabled |
 | grafana | `https://grafana.stinkyboi.com` | disabled |
+| kiali | `https://kiali.stinkyboi.com` | disabled |
 | deluge | `https://deluge.stinkyboi.com` | disabled |
 | prowlarr | `https://prowlarr.stinkyboi.com` | disabled |
 | radarr | `https://radarr.stinkyboi.com` | disabled |
@@ -51,8 +52,9 @@ Every other Istio gateway and VirtualService route manifest remains
 tailnet-only.
 
 Prometheus is intentionally absent from the tailnet route inventory. Grafana is
-the reviewed metrics UI, and direct Prometheus ingress must not be restored
-without a documented authentication plan and rollback path.
+the reviewed metrics UI, and Kiali is the reviewed read-only mesh UI. Direct
+Prometheus ingress must not be restored without a documented authentication plan
+and rollback path.
 
 OctoBot exposes its UI only through the tailnet Istio route at
 `https://octobot.stinkyboi.com`. The route is intended for private setup,

--- a/docs/rollback-argocd-apps.md
+++ b/docs/rollback-argocd-apps.md
@@ -17,15 +17,16 @@ handling is clear.
 8. media-postgres
 9. LiteLLM
 10. Deluge
-11. Grafana
-12. Descheduler
-13. Prometheus
-14. platform-storage
-15. Tailscale
-16. Istio
-17. cert-manager
-18. external-secrets
-19. platform-dns
+11. Kiali
+12. Grafana
+13. Descheduler
+14. Prometheus
+15. platform-storage
+16. Tailscale
+17. Istio
+18. cert-manager
+19. external-secrets
+20. platform-dns
 
 ## Persistent Data
 
@@ -40,6 +41,9 @@ the PostgreSQL PVC unless intentionally rebuilding the media apps from backups.
 Policy Bot is stateless. Roll back its public exposure by removing the
 `policy-bot-hook-funnel` Ingress first, then roll back the Deployment and
 ExternalSecret if the GitHub App should stop evaluating pull requests.
+
+Kiali is stateless. Remove the Kiali custom resource before removing the
+operator chart so the operator can clean up its managed server resources.
 
 ## Break-Glass
 

--- a/docs/runtime-isolation.md
+++ b/docs/runtime-isolation.md
@@ -48,8 +48,10 @@ The current service access contract is:
 | `openclaw` | `ai` | `cluster.local/ns/istio-system/sa/istio-ingressgateway` | Tailnet UI ingress. |
 | `n8n` | `automation` | `cluster.local/ns/istio-system/sa/istio-ingressgateway` | Tailnet UI and webhook ingress through the private gateway. |
 | `grafana` | `monitoring` | `cluster.local/ns/istio-system/sa/istio-ingressgateway` | Tailnet UI ingress. |
+| `grafana` | `monitoring` | `cluster.local/ns/monitoring/sa/kiali-service-account` | Kiali dashboard links and health checks. |
 | `grafana` | `monitoring` | `cluster.local/ns/monitoring/sa/prometheus-kube-prometheus-prometheus` | Prometheus scrapes Grafana metrics. |
 | `prometheus` | `monitoring` | `cluster.local/ns/monitoring/sa/grafana` | Grafana Prometheus datasource queries. |
+| `prometheus` | `monitoring` | `cluster.local/ns/monitoring/sa/kiali-service-account` | Kiali graph and health queries. |
 | `prometheus` | `monitoring` | `cluster.local/ns/monitoring/sa/prometheus-kube-prometheus-prometheus` | Prometheus self-scrape and in-stack access. |
 | `alertmanager` | `monitoring` | `cluster.local/ns/monitoring/sa/grafana` | Grafana Alertmanager datasource and contact point. |
 | `alertmanager` | `monitoring` | `cluster.local/ns/monitoring/sa/prometheus-kube-prometheus-prometheus` | Prometheus alert delivery. |

--- a/docs/validation-runbook.md
+++ b/docs/validation-runbook.md
@@ -19,7 +19,7 @@ cd IaC/live/argocd-apps
 terragrunt run --all plan -no-color
 ```
 
-Expected result: 17 requested Argo CD Applications plus the support
+Expected result: 18 requested Argo CD Applications plus the support
 Applications `platform-dns`, `platform-storage`, and `media-postgres` are
 planned, and every upstream relationship appears in a Terragrunt `dependencies`
 block.
@@ -63,9 +63,22 @@ argocd app get cert-manager
 argocd app get istio
 argocd app get tailscale
 argocd app get argocd-image-updater
+argocd app get kiali
 argocd app get platform-dns
 argocd app get platform-storage
 ```
+
+For Kiali, verify the operator-created custom resource and tailnet UI:
+
+```sh
+kubectl -n monitoring get kiali kiali
+kubectl -n monitoring get deploy,svc kiali
+curl -I https://kiali.stinkyboi.com
+```
+
+Expected result: the Kiali Application is synced and healthy, the Kiali custom
+resource is successfully reconciled, and the tailnet HTTPS route reaches the
+read-only UI.
 
 For image automation, confirm the controller and selector CR exist before
 relying on update pull requests:
@@ -159,6 +172,16 @@ migration.
   `nix flake check --no-build --all-systems` passed before live rollout.
   Focused Prowlarr Terragrunt initialization and validation use the
   repository-local `IaC/modules/argocd-application-kubernetes` module.
+- Kiali desired state was added on 2026-05-26. `terragrunt hcl fmt --check`,
+  `terragrunt hcl validate`, `kubectl kustomize clusters/homelab/apps/kiali`,
+  `helm template kiali-operator kiali-operator --repo
+  https://kiali.org/helm-charts --version 2.26.0 --namespace istio-system -f
+  clusters/homelab/apps/kiali/values.yaml`, focused
+  `terragrunt --log-disable validate -no-color`, focused
+  `terragrunt --log-disable plan -no-color`, `git diff --check`, repository
+  secret scanning, and `nix develop --command bash scripts/ci/static-checks.sh`
+  passed before any live rollout. The focused Kiali plan showed `1 to add, 0
+  to change, 0 to destroy`.
 
 ## Failure Modes
 


### PR DESCRIPTION
## Summary

This PR adds Kiali as the homelab's read-only Istio mesh UI. The normal app UIs
are already exposed through Istio `VirtualService` resources rather than
Kubernetes `Ingress`, but there was no operator-facing UI for inspecting mesh
traffic, route health, or Istio configuration. That made it harder to explain
and debug the current tailnet ingress model from inside the GitOps surface.

The root cause is simply that Istio does not ship a first-party dashboard in
this stack. Kiali is the established UI for this job, but it had not yet been
registered as an Argo CD-managed homelab application.

## Changes

- Added `clusters/homelab/apps/kiali` with Kiali operator values, a tailnet-only
  `VirtualService`, and app-specific README notes.
- Added `IaC/live/argocd-apps/kiali` to register Kiali through the local
  Argo CD Application module.
- Pinned the official Kiali operator chart to `2.26.0` and committed the
  focused OpenTofu lock file for the new unit.
- Added `https://kiali.org/helm-charts` to the homelab AppProject source allow
  list.
- Allowed Kiali's service account to query Grafana and Prometheus through the
  existing Istio AuthorizationPolicies.
- Updated onboarding, tailnet ingress, rollback, runtime isolation, validation,
  and knowledge-base docs.

## Operator Access Model

Kiali is exposed at `https://kiali.stinkyboi.com` through the shared
`istio-system/tailnet-gateway`. It is configured with anonymous authentication
and `view_only_mode: true`, so it is immediately usable from the private
tailnet without granting write operations through the UI.

This keeps Prometheus itself unexposed. Kiali queries Prometheus in-cluster for
graph and health data, while Grafana remains the reviewed metrics UI.

## Validation

- `kubectl kustomize clusters/homelab/apps/kiali`
- `kubectl kustomize clusters/homelab/apps/grafana`
- `kubectl kustomize clusters/homelab/apps/prometheus`
- `helm template kiali-operator kiali-operator --repo https://kiali.org/helm-charts --version 2.26.0 --namespace istio-system -f clusters/homelab/apps/kiali/values.yaml`
- `terragrunt hcl fmt --check`
- `terragrunt hcl validate`
- `terragrunt --log-disable validate -no-color` from `IaC/live/argocd-apps/kiali`
- `terragrunt --log-disable plan -no-color` from `IaC/live/argocd-apps/kiali`
- `git diff --check`
- `nix develop --command bash scripts/ci/static-checks.sh`

The focused Kiali plan reported `1 to add, 0 to change, 0 to destroy` for the
new `argocd/kiali` Application.

## Rollout Notes

The production apply workflow runs on pushes to `main` or manual dispatch. The
Kiali Application targets `main`, so the live apply path should run after this
PR lands on `main`; applying this branch directly would register an Argo CD app
that points at files not yet present on `main`.
