### PR TITLE
fix: forward terragrunt apply flags

### DIFF
--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -57,7 +57,10 @@ run the static checks and Conftest only.
 - The protected post-merge apply runs the production phases explicitly:
   bootstrap Argo CD, apply SSM parameter declarations, apply Entra application
   registrations, apply Argo CD Application registrations serially, and finally
-  materialize Kubernetes Secrets from SSM.
+  materialize Kubernetes Secrets from SSM. Stack-wide apply phases use
+  Terragrunt's explicit `run --all -- apply ...` form so OpenTofu flags such as
+  `-auto-approve` are forwarded to OpenTofu instead of being parsed as
+  Terragrunt CLI flags.
 
 References:
 

--- a/docs/knowledge-base/operations/change-log.md
+++ b/docs/knowledge-base/operations/change-log.md
@@ -10,6 +10,13 @@ Use [[templates/knowledge-update]] for new entries.
 
 ## Entries
 
+### 2026-05-26 - Forward Terragrunt apply flags explicitly
+
+- Updated `scripts/ci/terragrunt-apply.sh` so stack-wide apply phases call
+  `terragrunt run --all -- apply -no-color -auto-approve`, matching
+  Terragrunt 1.x flag parsing and forwarding OpenTofu flags correctly.
+- Documented the flag-forwarding requirement in the CI/CD runbook note.
+
 ### 2026-05-26 - Clarify SSM KMS apply-role access
 
 - Documented that `IaC/live/aws-ssm-parameters` uses a `us-west-2` SSM

--- a/docs/knowledge-base/runbooks/ci-cd.md
+++ b/docs/knowledge-base/runbooks/ci-cd.md
@@ -35,6 +35,9 @@ Source: `docs/ci-cd.md`
   managed KMS, IAM, and SSM resources that require the protected apply role.
   They also skip `IaC/live/kubernetes-secrets`; protected apply runs those
   stacks after review.
+- Stack-wide apply phases use Terragrunt's explicit `run --all -- apply ...`
+  form so OpenTofu flags such as `-auto-approve` are forwarded to OpenTofu
+  instead of being parsed as Terragrunt CLI flags.
 
 ## Environments
 

--- a/scripts/ci/terragrunt-apply.sh
+++ b/scripts/ci/terragrunt-apply.sh
@@ -38,7 +38,7 @@ echo "::group::AzureAD application registration apply"
 if azuread_credentials_available; then
   (
     cd IaC/live/azuread-applications
-    terragrunt run --all --parallelism 1 --source-update apply -no-color -auto-approve
+    terragrunt run --all --parallelism 1 --source-update -- apply -no-color -auto-approve
   )
 elif azuread_stack_changed; then
   echo "AzureAD credentials are required because IaC/live/azuread-applications changed or the apply diff could not be determined." >&2
@@ -52,13 +52,13 @@ echo "::endgroup::"
 echo "::group::Argo CD Application registration apply"
 (
   cd IaC/live/argocd-apps
-  terragrunt run --all --parallelism 1 --source-update apply -no-color -auto-approve
+  terragrunt run --all --parallelism 1 --source-update -- apply -no-color -auto-approve
 )
 echo "::endgroup::"
 
 echo "::group::Kubernetes secret materialization apply"
 (
   cd IaC/live/kubernetes-secrets
-  terragrunt run --all --parallelism 1 --source-update apply -no-color -auto-approve
+  terragrunt run --all --parallelism 1 --source-update -- apply -no-color -auto-approve
 )
 echo "::endgroup::"


### PR DESCRIPTION
## Summary

- Forward OpenTofu flags after `--` for stack-wide Terragrunt apply phases.
- Document the Terragrunt 1.x flag-forwarding requirement in the CI/CD docs and knowledge base.

## Validation

- `bash -n scripts/ci/terragrunt-apply.sh`
- `git diff --check`
- `nix develop --command bash scripts/ci/static-checks.sh`
- `nix develop --command bash scripts/ci/conftest-policies.sh`

## Operational Note

The live `Github-TF-State` role was updated with the missing homelab apply policy, and the rerun progressed through the SSM KMS/IAM phase. It then failed on this Terragrunt CLI flag parsing issue, which this PR fixes.


