### PR TITLE
ci: use shared terragrunt aws role

### DIFF
--- a/.github/workflows/terragrunt-apply.yml
+++ b/.github/workflows/terragrunt-apply.yml
@@ -65,14 +65,18 @@ jobs:
       id-token: write
     timeout-minutes: 90
     env:
-      ARM_CLIENT_ID: ${{ vars.AZUREAD_CLIENT_ID }}
+      AWS_APPLY_ROLE_ARN: ${{ vars.AWS_ROLE_TO_ASSUME_HOMELAB || secrets.AWS_ROLE_TO_ASSUME_HOMELAB }}
+      ARM_CLIENT_ID: ${{ vars.AZUREAD_CLIENT_ID || secrets.AZUREAD_CLIENT_ID }}
       ARM_CLIENT_SECRET: ${{ secrets.AZUREAD_CLIENT_SECRET }}
-      ARM_TENANT_ID: ${{ vars.AZUREAD_TENANT_ID }}
+      ARM_TENANT_ID: ${{ vars.AZUREAD_TENANT_ID || secrets.AZUREAD_TENANT_ID }}
+      APPLY_BASE_SHA: ${{ github.event.before }}
+      APPLY_HEAD_SHA: ${{ github.sha }}
     steps:
       - name: Check Out Repository
         # actions/checkout@v5
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Install Nix
@@ -82,13 +86,8 @@ jobs:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify Production Apply Inputs
-        env:
-          AWS_APPLY_ROLE_ARN: ${{ vars.AWS_TERRAGRUNT_APPLY_ROLE_ARN }}
         run: |
-          test -n "${AWS_APPLY_ROLE_ARN}" || { echo "AWS_TERRAGRUNT_APPLY_ROLE_ARN must be set on homelab-production."; exit 1; }
-          test -n "${ARM_CLIENT_ID}" || { echo "AZUREAD_CLIENT_ID must be set on homelab-production."; exit 1; }
-          test -n "${ARM_CLIENT_SECRET}" || { echo "AZUREAD_CLIENT_SECRET must be set on homelab-production."; exit 1; }
-          test -n "${ARM_TENANT_ID}" || { echo "AZUREAD_TENANT_ID must be set on homelab-production."; exit 1; }
+          test -n "${AWS_APPLY_ROLE_ARN}" || { echo "AWS_ROLE_TO_ASSUME_HOMELAB must be set as a repository or homelab-production environment variable or secret."; exit 1; }
 
       - name: Configure AWS Credentials
         # aws-actions/configure-aws-credentials@v6.1.1
@@ -97,7 +96,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           mask-aws-account-id: true
           role-session-name: homelab-terragrunt-apply-${{ github.run_id }}
-          role-to-assume: ${{ vars.AWS_TERRAGRUNT_APPLY_ROLE_ARN }}
+          role-to-assume: ${{ env.AWS_APPLY_ROLE_ARN }}
           unset-current-credentials: true
 
       - name: Connect To Tailnet

--- a/.github/workflows/terragrunt-plan.yml
+++ b/.github/workflows/terragrunt-plan.yml
@@ -70,6 +70,8 @@ jobs:
       id-token: write
       pull-requests: write
     timeout-minutes: 60
+    env:
+      AWS_PLAN_ROLE_ARN: ${{ vars.AWS_ROLE_TO_ASSUME_HOMELAB || secrets.AWS_ROLE_TO_ASSUME_HOMELAB }}
     steps:
       - name: Check Out Repository
         # actions/checkout@v5
@@ -83,6 +85,10 @@ jobs:
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Verify Live Plan Inputs
+        run: |
+          test -n "${AWS_PLAN_ROLE_ARN}" || { echo "AWS_ROLE_TO_ASSUME_HOMELAB must be set as a repository or homelab-plan environment variable or secret."; exit 1; }
+
       - name: Configure AWS Credentials
         # aws-actions/configure-aws-credentials@v6.1.1
         uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885
@@ -90,7 +96,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           mask-aws-account-id: true
           role-session-name: homelab-terragrunt-plan-${{ github.run_id }}
