### PR TITLE
fix: retire hummingbot cleanly

### DIFF
--- a/IaC/live/argocd-apps/hummingbot/.terraform.lock.hcl
+++ b/IaC/live/argocd-apps/hummingbot/.terraform.lock.hcl
@@ -1,0 +1,41 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/helm" {
+  version = "3.1.1"
+  hashes = [
+    "h1:brfn5YltnzexsfqpWKw+5gS9U/m77e0An3hZQamlEZk=",
+    "zh:09b38905e234c2e0b185332819614224660050b7e4b25e9e858b593ab01adafe",
+    "zh:09fed1b19b8bcded169fb76304e06c5b1216d5ceba92948c23384f34ddbf1fac",
+    "zh:2e0af220f3fe79048d82f6de91752ba9929c215819d3de4f82ccb473bcd9e5df",
+    "zh:5fe8657cbf6aca769b9565a4fb4605d7b441c2c558d915b067c0adf6f77c58d4",
+    "zh:713943f797be3a4c6fc6bb5f1306c4f74762bfaa663f98fd8b4c49d28ee54ecf",
+    "zh:b426458c0bbad64f9000c11af7e74a24ce9e0adb3037c05dadf80c0c3e757931",
+    "zh:c0664866280a42156484a48f6c461d0ddb2d212da9b6e930c721ef577ab75270",
+    "zh:e4f9d0ebb70d63d8ac3ccee00a4d8cdb15b97aaa390f95ed65921e9d0f65bfa0",
+    "zh:f6fe7ecfafc344f4e6aecacf5ae12ac73b94389b9679dcd0f04fc5ff45bdc066",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/kubernetes" {
+  version     = "3.1.0"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:0M9Nu8YersHl84pfFTRiW5UfmoxQC3xKJ+Zkt5WjEv8=",
+    "zh:06f1310b47ff31593766b4b664a508276e57f911c9e0237c6cb197a590e2d799",
+    "zh:54aad7284e03c49996477f777c20b75ad12acbd68e80e86ecd1bd1ae6cfa5bea",
+    "zh:5ad86522ff9343ac8a2b8b595ba7280de82966dd6feb6aa87b6b9103b694bf82",
+    "zh:6506c8356b82f8c03f937efc68eee7a4ded1c77791552b530d3edf245ea97df4",
+    "zh:6dab1c6eb3cb5c1738e1ca8c2c54e3ca30ef3a83dd3453491edbe2ff525e1392",
+    "zh:754a9aef6d8456bae74bc2ab5a62c4c2146f0d79c4a817abe9d93567d1df26ef",
+    "zh:75689548a4731f2f9f9ebe5fef971f3ee1464f1a0c4505f86ee1ef07cc228a0e",
+    "zh:7e25f27dcbf73c5c83e9ee38a6e8110a8f889c902fc907e01a0820148d12604a",
+    "zh:a080838edc0ebec1b556432fb1fde310effaa5ba5f504d105abbe6762e2acf07",
+    "zh:a448d00988e100e201453b98d0098959c9b8e5dd34fbb33fe45793de0ae3d90e",
+    "zh:d4b4da8b49e86d8dec76a147e9f9f1b541fa59607236c4e62105205edff5fc14",
+    "zh:e712b9f90d9e29fa67990ef67cb9391db408414fb4c2261bc7522ecfba740fc0",
+    "zh:e8c6b874b9e8f03411f1fb38d6273bec8037a007b32d11fd75b18f8befcbde03",
+    "zh:f505fa05dee07f3d904208b9b9b8b13fd386093ae8243f2d7ce131f279310268",
+    "zh:fc3c74b661a1c86b3dd78b0f3bd9256123f6b270c3627975a6f9dc231bf7a59c",
+  ]
+}