<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `f671bf0cfcb4a54e81cfce72ab0fbb471605e2f1`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

<details>
<summary>Argo CD bootstrap</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: argocd-image-updater</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      + computed_fields = [
          + "metadata.annotations",
          + "metadata.labels",
          + "spec.destination.name",
          + "spec.sources[0].path",
          + "spec.sources[1].path",
          + "spec.sources[2].path",
        ]
      ~ manifest        = {
          ~ spec       = {
              ~ destination = {
                  ~ name      = null -> ""
                    # (2 unchanged attributes hidden)
                }
              ~ sources     = [
                  ~ {
                      + path           = "."
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      + path           = "."
                        # (4 unchanged attributes hidden)
                    },
                    {
                        kustomize      = {}
                        path           = "clusters/homelab/apps/argocd-image-updater"
                        repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                        targetRevision = "main"
                    },
                ]
                # (3 unchanged attributes hidden)
            }
            # (3 unchanged attributes hidden)
        }
      ~ object          = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
              ~ sources              = [
                  ~ {
                        name           = null
                      + path           = (known after apply)
                        # (8 unchanged attributes hidden)
                    },
                  ~ {
                        name           = null
                      + path           = (known after apply)
                        # (8 unchanged attributes hidden)
                    },
                    {
                        chart          = null
                        directory      = {
                            exclude = null
                            include = null
                            jsonnet = {
                                extVars = null
                                libs    = null
                                tlas    = null
                            }
                            recurse = null
                        }
                        helm           = {
                            apiVersions             = null
                            fileParameters          = null
                            ignoreMissingValueFiles = null
                            kubeVersion             = null
                            namespace               = null
                            parameters              = null
                            passCredentials         = null
                            releaseName             = null
                            skipCrds                = null
                            skipSchemaValidation    = null
                            skipTests               = null
                            valueFiles              = null
                            values                  = null
                            valuesObject            = null
                            version                 = null
                        }
                        kustomize      = {
                            apiVersions               = null
                            commonAnnotations         = null
                            commonAnnotationsEnvsubst = null
                            commonLabels              = null
                            components                = null
                            forceCommonAnnotations    = null
                            forceCommonLabels         = null
                            ignoreMissingComponents   = null
                            images                    = null
                            kubeVersion               = null
                            labelIncludeTemplates     = null
                            labelWithoutSelector      = null
                            namePrefix                = null
                            nameSuffix                = null
                            namespace                 = null
                            patches                   = null
                            replicas                  = null
                            version                   = null
                        }
                        name           = null
                        path           = "clusters/homelab/apps/argocd-image-updater"
                        plugin         = {
                            env        = null
                            name       = null
                            parameters = null
                        }
                        ref            = null
                        repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                        targetRevision = "main"
                    },
                ]
                # (7 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Changes to Outputs:
  ~ manifest  = {
      ~ spec       = {
          ~ destination = {
              ~ name      = null -> ""
                # (2 unchanged attributes hidden)
            }
          ~ sources     = [
              ~ {
                  + path           = "."
                    # (4 unchanged attributes hidden)
                },
              ~ {
                  + path           = "."
                    # (4 unchanged attributes hidden)
                },
                {
                    kustomize      = {}
                    path           = "clusters/homelab/apps/argocd-image-updater"
                    repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                    targetRevision = "main"
                },
            ]
            # (3 unchanged attributes hidden)
        }
        # (3 unchanged attributes hidden)
    }
~~~~

</details>