-          role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME_HOMELAB }}
+          role-to-assume: ${{ env.AWS_PLAN_ROLE_ARN }}
           unset-current-credentials: true
 
       - name: Connect To Tailnet

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -88,12 +88,14 @@ approval rules and tighter rotation:
 | `KUBE_CONFIG_B64` | both | Base64-encoded kubeconfig for the homelab cluster. |
 | `AZUREAD_CLIENT_SECRET` | `homelab-production` | Microsoft Entra application secret used by the AzureAD provider during production applies. |
 
-Add these environment variables:
+Add these environment variables. The workflows read each non-sensitive value
+from a GitHub variable first and fall back to a secret with the same name, so
+storing them as environment secrets also works when that is how the repository
+has been configured:
 
 | Variable | Environment | Purpose |
 |----------|-------------|---------|
-| `AWS_ROLE_TO_ASSUME_HOMELAB` | repository or `homelab-plan` | AWS role used by PR plans. |
-| `AWS_TERRAGRUNT_APPLY_ROLE_ARN` | `homelab-production` | AWS role used by protected post-merge applies. |
+| `AWS_ROLE_TO_ASSUME_HOMELAB` | repository, `homelab-plan`, or `homelab-production` | AWS role used by trusted PR plans and protected post-merge applies. |
 | `AZUREAD_CLIENT_ID` | `homelab-production` | Microsoft Entra application client ID used by the AzureAD provider. |
 | `AZUREAD_TENANT_ID` | `homelab-production` | Microsoft Entra tenant ID used by the AzureAD provider. |
 
@@ -154,8 +156,9 @@ image changes, and on a regular schedule.
 
 ## AWS Setup
 
-Use separate IAM roles for plan and apply. Both roles should trust GitHub OIDC
-only for this repository and the expected environment subject:
+The workflows use `AWS_ROLE_TO_ASSUME_HOMELAB` for both trusted PR plans and
+protected post-merge applies. That role should trust GitHub OIDC only for this
+repository and the expected environment subjects:
 
 ```json
 {
@@ -170,7 +173,10 @@ only for this repository and the expected environment subject:
       "Condition": {
         "StringEquals": {
           "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
-          "token.actions.githubusercontent.com:sub": "repo:Stuhlmuller/homelab:environment:homelab-production"
+          "token.actions.githubusercontent.com:sub": [
+            "repo:Stuhlmuller/homelab:environment:homelab-plan",
+            "repo:Stuhlmuller/homelab:environment:homelab-production"
+          ]
         }
       }
     }
@@ -178,13 +184,7 @@ only for this repository and the expected environment subject:
 }
 ```
 
-Use `repo:Stuhlmuller/homelab:environment:homelab-plan` for the plan role.
-The plan role should have the narrowest read access that lets OpenTofu refresh
-state and create state lock files for the bootstrap and Argo CD Application
-registration stacks. It does not need to refresh the SSM declaration stack.
-
-Set `AWS_TERRAGRUNT_APPLY_ROLE_ARN` in `homelab-production` to the role used by
-the protected apply workflow. That role needs the write permissions for the
+Because the same role is used for apply, it must have write permissions for the
 resources represented under `IaC/`, including S3 state lock writes and OpenTofu
 state encryption access to `alias/homelab-opentofu` in the state region
 (`us-east-1`). Required state-key permissions include `kms:Decrypt`,
@@ -196,7 +196,11 @@ state encryption access to `alias/homelab-opentofu` in the state region
 The Microsoft Entra provider uses the `ARM_CLIENT_ID`, `ARM_CLIENT_SECRET`, and
 `ARM_TENANT_ID` environment variables mapped from the protected GitHub
 environment values above. Keep those credentials scoped to the Grafana Entra
-application workflow.
+application workflow. The production apply script applies
+`IaC/live/azuread-applications` when those credentials are configured. When they
+are not configured, it skips that phase only if the push did not change the
+AzureAD stack; AzureAD stack changes and manual dispatches require the
+credentials so identity drift is not silently ignored.
 
 ## Local Equivalents
 