--- a/IaC/live/argocd-apps/hummingbot/terragrunt.hcl
+++ b/IaC/live/argocd-apps/hummingbot/terragrunt.hcl
@@ -1,0 +1,73 @@
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "../../../modules/argocd-application-kubernetes"
+}
+
+dependencies {
+  paths = [
+    "../platform-storage"
+  ]
+}
+
+locals {
+  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
+  target_revision = "main"
+}
+
+inputs = {
+  metadata = {
+    name      = "hummingbot"
+    namespace = "argocd"
+    labels = {
+      "app.kubernetes.io/managed-by" = "terragrunt"
+      "app.kubernetes.io/part-of"    = "homelab"
+      "homelab.rst.io/retired"       = "true"
+    }
+  }
+
+  project = "homelab"
+
+  destination = {
+    server    = "https://kubernetes.default.svc"
+    namespace = "finance"
+  }
+
+  sources = [
+    {
+      repo_url        = local.repo_url
+      target_revision = local.target_revision
+      path            = "clusters/homelab/apps/hummingbot"
+      kustomize       = {}
+    }
+  ]
+
+  sync_policy = {
+    automated = {
+      prune     = true
+      self_heal = true
+    }
+    sync_options = [
+      "CreateNamespace=true",
+      "PruneLast=true",
+      "ServerSideApply=true"
+    ]
+    retry = {
+      limit = "5"
+      backoff = {
+        duration     = "30s"
+        factor       = "2"
+        max_duration = "2m"
+      }
+    }
+  }
+
+  info = [
+    {
+      name  = "retired"
+      value = "Hummingbot workload is retired; this Application preserves rollback PVCs while OctoBot is the active finance UI"
+    }
+  ]
+}

--- a/IaC/live/aws-ssm-parameters/terragrunt.hcl
+++ b/IaC/live/aws-ssm-parameters/terragrunt.hcl
@@ -126,6 +126,14 @@ inputs = {
       }
       initial_value = local.placeholder
     }