<details>
<summary>Argo CD Application: cert-manager</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      + computed_fields = [
          + "metadata.annotations",
          + "metadata.labels",
          + "spec.destination.name",
          + "spec.sources[0].path",
          + "spec.sources[1].path",
          + "spec.sources[2].path",
        ]
      ~ manifest        = {
          ~ spec       = {
              ~ destination = {
                  ~ name      = null -> ""
                    # (2 unchanged attributes hidden)
                }
              ~ sources     = [
                  ~ {
                      + path           = "."
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      + path           = "."
                        # (4 unchanged attributes hidden)
                    },
                    {
                        kustomize      = {}
                        path           = "clusters/homelab/apps/cert-manager"
                        repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                        targetRevision = "main"
                    },
                ]
                # (2 unchanged attributes hidden)
            }
            # (3 unchanged attributes hidden)
        }
      ~ object          = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
              ~ sources              = [
                  ~ {
                        name           = null
                      + path           = (known after apply)
                        # (8 unchanged attributes hidden)
                    },
                  ~ {
                        name           = null
                      + path           = (known after apply)
                        # (8 unchanged attributes hidden)
                    },
                    {
                        chart          = null
                        directory      = {
                            exclude = null
                            include = null
                            jsonnet = {
                                extVars = null
                                libs    = null
                                tlas    = null
                            }
                            recurse = null
                        }
                        helm           = {
                            apiVersions             = null
                            fileParameters          = null
                            ignoreMissingValueFiles = null
                            kubeVersion             = null
                            namespace               = null
                            parameters              = null
                            passCredentials         = null
                            releaseName             = null
                            skipCrds                = null
                            skipSchemaValidation    = null
                            skipTests               = null
                            valueFiles              = null
                            values                  = null
                            valuesObject            = null
                            version                 = null
                        }
                        kustomize      = {
                            apiVersions               = null
                            commonAnnotations         = null
                            commonAnnotationsEnvsubst = null
                            commonLabels              = null
                            components                = null
                            forceCommonAnnotations    = null
                            forceCommonLabels         = null
                            ignoreMissingComponents   = null
                            images                    = null
                            kubeVersion               = null
                            labelIncludeTemplates     = null
                            labelWithoutSelector      = null
                            namePrefix                = null
                            nameSuffix                = null
                            namespace                 = null
                            patches                   = null
                            replicas                  = null
                            version                   = null
                        }
                        name           = null
                        path           = "clusters/homelab/apps/cert-manager"
                        plugin         = {
                            env        = null
                            name       = null
                            parameters = null
                        }
                        ref            = null
                        repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                        targetRevision = "main"
                    },
                ]
                # (7 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Changes to Outputs:
  ~ manifest  = {
      ~ spec       = {
          ~ destination = {
              ~ name      = null -> ""
                # (2 unchanged attributes hidden)
            }
          ~ sources     = [
              ~ {
                  + path           = "."
                    # (4 unchanged attributes hidden)
                },
              ~ {
                  + path           = "."
                    # (4 unchanged attributes hidden)
                },
                {
                    kustomize      = {}
                    path           = "clusters/homelab/apps/cert-manager"
                    repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                    targetRevision = "main"
                },
            ]
            # (2 unchanged attributes hidden)
        }
        # (3 unchanged attributes hidden)
    }
~~~~

</details>