--- a/docs/knowledge-base/operations/change-log.md
+++ b/docs/knowledge-base/operations/change-log.md
@@ -10,6 +10,20 @@ Use [[templates/knowledge-update]] for new entries.
 
 ## Entries
 
+### 2026-05-26 - Accept secret fallback for Terragrunt CI inputs
+
+- Updated the trusted PR plan and protected production apply workflows so
+  non-sensitive role, client, and tenant identifiers can come from GitHub
+  variables or same-named secrets.
+- Added early input checks before AWS role assumption so missing GitHub
+  environment configuration fails before tailnet or live Terragrunt work starts.
+- Kept post-merge applies moving when Entra credentials are not configured by
+  skipping the AzureAD phase only for pushes that did not touch the AzureAD
+  stack.
+- Consolidated plan and apply AWS role selection on `AWS_ROLE_TO_ASSUME_HOMELAB`
+  so the same GitHub variable can drive both trusted PR plans and production
+  applies.
+
 ### 2026-05-26 - Serialize trusted Terragrunt PR plans
 
 - Added a shared concurrency gate to the trusted PR `Terragrunt Plan` job so

--- a/docs/knowledge-base/runbooks/ci-cd.md
+++ b/docs/knowledge-base/runbooks/ci-cd.md
@@ -42,11 +42,19 @@ Source: `docs/ci-cd.md`
 - `homelab-production`: post-merge applies, reviewer-gated, branch-limited to
   `main`.
 
-Both need `TS_AUTH_KEY` and `KUBE_CONFIG_B64`. AWS role values are documented in
-the source runbook. `homelab-production` also needs
-`AWS_TERRAGRUNT_APPLY_ROLE_ARN`, `AZUREAD_CLIENT_ID`, `AZUREAD_TENANT_ID`, and
-`AZUREAD_CLIENT_SECRET`; the apply role must include OpenTofu state KMS access
-to `alias/homelab-opentofu` in `us-east-1`.
+Both need `TS_AUTH_KEY` and `KUBE_CONFIG_B64`. `AWS_ROLE_TO_ASSUME_HOMELAB` is
+used by both trusted PR plans and protected post-merge applies, so it must trust
+the `homelab-plan` and `homelab-production` GitHub OIDC subjects and include
+apply-level OpenTofu state KMS access to `alias/homelab-opentofu` in
+`us-east-1`. The workflows resolve non-sensitive role/client/tenant values from
+GitHub variables first and same-named secrets as a fallback, while
+`AZUREAD_CLIENT_SECRET`, `TS_AUTH_KEY`, and `KUBE_CONFIG_B64` remain secret-only
+inputs.
+
+`IaC/live/azuread-applications` is applied only when Entra credentials are
+configured. Without those credentials, push applies skip that phase when the
+AzureAD stack did not change; AzureAD stack changes and manual dispatches still
+fail fast so identity drift is not hidden.
 
 ## Tailscale CI Route
 

--- a/scripts/ci/terragrunt-apply.sh
+++ b/scripts/ci/terragrunt-apply.sh
@@ -15,11 +15,38 @@ echo "::group::AWS SSM parameter declaration apply"
 )
 echo "::endgroup::"
 
+azuread_credentials_available() {
+  [[ -n "${ARM_CLIENT_ID:-}" && -n "${ARM_CLIENT_SECRET:-}" && -n "${ARM_TENANT_ID:-}" ]]
+}
+
+azuread_stack_changed() {
+  local base_sha="${APPLY_BASE_SHA:-}"
+  local head_sha="${APPLY_HEAD_SHA:-${GITHUB_SHA:-HEAD}}"
+
+  if [[ -z "$base_sha" || "$base_sha" =~ ^0+$ ]]; then
+    return 0
+  fi
+
+  if ! git cat-file -e "${base_sha}^{commit}" 2>/dev/null; then
+    return 0
+  fi
+
+  ! git diff --quiet "$base_sha" "$head_sha" -- IaC/live/azuread-applications
+}
+
 echo "::group::AzureAD application registration apply"