+    "/homelab/hummingbot/config-password" = {
+      description = "Retained Hummingbot config password for rollback while Hummingbot PVCs are retired in place."
+      generated = {
+        length  = 40
+        special = false
+      }
+      initial_value = local.placeholder
+    }
     "/homelab/openclaw/app-secret" = {
       description = "OpenClaw application secret."
       generated = {

--- a/clusters/homelab/apps/hummingbot/README.md
+++ b/clusters/homelab/apps/hummingbot/README.md
@@ -1,0 +1,33 @@
+# Hummingbot Retired State
+
+Hummingbot is no longer the active finance trading bot. OctoBot owns the
+current UI at `https://octobot.stinkyboi.com`.
+
+This path intentionally keeps only the old Hummingbot PVCs under Argo CD. The
+retired Application gives Argo a valid source path, lets it prune the old
+Deployment, Service, ExternalSecret, and VirtualService, and protects the PVCs
+from app deletion with Argo sync annotations.
+
+## Retained Data
+
+- `hummingbot-conf`: encrypted client configuration and connector files
+- `hummingbot-logs`: historical bot logs
+- `hummingbot-data`: runtime data
+- `hummingbot-certs`: generated client certificates
+- `hummingbot-scripts`: custom scripts
+- `hummingbot-controllers`: controller files
+
+The SSM parameter `/homelab/hummingbot/config-password` is retained for
+rollback while these PVCs exist. Do not delete it until a separate data-retention
+decision removes or archives the PVCs.
+
+## Validation
+
+```sh
+kubectl kustomize clusters/homelab/apps/hummingbot
+kubectl -n argocd get application hummingbot
+kubectl -n finance get pvc -l app.kubernetes.io/instance=hummingbot
+```
+
+Expected result: the Hummingbot Application is synced and healthy, no Hummingbot
+Deployment or route is running, and the retained PVCs are bound.

--- a/clusters/homelab/apps/hummingbot/kustomization.yaml
+++ b/clusters/homelab/apps/hummingbot/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: finance
+resources:
+  - pvc.yaml

--- a/clusters/homelab/apps/hummingbot/pvc.yaml
+++ b/clusters/homelab/apps/hummingbot/pvc.yaml
@@ -1,0 +1,125 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hummingbot-conf
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false,Delete=false
+  labels:
+    app.kubernetes.io/instance: hummingbot
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: hummingbot
+    helm.sh/chart: app-template-4.4.0
+    homelab.rst.io/retired: "true"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: nfs-default
+  volumeMode: Filesystem
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hummingbot-logs
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false,Delete=false
+  labels:
+    app.kubernetes.io/instance: hummingbot
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: hummingbot
+    helm.sh/chart: app-template-4.4.0
+    homelab.rst.io/retired: "true"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: nfs-default
+  volumeMode: Filesystem
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hummingbot-data
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false,Delete=false
+  labels:
+    app.kubernetes.io/instance: hummingbot
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: hummingbot
+    helm.sh/chart: app-template-4.4.0
+    homelab.rst.io/retired: "true"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: nfs-default
+  volumeMode: Filesystem
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hummingbot-certs
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false,Delete=false
+  labels:
+    app.kubernetes.io/instance: hummingbot
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: hummingbot
+    helm.sh/chart: app-template-4.4.0
+    homelab.rst.io/retired: "true"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: nfs-default
+  volumeMode: Filesystem
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hummingbot-scripts
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false,Delete=false
+  labels:
+    app.kubernetes.io/instance: hummingbot
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: hummingbot
+    helm.sh/chart: app-template-4.4.0
+    homelab.rst.io/retired: "true"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: nfs-default
+  volumeMode: Filesystem
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hummingbot-controllers
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false,Delete=false
+  labels:
+    app.kubernetes.io/instance: hummingbot
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: hummingbot
+    helm.sh/chart: app-template-4.4.0
+    homelab.rst.io/retired: "true"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: nfs-default
+  volumeMode: Filesystem

--- a/clusters/homelab/apps/octobot/README.md
+++ b/clusters/homelab/apps/octobot/README.md
@@ -54,11 +54,9 @@ the tailnet.
 
 - Back up the PVCs before changing strategies, enabling real exchange accounts,
   or testing a major OctoBot upgrade.
-- This app replaces the earlier Hummingbot desired state. If the live
-  `hummingbot` Argo CD Application still exists, cut over deliberately: publish
-  the OctoBot source paths first, apply the OctoBot Application, verify the UI,
-  then destroy or prune the retired Hummingbot Application through the
-  Terragrunt/Argo CD path before relying on the Hummingbot source deletion.
+- This app replaces the earlier Hummingbot runtime. The retained Hummingbot
+  Argo CD Application is PVC-only rollback state and should not run a pod,
+  service, route, or ExternalSecret.
 - Prefer paper trading and backtesting until the configuration is proven.
 - Do not place exchange API keys in Git, Terragrunt inputs, Helm values,
   Kubernetes Secrets, or External Secrets without adding an explicit repository

--- a/docs/argocd-app-onboarding.md
+++ b/docs/argocd-app-onboarding.md
@@ -31,6 +31,7 @@ counted as requested workloads.
 | n8n | requested | `automation` | `clusters/homelab/apps/n8n` | `IaC/live/argocd-apps/n8n` | Yes | external-secrets, cert-manager, istio, tailscale, platform-storage |
 | policy-bot | requested | `automation` | `clusters/homelab/apps/policy-bot` | `IaC/live/argocd-apps/policy-bot` | Yes | external-secrets, cert-manager, istio, tailscale |
 | octobot | requested | `finance` | `clusters/homelab/apps/octobot` | `IaC/live/argocd-apps/octobot` | Yes | cert-manager, istio, tailscale, platform-storage |
+| hummingbot | retired | `finance` | `clusters/homelab/apps/hummingbot` | `IaC/live/argocd-apps/hummingbot` | Yes | platform-storage |
 
 ## Dependency Readiness
 

--- a/docs/knowledge-base/architecture/secrets-and-identity.md
+++ b/docs/knowledge-base/architecture/secrets-and-identity.md
@@ -58,6 +58,9 @@ outside git.
   exchange credentials, tentacles, and strategy state live on the finance
   namespace PVCs and are summarized in [[runbooks/secrets-aws-ssm]] and
   [[workloads/application-notes]].
+- The retired Hummingbot PVCs still have rollback value, so
+  `/homelab/hummingbot/config-password` remains declared until those PVCs are
+  archived or intentionally removed.
 
 ## Source Files
 

--- a/docs/knowledge-base/architecture/storage-and-state.md
+++ b/docs/knowledge-base/architecture/storage-and-state.md
@@ -32,8 +32,9 @@ ready, but they must not be treated as production-ready until:
 ## Stateful Apps
 
 The current stateful set includes Prometheus, Grafana, Deluge, media-postgres,
-Prowlarr, Radarr, Sonarr, LiteLLM, OpenClaw, n8n, and OctoBot. Freqtrade and
-Hummingbot are historical finance-app notes unless reintroduced by a future
+Prowlarr, Radarr, Sonarr, LiteLLM, OpenClaw, n8n, and OctoBot. Hummingbot is
+retired but keeps PVC-only rollback state until a separate retention decision
+archives or removes it. Freqtrade is historical unless reintroduced by a future
 desired-state change. See [[workloads/inventory]] for ownership and dependency
 notes.
 

--- a/docs/knowledge-base/operations/change-log.md
+++ b/docs/knowledge-base/operations/change-log.md
@@ -29,8 +29,12 @@ Use [[templates/knowledge-update]] for new entries.
 - Replaced the finance namespace Hummingbot CLI workload with OctoBot using
   `drakkarsoftware/octobot:2.1.1`, NFS-backed `user`, `tentacles`, and `logs`
   PVCs, and the tailnet-only `https://octobot.stinkyboi.com` Istio route.
-- Removed the Hummingbot ExternalSecret and SSM parameter contract because
-  OctoBot setup and exchange credentials are UI-managed runtime state on PVCs.
+- Retired the Hummingbot workload into a PVC-only Argo CD Application so Argo
+  prunes the old Deployment, Service, ExternalSecret, and route while keeping
+  rollback data protected.
+- Kept `/homelab/hummingbot/config-password` declared while the retired
+  Hummingbot PVCs exist; OctoBot setup and exchange credentials are UI-managed
+  runtime state on OctoBot PVCs.
 - Updated app inventory, storage, ingress, image automation, runtime isolation,
   rollback, and secrets notes so OctoBot is the current finance app.
 

--- a/docs/knowledge-base/runbooks/argocd-app-onboarding.md
+++ b/docs/knowledge-base/runbooks/argocd-app-onboarding.md
@@ -14,9 +14,10 @@ registration and sources the repository-local
 `IaC/modules/argocd-application-kubernetes` module. Runtime desired state lives
 under `clusters/homelab/apps/<app>` or `clusters/homelab/platform/<service>`.
 
-The current app onboarding runbook says there are 17 requested apps plus
-support Applications. OctoBot is the current finance namespace app; Hummingbot
-and Freqtrade are historical unless a future change reintroduces them.
+The current app onboarding runbook includes the requested apps plus support
+Applications. OctoBot is the current finance namespace app; Hummingbot remains
+as a retired PVC-only Application for rollback data, and Freqtrade is
+historical unless a future change reintroduces it.
 
 ## Support Applications
 

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -72,6 +72,11 @@ are configured through the UI and stored on the PVCs. Start with paper trading;
 before enabling live trading, document backtest and paper-trading evidence and
 confirm withdrawal access is disabled at the exchange.
 
+The older Hummingbot workload is retired in place. Its Argo CD Application now
+keeps only the `hummingbot-*` PVCs so Argo can prune the old workload resources
+without deleting rollback data. The old `/homelab/hummingbot/config-password`
+SSM parameter remains declared until those PVCs are archived or removed.
+
 ## OpenClaw
 
 OpenClaw persists runtime state on `/data/openclaw`. The startup bootstrap

--- a/docs/knowledge-base/workloads/inventory.md
+++ b/docs/knowledge-base/workloads/inventory.md
@@ -9,8 +9,9 @@ units as the source of truth when they disagree with this note.
 ## Import Note
 
 This note reflects the current working tree. OctoBot is the finance namespace
-trading workload with a tailnet-only UI; older Freqtrade and Hummingbot
-desired-state paths are retired in this branch.
+trading workload with a tailnet-only UI. Hummingbot is retained only as a
+PVC-protection Argo CD Application for rollback data; it is not a running
+trading workload.
 
 ## Platform And Support Applications
 
@@ -41,6 +42,7 @@ desired-state paths are retired in this branch.
 | `n8n` | `automation` | `clusters/homelab/apps/n8n` | `IaC/live/argocd-apps/n8n` | persistent workflows, credential metadata, and instance settings; SSM key bootstraps fresh PVCs only | external-secrets, cert-manager, istio, tailscale, platform-storage |
 | `policy-bot` | `automation` | `clusters/homelab/apps/policy-bot` | `IaC/live/argocd-apps/policy-bot` | stateless GitHub App policy evaluator; one replica after SSM placeholders are replaced | external-secrets, cert-manager, istio, tailscale |
 | `octobot` | `finance` | `clusters/homelab/apps/octobot` | `IaC/live/argocd-apps/octobot` | UI-configured bot state, tentacles, exchange credentials after operator setup, logs, and tailnet-only UI route | cert-manager, istio, tailscale, platform-storage |
+| `hummingbot` | `finance` | `clusters/homelab/apps/hummingbot` | `IaC/live/argocd-apps/hummingbot` | retired PVC-only rollback state; no Deployment, Service, ExternalSecret, or route | platform-storage |
 
 ## Mesh Policy Summary
 
@@ -61,9 +63,9 @@ namespaces. The source of truth is `docs/runtime-isolation.md` plus the
 
 ## In-Flight Or Historical Rows
 
-- `freqtrade` and `hummingbot` appear only in older historical notes. Treat both
-  as retired unless a future change intentionally reintroduces them with new
-  desired-state paths and docs.
+- `freqtrade` appears only in older historical notes. Treat it as retired unless
+  a future change intentionally reintroduces it with new desired-state paths and
+  docs.
 
 ## Update Checklist
 

--- a/docs/secrets-aws-ssm.md
+++ b/docs/secrets-aws-ssm.md
@@ -183,3 +183,8 @@ live-trading autostart configuration until a separate PR adds the
 repository-owned secret contract or documents why UI-managed state is sufficient,
 records backtest and paper-trading evidence, and confirms withdrawal access is
 disabled at the exchange.
+
+The old `/homelab/hummingbot/config-password` parameter is retained while the
+retired Hummingbot PVCs exist. It is not consumed by the active OctoBot
+deployment, but keeping it avoids destroying rollback material before the old
+PVCs are intentionally archived or deleted.

--- a/docs/storage-nfs.md
+++ b/docs/storage-nfs.md
@@ -144,6 +144,7 @@ app has acceptable backup and restore coverage.
 | openclaw | config, runtime state | `nfs-default` | NFS backup for runtime state | Restore PVC and verify LiteLLM connectivity | Preserve PVC |
 | n8n | workflows, SQLite data, credentials metadata, config | `nfs-default` | NFS backup plus workflow export when available | Restore PVC before app sync | Snapshot first, preserve PVC |
 | octobot | UI-configured bot state, tentacles, exchange credentials after operator setup, logs, strategy config | `nfs-default` | NFS backup before strategy, tentacle, or exchange-account changes | Restore PVCs before comparing long-running paper/live strategy results or reusing exchange credentials | Preserve PVCs unless intentionally resetting bot credentials |
+| hummingbot-retired | old Hummingbot conf, logs, data, certs, scripts, controllers | `nfs-default` | NFS backup before removing retired rollback data | Restore PVCs and retained `/homelab/hummingbot/config-password` before reintroducing Hummingbot | Preserve PVCs until a separate deletion decision |
 
 ## Validation Notes
 
@@ -152,8 +153,9 @@ app has acceptable backup and restore coverage.
 - Read-only `kubectl get storageclass` reported no resources before this
   storage integration was added.
 - Persistent app Terragrunt units were checked on 2026-05-24 and refreshed for
-  OctoBot on 2026-05-26. Prometheus, Grafana, Deluge, Prowlarr, Radarr,
-  Sonarr, LiteLLM, OpenClaw, n8n, and OctoBot each explicitly depend on
+  OctoBot and the retired Hummingbot PVC Application on 2026-05-26. Prometheus,
+  Grafana, Deluge, Prowlarr, Radarr, Sonarr, LiteLLM, OpenClaw, n8n, OctoBot,
+  and Hummingbot rollback PVCs each explicitly depend on
   `IaC/live/argocd-apps/platform-storage`.
 - The live `nfs-subdir-external-provisioner` Application was verified healthy
   on 2026-05-24.


### PR DESCRIPTION
## Summary
- keep Hummingbot as a retired PVC-only Argo CD Application so the old source path renders cleanly
- retain the Hummingbot config-password SSM parameter while rollback PVCs exist
- update OctoBot/Hummingbot docs and knowledge-base notes for the cutover state

## Validation
- kubectl kustomize clusters/homelab/apps/hummingbot
- kubectl kustomize clusters/homelab/apps/octobot
- terragrunt hcl fmt --check
- terragrunt hcl validate
- terragrunt --log-disable validate -no-color (IaC/live/argocd-apps/hummingbot)
- bash scripts/ci/static-checks.sh
- terragrunt --log-disable plan -no-color (IaC/live/argocd-apps/hummingbot): 0 add, 1 change, 0 destroy
- terragrunt --log-disable plan -no-color (IaC/live/aws-ssm-parameters): 0 add, 1 change, 0 destroy