<details>
<summary>Argo CD Application: deluge</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      + computed_fields = [
          + "metadata.annotations",
          + "metadata.labels",
          + "spec.destination.name",
          + "spec.sources[0].path",
          + "spec.sources[1].path",
          + "spec.sources[2].path",
        ]
      ~ manifest        = {
          ~ spec       = {
              ~ destination = {
                  ~ name      = null -> ""
                    # (2 unchanged attributes hidden)
                }
              ~ sources     = [
                  ~ {
                      + path           = "."
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      + path           = "."
                        # (4 unchanged attributes hidden)
                    },
                    {
                        kustomize      = {}
                        path           = "clusters/homelab/apps/deluge"
                        repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                        targetRevision = "main"
                    },
                ]
                # (3 unchanged attributes hidden)
            }
            # (3 unchanged attributes hidden)
        }
      ~ object          = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
              ~ sources              = [
                  ~ {
                        name           = null
                      + path           = (known after apply)
                        # (8 unchanged attributes hidden)
                    },
                  ~ {
                        name           = null
                      + path           = (known after apply)
                        # (8 unchanged attributes hidden)
                    },
                    {
                        chart          = null
                        directory      = {
                            exclude = null
                            include = null
                            jsonnet = {
                                extVars = null
                                libs    = null
                                tlas    = null
                            }
                            recurse = null
                        }
                        helm           = {
                            apiVersions             = null
                            fileParameters          = null
                            ignoreMissingValueFiles = null
                            kubeVersion             = null
                            namespace               = null
                            parameters              = null
                            passCredentials         = null
                            releaseName             = null
                            skipCrds                = null
                            skipSchemaValidation    = null
                            skipTests               = null
                            valueFiles              = null
                            values                  = null
                            valuesObject            = null
                            version                 = null
                        }
                        kustomize      = {
                            apiVersions               = null
                            commonAnnotations         = null
                            commonAnnotationsEnvsubst = null
                            commonLabels              = null
                            components                = null
                            forceCommonAnnotations    = null
                            forceCommonLabels         = null
                            ignoreMissingComponents   = null
                            images                    = null
                            kubeVersion               = null
                            labelIncludeTemplates     = null
                            labelWithoutSelector      = null
                            namePrefix                = null
                            nameSuffix                = null
                            namespace                 = null
                            patches                   = null
                            replicas                  = null
                            version                   = null
                        }
                        name           = null
                        path           = "clusters/homelab/apps/deluge"
                        plugin         = {
                            env        = null
                            name       = null
                            parameters = null
                        }
                        ref            = null
                        repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                        targetRevision = "main"
                    },
                ]
                # (7 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Changes to Outputs:
  ~ manifest  = {
      ~ spec       = {
          ~ destination = {
              ~ name      = null -> ""
                # (2 unchanged attributes hidden)
            }
          ~ sources     = [
              ~ {
                  + path           = "."
                    # (4 unchanged attributes hidden)
                },
              ~ {
                  + path           = "."
                    # (4 unchanged attributes hidden)
                },
                {
                    kustomize      = {}
                    path           = "clusters/homelab/apps/deluge"
                    repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                    targetRevision = "main"
                },
            ]
            # (3 unchanged attributes hidden)
        }
        # (3 unchanged attributes hidden)
    }
~~~~

</details>

<details>
<summary>Argo CD Application: descheduler</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      + computed_fields = [
          + "metadata.annotations",
          + "metadata.labels",
          + "spec.destination.name",
          + "spec.sources[0].path",
          + "spec.sources[1].path",
          + "spec.sources[2].path",
        ]
      ~ manifest        = {
          ~ spec       = {
              ~ destination = {
                  ~ name      = null -> ""
                    # (2 unchanged attributes hidden)
                }
              ~ sources     = [
                  ~ {
                      + path           = "."
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      + path           = "."
                        # (4 unchanged attributes hidden)
                    },
                    {
                        kustomize      = {}
                        path           = "clusters/homelab/apps/descheduler"
                        repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                        targetRevision = "main"
                    },
                ]
                # (2 unchanged attributes hidden)
            }
            # (3 unchanged attributes hidden)
        }
      ~ object          = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
              ~ sources              = [
                  ~ {
                        name           = null
                      + path           = (known after apply)
                        # (8 unchanged attributes hidden)
                    },
                  ~ {
                        name           = null
                      + path           = (known after apply)
                        # (8 unchanged attributes hidden)
                    },
                    {
                        chart          = null
                        directory      = {
                            exclude = null
                            include = null
                            jsonnet = {
                                extVars = null
                                libs    = null
                                tlas    = null
                            }
                            recurse = null
                        }
                        helm           = {
                            apiVersions             = null
                            fileParameters          = null
                            ignoreMissingValueFiles = null
                            kubeVersion             = null
                            namespace               = null
                            parameters              = null
                            passCredentials         = null
                            releaseName             = null
                            skipCrds                = null
                            skipSchemaValidation    = null
                            skipTests               = null
                            valueFiles              = null
                            values                  = null
                            valuesObject            = null
                            version                 = null
                        }
                        kustomize      = {
                            apiVersions               = null
                            commonAnnotations         = null
                            commonAnnotationsEnvsubst = null
                            commonLabels              = null
                            components                = null
                            forceCommonAnnotations    = null
                            forceCommonLabels         = null
                            ignoreMissingComponents   = null
                            images                    = null
                            kubeVersion               = null
                            labelIncludeTemplates     = null
                            labelWithoutSelector      = null
                            namePrefix                = null
                            nameSuffix                = null
                            namespace                 = null
                            patches                   = null
                            replicas                  = null
                            version                   = null
                        }
                        name           = null
                        path           = "clusters/homelab/apps/descheduler"
                        plugin         = {
                            env        = null
                            name       = null
                            parameters = null
                        }
                        ref            = null
                        repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                        targetRevision = "main"
                    },
                ]
                # (7 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Changes to Outputs:
  ~ manifest  = {
      ~ spec       = {
          ~ destination = {
              ~ name      = null -> ""
                # (2 unchanged attributes hidden)
            }
          ~ sources     = [
              ~ {
                  + path           = "."
                    # (4 unchanged attributes hidden)
                },
              ~ {
                  + path           = "."
                    # (4 unchanged attributes hidden)
                },
                {
                    kustomize      = {}
                    path           = "clusters/homelab/apps/descheduler"
                    repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                    targetRevision = "main"
                },
            ]
            # (2 unchanged attributes hidden)
        }
        # (3 unchanged attributes hidden)
    }