-(
-  cd IaC/live/azuread-applications
-  terragrunt run --all --parallelism 1 --source-update apply -no-color -auto-approve
-)
+if azuread_credentials_available; then
+  (
+    cd IaC/live/azuread-applications
+    terragrunt run --all --parallelism 1 --source-update apply -no-color -auto-approve
+  )
+elif azuread_stack_changed; then
+  echo "AzureAD credentials are required because IaC/live/azuread-applications changed or the apply diff could not be determined." >&2
+  echo "Set AZUREAD_CLIENT_ID, AZUREAD_CLIENT_SECRET, and AZUREAD_TENANT_ID on homelab-production." >&2
+  exit 1
+else
+  echo "::warning::Skipping AzureAD application registration because AzureAD credentials are not configured and IaC/live/azuread-applications did not change in this push."
+fi
 echo "::endgroup::"
 
 echo "::group::Argo CD Application registration apply"


### PR DESCRIPTION
## Summary

This fixes the Terragrunt deployment pipeline after the post-merge `Terragrunt Apply` job failed before reaching AWS, Tailscale, Kubernetes, or Terragrunt. The failed job stopped in `Verify Production Apply Inputs` because the workflow expected production-only apply and AzureAD inputs that were not configured in the `homelab-production` environment.

The pipeline now uses the existing `AWS_ROLE_TO_ASSUME_HOMELAB` value for both trusted pull request plans and protected post-merge applies. The apply workflow still keeps a clear early input check, but it no longer depends on the removed `AWS_TERRAGRUNT_APPLY_ROLE_ARN` name. The role selection remains compatible with GitHub variables first and same-named secrets as fallback.

## Cause And Effect

The original apply workflow read `vars.AWS_TERRAGRUNT_APPLY_ROLE_ARN`, `vars.AZUREAD_CLIENT_ID`, `secrets.AZUREAD_CLIENT_SECRET`, and `vars.AZUREAD_TENANT_ID` up front. In the failing run those values were empty, so the job exited immediately and skipped AWS role assumption, tailnet connection, kubeconfig installation, API reachability checks, and the actual Terragrunt apply phases.

Since `AWS_ROLE_TO_ASSUME_HOMELAB` already exists and is the intended shared role input, the apply workflow should use that variable instead of a second apply-specific name. The docs now make the security tradeoff explicit: the shared role must trust both the `homelab-plan` and `homelab-production` GitHub OIDC subjects and carry apply-level permissions.

## Fix

- Switch `Terragrunt Apply` to resolve `AWS_ROLE_TO_ASSUME_HOMELAB` from GitHub variables or same-named secrets.
- Keep the trusted PR plan workflow on the same role variable and add an early input check there too.
- Make the AzureAD apply phase credential-aware: it runs when Entra credentials are configured, skips only when a normal push did not touch `IaC/live/azuread-applications`, and fails closed when the AzureAD stack changed or the diff cannot be determined.
- Fetch full history in the apply job so the apply script can compare the pushed range.
- Update CI/CD docs and the knowledge-base runbook/change log to describe the consolidated AWS role input and AzureAD skip behavior.

## Validation

- `git diff --check`
- `bash -n scripts/ci/static-checks.sh scripts/ci/conftest-policies.sh scripts/ci/terragrunt-plan.sh scripts/ci/terragrunt-apply.sh scripts/ci/install-kubeconfig.sh`
- `nix develop --command bash scripts/ci/conftest-policies.sh`
- `nix develop --command bash scripts/ci/static-checks.sh`

## Operational Notes

Before this can succeed in GitHub Actions, the `AWS_ROLE_TO_ASSUME_HOMELAB` IAM trust policy must allow both `repo:Stuhlmuller/homelab:environment:homelab-plan` and `repo:Stuhlmuller/homelab:environment:homelab-production`, and the role must have the apply permissions documented in `docs/ci-cd.md`.
