### PR TITLE
ci: queue Terragrunt PR refreshes

### DIFF
--- a/.github/workflows/terragrunt-plan.yml
+++ b/.github/workflows/terragrunt-plan.yml
@@ -22,7 +22,7 @@ permissions: {}
 
 concurrency:
   group: terragrunt-plan-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 env:
   AWS_REGION: us-east-1

--- a/docs/knowledge-base/operations/change-log.md
+++ b/docs/knowledge-base/operations/change-log.md
@@ -42,6 +42,9 @@ Use [[templates/knowledge-update]] for new entries.
 - Added a shared concurrency gate to the trusted PR `Terragrunt Plan` job so
   simultaneous Renovate branches queue before reading the shared OpenTofu S3
   backend state.
+- Changed same-PR workflow concurrency to queue replacement runs instead of
+  canceling active runs, because canceling a live OpenTofu plan can strand an
+  S3 backend lock.
 - Documented that queued Terragrunt PR plans are expected when another trusted
   PR is already holding the live-state lock lane.
 

--- a/docs/knowledge-base/operations/validation-gates.md
+++ b/docs/knowledge-base/operations/validation-gates.md
@@ -69,7 +69,9 @@ when reproducing PR gate behavior.
 The trusted GitHub Actions PR plan job is serialized with a shared concurrency
 group because it reads the same OpenTofu S3 backend state across pull requests.
 Do not treat a queued PR plan as unhealthy; it is waiting for the live-state
-lock lane.
+lock lane. Same-PR replacement runs also queue instead of canceling in-progress
+plans, because interrupting OpenTofu while it holds an S3 backend lock can leave
+a stale lock that blocks later plans.
 
 ## Live Rollout Rule
 


### PR DESCRIPTION
## Summary
- queue same-PR Terragrunt Plan workflow replacements instead of canceling in-flight plans
- document that canceling OpenTofu while it holds an S3 backend lock can strand later PR plans

## Validation
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/terragrunt-plan.yml"); puts "terragrunt-plan.yml parses"'
- nix develop --command bash scripts/ci/static-checks.sh
- nix develop --command bash scripts/ci/conftest-policies.sh

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `2dd4b44d5b89a7143aea5875256730a9d9186626`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

<details>
<summary>Argo CD bootstrap</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: argocd-image-updater</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      ~ object   = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
                # (8 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
~~~~

</details>

<details>
<summary>Argo CD Application: cert-manager</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      ~ object   = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
                # (8 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
~~~~

</details>

<details>
<summary>Argo CD Application: deluge</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      ~ object   = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
                # (8 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
~~~~

</details>

<details>
<summary>Argo CD Application: descheduler</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      ~ object   = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
                # (8 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
~~~~

</details>

<details>
<summary>Argo CD Application: external-secrets</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      ~ object   = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
                # (8 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
~~~~

</details>

<details>
<summary>Argo CD Application: grafana</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      ~ object   = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
                # (8 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
~~~~

</details>

<details>
<summary>Argo CD Application: hummingbot</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      ~ object   = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
                # (8 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
~~~~

</details>

<details>
<summary>Argo CD Application: istio</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      ~ object   = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
                # (8 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
~~~~

</details>

<details>
<summary>Argo CD Application: litellm</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      ~ object   = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
                # (8 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
~~~~

</details>

<details>
<summary>Argo CD Application: media-postgres</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      ~ object   = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
                # (8 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
~~~~

</details>

<details>
<summary>Argo CD Application: n8n</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      ~ object   = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
                # (8 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
~~~~

</details>

<details>
<summary>Argo CD Application: openclaw</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      ~ object   = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
                # (8 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
~~~~

</details>

<details>
<summary>Argo CD Application: platform-dns</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      ~ object   = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
                # (8 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
~~~~

</details>

<details>
<summary>Argo CD Application: platform-storage</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      ~ object   = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
                # (8 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
~~~~

</details>

<details>
<summary>Argo CD Application: policy-bot</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      ~ object   = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
                # (8 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
~~~~

</details>

<details>
<summary>Argo CD Application: prometheus</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      ~ object   = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
                # (8 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
~~~~

</details>

<details>
<summary>Argo CD Application: prowlarr</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      ~ object   = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
                # (8 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
~~~~

</details>

<details>
<summary>Argo CD Application: radarr</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      ~ object   = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
                # (8 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
~~~~

</details>

<details>
<summary>Argo CD Application: sonarr</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      ~ object   = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
                # (8 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
~~~~

</details>

<details>
<summary>Argo CD Application: tailscale</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      ~ object   = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
                # (8 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
~~~~

</details>


<!-- terragrunt-plan:end -->