~~~~

</details>

<details>
<summary>Argo CD Application: external-secrets</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      + computed_fields = [
          + "metadata.annotations",
          + "metadata.labels",
          + "spec.destination.name",
          + "spec.sources[0].path",
          + "spec.sources[1].path",
          + "spec.sources[2].path",
        ]
      ~ manifest        = {
          ~ spec       = {
              ~ destination = {
                  ~ name      = null -> ""
                    # (2 unchanged attributes hidden)
                }
              ~ sources     = [
                  ~ {
                      + path           = "."
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      + path           = "."
                        # (4 unchanged attributes hidden)
                    },
                    {
                        kustomize      = {}
                        path           = "clusters/homelab/apps/external-secrets"
                        repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                        targetRevision = "main"
                    },
                ]
                # (3 unchanged attributes hidden)
            }
            # (3 unchanged attributes hidden)
        }
      ~ object          = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
              ~ sources              = [
                  ~ {
                        name           = null
                      + path           = (known after apply)
                        # (8 unchanged attributes hidden)
                    },
                  ~ {
                        name           = null
                      + path           = (known after apply)
                        # (8 unchanged attributes hidden)
                    },
                    {
                        chart          = null
                        directory      = {
                            exclude = null
                            include = null
                            jsonnet = {
                                extVars = null
                                libs    = null
                                tlas    = null
                            }
                            recurse = null
                        }
                        helm           = {
                            apiVersions             = null
                            fileParameters          = null
                            ignoreMissingValueFiles = null
                            kubeVersion             = null
                            namespace               = null
                            parameters              = null
                            passCredentials         = null
                            releaseName             = null
                            skipCrds                = null
                            skipSchemaValidation    = null
                            skipTests               = null
                            valueFiles              = null
                            values                  = null
                            valuesObject            = null
                            version                 = null
                        }
                        kustomize      = {
                            apiVersions               = null
                            commonAnnotations         = null
                            commonAnnotationsEnvsubst = null
                            commonLabels              = null
                            components                = null
                            forceCommonAnnotations    = null
                            forceCommonLabels         = null
                            ignoreMissingComponents   = null
                            images                    = null
                            kubeVersion               = null
                            labelIncludeTemplates     = null
                            labelWithoutSelector      = null
                            namePrefix                = null
                            nameSuffix                = null
                            namespace                 = null
                            patches                   = null
                            replicas                  = null
                            version                   = null
                        }
                        name           = null
                        path           = "clusters/homelab/apps/external-secrets"
                        plugin         = {
                            env        = null
                            name       = null
                            parameters = null
                        }
                        ref            = null
                        repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                        targetRevision = "main"
                    },
                ]
                # (7 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Changes to Outputs:
  ~ manifest  = {
      ~ spec       = {
          ~ destination = {
              ~ name      = null -> ""
                # (2 unchanged attributes hidden)
            }
          ~ sources     = [
              ~ {
                  + path           = "."
                    # (4 unchanged attributes hidden)
                },
              ~ {
                  + path           = "."
                    # (4 unchanged attributes hidden)
                },
                {
                    kustomize      = {}
                    path           = "clusters/homelab/apps/external-secrets"
                    repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                    targetRevision = "main"
                },
            ]
            # (3 unchanged attributes hidden)
        }
        # (3 unchanged attributes hidden)
    }
~~~~

</details>

<details>
<summary>Argo CD Application: grafana</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      + computed_fields = [
          + "metadata.annotations",
          + "metadata.labels",
          + "spec.destination.name",
          + "spec.sources[0].path",
          + "spec.sources[1].path",
          + "spec.sources[2].path",
        ]
      ~ manifest        = {
          ~ spec       = {
              ~ destination = {
                  ~ name      = null -> ""
                    # (2 unchanged attributes hidden)
                }
              ~ sources     = [
                  ~ {
                      + path           = "."
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      + path           = "."
                        # (4 unchanged attributes hidden)
                    },
                    {
                        kustomize      = {}
                        path           = "clusters/homelab/apps/grafana"
                        repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                        targetRevision = "main"
                    },
                ]
                # (3 unchanged attributes hidden)
            }
            # (3 unchanged attributes hidden)
        }
      ~ object          = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
              ~ sources              = [
                  ~ {
                        name           = null
                      + path           = (known after apply)
                        # (8 unchanged attributes hidden)
                    },
                  ~ {
                        name           = null
                      + path           = (known after apply)
                        # (8 unchanged attributes hidden)
                    },
                    {
                        chart          = null
                        directory      = {
                            exclude = null
                            include = null
                            jsonnet = {
                                extVars = null
                                libs    = null
                                tlas    = null
                            }
                            recurse = null
                        }
                        helm           = {
                            apiVersions             = null
                            fileParameters          = null
                            ignoreMissingValueFiles = null
                            kubeVersion             = null
                            namespace               = null
                            parameters              = null
                            passCredentials         = null
                            releaseName             = null
                            skipCrds                = null
                            skipSchemaValidation    = null
                            skipTests               = null
                            valueFiles              = null
                            values                  = null
                            valuesObject            = null
                            version                 = null
                        }
                        kustomize      = {
                            apiVersions               = null
                            commonAnnotations         = null
                            commonAnnotationsEnvsubst = null
                            commonLabels              = null
                            components                = null
                            forceCommonAnnotations    = null
                            forceCommonLabels         = null
                            ignoreMissingComponents   = null
                            images                    = null
                            kubeVersion               = null
                            labelIncludeTemplates     = null
                            labelWithoutSelector      = null
                            namePrefix                = null
                            nameSuffix                = null
                            namespace                 = null
                            patches                   = null
                            replicas                  = null
                            version                   = null
                        }
                        name           = null
                        path           = "clusters/homelab/apps/grafana"
                        plugin         = {
                            env        = null
                            name       = null
                            parameters = null
                        }
                        ref            = null
                        repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                        targetRevision = "main"
                    },
                ]
                # (7 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
~~~~

</details>

<details>
<summary>Argo CD Application: hummingbot</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      + computed_fields = [
          + "metadata.annotations",
          + "metadata.labels",
          + "spec.destination.name",
          + "spec.sources[0].path",
        ]
      ~ manifest        = {
          ~ spec       = {
              ~ destination = {
                  ~ name      = null -> ""
                    # (2 unchanged attributes hidden)
                }
                # (4 unchanged attributes hidden)
            }
            # (3 unchanged attributes hidden)
        }
      ~ object          = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
                # (8 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Changes to Outputs:
  ~ manifest  = {
      ~ spec       = {
          ~ destination = {
              ~ name      = null -> ""
                # (2 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }
        # (3 unchanged attributes hidden)
    }
~~~~

</details>

<details>
<summary>Argo CD Application: istio</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      + computed_fields = [
          + "metadata.annotations",
          + "metadata.labels",
          + "spec.destination.name",
          + "spec.sources[0].path",
          + "spec.sources[1].path",
          + "spec.sources[2].path",
          + "spec.sources[3].path",
          + "spec.sources[4].path",
          + "spec.sources[5].path",
          + "spec.sources[6].path",
        ]
      ~ manifest        = {
          ~ spec       = {
              ~ destination       = {
                  ~ name      = null -> ""
                    # (2 unchanged attributes hidden)
                }
              ~ sources           = [
                  ~ {
                      + path           = "."
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      + path           = "."
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      + path           = "."
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      + path           = "."
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      + path           = "."
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      + path           = "."
                        # (4 unchanged attributes hidden)
                    },
                    {
                        kustomize      = {}
                        path           = "clusters/homelab/apps/istio"
                        repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                        targetRevision = "main"
                    },
                ]
                # (4 unchanged attributes hidden)
            }
            # (3 unchanged attributes hidden)
        }
      ~ object          = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
              ~ sources              = [
                  ~ {
                        name           = null
                      + path           = (known after apply)
                        # (8 unchanged attributes hidden)
                    },
                  ~ {
                        name           = null
                      + path           = (known after apply)
                        # (8 unchanged attributes hidden)
                    },
                  ~ {
                        name           = null
                      + path           = (known after apply)
                        # (8 unchanged attributes hidden)
                    },
                  ~ {
                        name           = null
                      + path           = (known after apply)
                        # (8 unchanged attributes hidden)
                    },
                  ~ {
                        name           = null
                      + path           = (known after apply)
                        # (8 unchanged attributes hidden)
                    },
                  ~ {
                        name           = null
                      + path           = (known after apply)
                        # (8 unchanged attributes hidden)
                    },
                    {
                        chart          = null
                        directory      = {
                            exclude = null
                            include = null
                            jsonnet = {
                                extVars = null
                                libs    = null
                                tlas    = null
                            }
                            recurse = null
                        }
                        helm           = {
                            apiVersions             = null
                            fileParameters          = null
                            ignoreMissingValueFiles = null
                            kubeVersion             = null
                            namespace               = null
                            parameters              = null
                            passCredentials         = null
                            releaseName             = null
                            skipCrds                = null
                            skipSchemaValidation    = null
                            skipTests               = null
                            valueFiles              = null
                            values                  = null
                            valuesObject            = null
                            version                 = null
                        }
                        kustomize      = {
                            apiVersions               = null
                            commonAnnotations         = null
                            commonAnnotationsEnvsubst = null
                            commonLabels              = null
                            components                = null
                            forceCommonAnnotations    = null
                            forceCommonLabels         = null
                            ignoreMissingComponents   = null
                            images                    = null
                            kubeVersion               = null
                            labelIncludeTemplates     = null
                            labelWithoutSelector      = null
                            namePrefix                = null
                            nameSuffix                = null
                            namespace                 = null
                            patches                   = null
                            replicas                  = null
                            version                   = null
                        }
                        name           = null
                        path           = "clusters/homelab/apps/istio"
                        plugin         = {
                            env        = null
                            name       = null
                            parameters = null
                        }
                        ref            = null
                        repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                        targetRevision = "main"
                    },
                ]
                # (7 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Changes to Outputs:
  ~ manifest  = {
      ~ spec       = {
          ~ destination       = {
              ~ name      = null -> ""
                # (2 unchanged attributes hidden)
            }
          ~ sources           = [
              ~ {
                  + path           = "."
                    # (4 unchanged attributes hidden)
                },
              ~ {
                  + path           = "."
                    # (4 unchanged attributes hidden)
                },
              ~ {
                  + path           = "."
                    # (4 unchanged attributes hidden)
                },
              ~ {
                  + path           = "."
                    # (4 unchanged attributes hidden)
                },
              ~ {
                  + path           = "."
                    # (4 unchanged attributes hidden)
                },
              ~ {
                  + path           = "."
                    # (4 unchanged attributes hidden)
                },
                {
                    kustomize      = {}
                    path           = "clusters/homelab/apps/istio"
                    repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                    targetRevision = "main"
                },
            ]
            # (4 unchanged attributes hidden)
        }
        # (3 unchanged attributes hidden)
    }
~~~~

</details>

<details>
<summary>Argo CD Application: kiali</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be created
  + resource "kubernetes_manifest" "this" {
      + computed_fields = [
          + "metadata.annotations",
          + "metadata.labels",
          + "spec.destination.name",
          + "spec.sources[0].path",
          + "spec.sources[1].path",
          + "spec.sources[2].path",
        ]
      + manifest        = {
          + apiVersion = "argoproj.io/v1alpha1"
          + kind       = "Application"
          + metadata   = {
              + labels    = {
                  + "app.kubernetes.io/managed-by" = "terragrunt"
                  + "app.kubernetes.io/part-of"    = "homelab"
                }
              + name      = "kiali"
              + namespace = "argocd"
            }
          + spec       = {
              + destination = {
                  + name      = ""
                  + namespace = "istio-system"
                  + server    = "https://kubernetes.default.svc"
                }
              + info        = [
                  + {
                      + name  = "ingress"
                      + value = "docs/networking-tailnet-ingress.md"
                    },
                  + {
                      + name  = "auth"
                      + value = "anonymous read-only; tailnet-only"
                    },
                ]
              + project     = "homelab"
              + sources     = [
                  + {
                      + chart          = "kiali-operator"
                      + helm           = {
                          + releaseName = "kiali-operator"
                          + valueFiles  = [
                              + "$values/clusters/homelab/apps/kiali/values.yaml",
                            ]
                        }
                      + path           = "."
                      + repoURL        = "https://kiali.org/helm-charts"
                      + targetRevision = "2.26.0"
                    },
                  + {
                      + directory      = {
                          + include = ".argocd-values-ref-placeholder.yaml"
                        }
                      + path           = "."
                      + ref            = "values"
                      + repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                      + targetRevision = "main"
                    },
                  + {
                      + kustomize      = {}
                      + path           = "clusters/homelab/apps/kiali"
                      + repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                      + targetRevision = "main"
                    },
                ]
              + syncPolicy  = {
                  + automated   = {
                      + allowEmpty = false
                      + enabled    = true
                      + prune      = true
                      + selfHeal   = true
                    }
                  + retry       = {
                      + backoff = {
                          + duration    = "30s"
                          + factor      = "2"
                          + maxDuration = "2m"
                        }
                      + limit   = "5"
                    }
                  + syncOptions = [
                      + "CreateNamespace=true",
                      + "ServerSideApply=true",
                    ]
                }
            }
        }
      + object          = {
          + apiVersion = "argoproj.io/v1alpha1"
          + kind       = "Application"
          + metadata   = {
              + annotations                = (known after apply)
              + creationTimestamp          = (known after apply)
              + deletionGracePeriodSeconds = (known after apply)
              + deletionTimestamp          = (known after apply)
              + finalizers                 = (known after apply)
              + generateName               = (known after apply)
              + generation                 = (known after apply)
              + labels                     = (known after apply)
              + managedFields              = (known after apply)
              + name                       = "kiali"
              + namespace                  = "argocd"
              + ownerReferences            = (known after apply)
              + resourceVersion            = (known after apply)
              + selfLink                   = (known after apply)
              + uid                        = (known after apply)
            }
          + operation  = {
              + info        = (known after apply)
              + initiatedBy = {
                  + automated = (known after apply)
                  + username  = (known after apply)
                }
              + retry       = {
                  + backoff = {
                      + duration    = (known after apply)
                      + factor      = (known after apply)
                      + maxDuration = (known after apply)
                    }
                  + limit   = (known after apply)
                  + refresh = (known after apply)
                }
              + sync        = {
                  + autoHealAttemptsCount = (known after apply)
                  + dryRun                = (known after apply)
                  + manifests             = (known after apply)
                  + prune                 = (known after apply)
                  + resources             = (known after apply)
                  + revision              = (known after apply)
                  + revisions             = (known after apply)
                  + source                = {
                      + chart          = (known after apply)
                      + directory      = {
                          + exclude = (known after apply)
                          + include = (known after apply)
                          + jsonnet = {
                              + extVars = (known after apply)
                              + libs    = (known after apply)
                              + tlas    = (known after apply)
                            }
                          + recurse = (known after apply)
                        }
                      + helm           = {
                          + apiVersions             = (known after apply)
                        

> Plan output was truncated to keep the pull request description within GitHub limits. Re-run `nix develop --command bash scripts/ci/terragrunt-plan.sh` locally for the full saved plan output.

<!-- terragrunt-plan:end -->
