### PR TITLE
fix: make terragrunt apply non-interactive

### DIFF
--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -58,9 +58,9 @@ run the static checks and Conftest only.
   bootstrap Argo CD, apply SSM parameter declarations, apply Entra application
   registrations, apply Argo CD Application registrations serially, and finally
   materialize Kubernetes Secrets from SSM. Stack-wide apply phases use
-  Terragrunt's explicit `run --all -- apply ...` form so OpenTofu flags such as
-  `-auto-approve` are forwarded to OpenTofu instead of being parsed as
-  Terragrunt CLI flags.
+  Terragrunt's explicit `run --all --non-interactive -- apply ...` form so the
+  run queue is accepted in Actions and OpenTofu flags such as `-auto-approve`
+  are forwarded to OpenTofu instead of being parsed as Terragrunt CLI flags.
 
 References:
 

--- a/docs/knowledge-base/operations/change-log.md
+++ b/docs/knowledge-base/operations/change-log.md
@@ -10,6 +10,13 @@ Use [[templates/knowledge-update]] for new entries.
 
 ## Entries
 
+### 2026-05-26 - Make Terragrunt apply non-interactive
+
+- Added `--non-interactive` to stack-wide production apply phases so
+  Terragrunt accepts the `run --all` apply queue in GitHub Actions before
+  forwarding OpenTofu flags.
+- Updated the CI/CD runbook note with the final non-interactive command shape.
+
 ### 2026-05-26 - Enable OpenClaw memory wiki
 
 - Enabled OpenClaw's bundled `memory-wiki` plugin during pod startup bootstrap

--- a/docs/knowledge-base/runbooks/ci-cd.md
+++ b/docs/knowledge-base/runbooks/ci-cd.md
@@ -35,9 +35,10 @@ Source: `docs/ci-cd.md`
   managed KMS, IAM, and SSM resources that require the protected apply role.
   They also skip `IaC/live/kubernetes-secrets`; protected apply runs those
   stacks after review.
-- Stack-wide apply phases use Terragrunt's explicit `run --all -- apply ...`
-  form so OpenTofu flags such as `-auto-approve` are forwarded to OpenTofu
-  instead of being parsed as Terragrunt CLI flags.
+- Stack-wide apply phases use Terragrunt's explicit
+  `run --all --non-interactive -- apply ...` form so the run queue is accepted
+  in Actions and OpenTofu flags such as `-auto-approve` are forwarded to
+  OpenTofu instead of being parsed as Terragrunt CLI flags.
 
 ## Environments
 

--- a/scripts/ci/terragrunt-apply.sh
+++ b/scripts/ci/terragrunt-apply.sh
@@ -38,7 +38,7 @@ echo "::group::AzureAD application registration apply"
 if azuread_credentials_available; then
   (
     cd IaC/live/azuread-applications
-    terragrunt run --all --parallelism 1 --source-update -- apply -no-color -auto-approve
+    terragrunt run --all --non-interactive --parallelism 1 --source-update -- apply -no-color -auto-approve
   )
 elif azuread_stack_changed; then
   echo "AzureAD credentials are required because IaC/live/azuread-applications changed or the apply diff could not be determined." >&2
@@ -52,13 +52,13 @@ echo "::endgroup::"
 echo "::group::Argo CD Application registration apply"
 (
   cd IaC/live/argocd-apps
-  terragrunt run --all --parallelism 1 --source-update -- apply -no-color -auto-approve
+  terragrunt run --all --non-interactive --parallelism 1 --source-update -- apply -no-color -auto-approve
 )
 echo "::endgroup::"
 
 echo "::group::Kubernetes secret materialization apply"
 (
   cd IaC/live/kubernetes-secrets
-  terragrunt run --all --parallelism 1 --source-update -- apply -no-color -auto-approve
+  terragrunt run --all --non-interactive --parallelism 1 --source-update -- apply -no-color -auto-approve
 )
 echo "::endgroup::"


### PR DESCRIPTION
## Summary
- add Terragrunt --non-interactive to stack-wide production apply phases
- keep OpenTofu -auto-approve after -- so it is forwarded to apply
- document the final CI command shape in CI/CD docs and the knowledge base

## Validation
- bash -n scripts/ci/terragrunt-apply.sh
- git diff --check
- nix develop --command bash scripts/ci/static-checks.sh
- nix develop --command bash scripts/ci/conftest-policies.sh

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `d0ce1aa13c047afb99159b1fbc7d04f880e59f47`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

<details>
<summary>Argo CD bootstrap</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: argocd-image-updater</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: cert-manager</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: deluge</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: descheduler</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: external-secrets</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: grafana</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be updated in-place
  ~ resource "kubernetes_manifest" "this" {
      + computed_fields = [
          + "metadata.annotations",
          + "metadata.labels",
          + "spec.destination.name",
          + "spec.sources[0].path",
          + "spec.sources[1].path",
          + "spec.sources[2].path",
        ]
      ~ manifest        = {
          ~ spec       = {
              ~ destination = {
                  ~ name      = null -> ""
                    # (2 unchanged attributes hidden)
                }
              ~ sources     = [
                  ~ {
                      + path           = "."
                        # (4 unchanged attributes hidden)
                    },
                  ~ {
                      + path           = "."
                        # (4 unchanged attributes hidden)
                    },
                    {
                        kustomize      = {}
                        path           = "clusters/homelab/apps/grafana"
                        repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                        targetRevision = "main"
                    },
                ]
                # (3 unchanged attributes hidden)
            }
            # (3 unchanged attributes hidden)
        }
      ~ object          = {
          ~ spec       = {
              ~ destination          = {
                  + name      = (known after apply)
                    # (2 unchanged attributes hidden)
                }
              ~ sources              = [
                  ~ {
                        name           = null
                      + path           = (known after apply)
                        # (8 unchanged attributes hidden)
                    },
                  ~ {
                        name           = null
                      + path           = (known after apply)
                        # (8 unchanged attributes hidden)
                    },
                    {
                        chart          = null
                        directory      = {
                            exclude = null
                            include = null
                            jsonnet = {
                                extVars = null
                                libs    = null
                                tlas    = null
                            }
                            recurse = null
                        }
                        helm           = {
                            apiVersions             = null
                            fileParameters          = null
                            ignoreMissingValueFiles = null
                            kubeVersion             = null
                            namespace               = null
                            parameters              = null
                            passCredentials         = null
                            releaseName             = null
                            skipCrds                = null
                            skipSchemaValidation    = null
                            skipTests               = null
                            valueFiles              = null
                            values                  = null
                            valuesObject            = null
                            version                 = null
                        }
                        kustomize      = {
                            apiVersions               = null
                            commonAnnotations         = null
                            commonAnnotationsEnvsubst = null
                            commonLabels              = null
                            components                = null
                            forceCommonAnnotations    = null
                            forceCommonLabels         = null
                            ignoreMissingComponents   = null
                            images                    = null
                            kubeVersion               = null
                            labelIncludeTemplates     = null
                            labelWithoutSelector      = null
                            namePrefix                = null
                            nameSuffix                = null
                            namespace                 = null
                            patches                   = null
                            replicas                  = null
                            version                   = null
                        }
                        name           = null
                        path           = "clusters/homelab/apps/grafana"
                        plugin         = {
                            env        = null
                            name       = null
                            parameters = null
                        }
                        ref            = null
                        repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                        targetRevision = "main"
                    },
                ]
                # (7 unchanged attributes hidden)
            }
            # (4 unchanged attributes hidden)
        }

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
~~~~

</details>

<details>
<summary>Argo CD Application: hummingbot</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: istio</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: kiali</summary>

~~~~text

OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

OpenTofu will perform the following actions:

  # kubernetes_manifest.this will be created
  + resource "kubernetes_manifest" "this" {
      + computed_fields = [
          + "metadata.annotations",
          + "metadata.labels",
          + "spec.destination.name",
          + "spec.sources[0].path",
          + "spec.sources[1].path",
          + "spec.sources[2].path",
        ]
      + manifest        = {
          + apiVersion = "argoproj.io/v1alpha1"
          + kind       = "Application"
          + metadata   = {
              + labels    = {
                  + "app.kubernetes.io/managed-by" = "terragrunt"
                  + "app.kubernetes.io/part-of"    = "homelab"
                }
              + name      = "kiali"
              + namespace = "argocd"
            }
          + spec       = {
              + destination = {
                  + name      = ""
                  + namespace = "istio-system"
                  + server    = "https://kubernetes.default.svc"
                }
              + info        = [
                  + {
                      + name  = "ingress"
                      + value = "docs/networking-tailnet-ingress.md"
                    },
                  + {
                      + name  = "auth"
                      + value = "anonymous read-only; tailnet-only"
                    },
                ]
              + project     = "homelab"
              + sources     = [
                  + {
                      + chart          = "kiali-operator"
                      + helm           = {
                          + releaseName = "kiali-operator"
                          + valueFiles  = [
                              + "$values/clusters/homelab/apps/kiali/values.yaml",
                            ]
                        }
                      + path           = "."
                      + repoURL        = "https://kiali.org/helm-charts"
                      + targetRevision = "2.26.0"
                    },
                  + {
                      + directory      = {
                          + include = ".argocd-values-ref-placeholder.yaml"
                        }
                      + path           = "."
                      + ref            = "values"
                      + repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                      + targetRevision = "main"
                    },
                  + {
                      + kustomize      = {}
                      + path           = "clusters/homelab/apps/kiali"
                      + repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                      + targetRevision = "main"
                    },
                ]
              + syncPolicy  = {
                  + automated   = {
                      + allowEmpty = false
                      + enabled    = true
                      + prune      = true
                      + selfHeal   = true
                    }
                  + retry       = {
                      + backoff = {
                          + duration    = "30s"
                          + factor      = "2"
                          + maxDuration = "2m"
                        }
                      + limit   = "5"
                    }
                  + syncOptions = [
                      + "CreateNamespace=true",
                      + "ServerSideApply=true",
                    ]
                }
            }
        }
      + object          = {
          + apiVersion = "argoproj.io/v1alpha1"
          + kind       = "Application"
          + metadata   = {
              + annotations                = (known after apply)
              + creationTimestamp          = (known after apply)
              + deletionGracePeriodSeconds = (known after apply)
              + deletionTimestamp          = (known after apply)
              + finalizers                 = (known after apply)
              + generateName               = (known after apply)
              + generation                 = (known after apply)
              + labels                     = (known after apply)
              + managedFields              = (known after apply)
              + name                       = "kiali"
              + namespace                  = "argocd"
              + ownerReferences            = (known after apply)
              + resourceVersion            = (known after apply)
              + selfLink                   = (known after apply)
              + uid                        = (known after apply)
            }
          + operation  = {
              + info        = (known after apply)
              + initiatedBy = {
                  + automated = (known after apply)
                  + username  = (known after apply)
                }
              + retry       = {
                  + backoff = {
                      + duration    = (known after apply)
                      + factor      = (known after apply)
                      + maxDuration = (known after apply)
                    }
                  + limit   = (known after apply)
                  + refresh = (known after apply)
                }
              + sync        = {
                  + autoHealAttemptsCount = (known after apply)
                  + dryRun                = (known after apply)
                  + manifests             = (known after apply)
                  + prune                 = (known after apply)
                  + resources             = (known after apply)
                  + revision              = (known after apply)
                  + revisions             = (known after apply)
                  + source                = {
                      + chart          = (known after apply)
                      + directory      = {
                          + exclude = (known after apply)
                          + include = (known after apply)
                          + jsonnet = {
                              + extVars = (known after apply)
                              + libs    = (known after apply)
                              + tlas    = (known after apply)
                            }
                          + recurse = (known after apply)
                        }
                      + helm           = {
                          + apiVersions             = (known after apply)
                          + fileParameters          = (known after apply)
                          + ignoreMissingValueFiles = (known after apply)
                          + kubeVersion             = (known after apply)
                          + namespace               = (known after apply)
                          + parameters              = (known after apply)
                          + passCredentials         = (known after apply)
                          + releaseName             = (known after apply)
                          + skipCrds                = (known after apply)
                          + skipSchemaValidation    = (known after apply)
                          + skipTests               = (known after apply)
                          + valueFiles              = (known after apply)
                          + values                  = (known after apply)
                          + valuesObject            = (known after apply)
                          + version                 = (known after apply)
                        }
                      + kustomize      = {
                          + apiVersions               = (known after apply)
                          + commonAnnotations         = (known after apply)
                          + commonAnnotationsEnvsubst = (known after apply)
                          + commonLabels              = (known after apply)
                          + components                = (known after apply)
                          + forceCommonAnnotations    = (known after apply)
                          + forceCommonLabels         = (known after apply)
                          + ignoreMissingComponents   = (known after apply)
                          + images                    = (known after apply)
                          + kubeVersion               = (known after apply)
                          + labelIncludeTemplates     = (known after apply)
                          + labelWithoutSelector      = (known after apply)
                          + namePrefix                = (known after apply)
                          + nameSuffix                = (known after apply)
                          + namespace                 = (known after apply)
                          + patches                   = (known after apply)
                          + replicas                  = (known after apply)
                          + version                   = (known after apply)
                        }
                      + name           = (known after apply)
                      + path           = (known after apply)
                      + plugin         = {
                          + env        = (known after apply)
                          + name       = (known after apply)
                          + parameters = (known after apply)
                        }
                      + ref            = (known after apply)
                      + repoURL        = (known after apply)
                      + targetRevision = (known after apply)
                    }
                  + sources               = (known after apply)
                  + syncOptions           = (known after apply)
                  + syncStrategy          = {
                      + apply = {
                          + force = (known after apply)
                        }
                      + hook  = {
                          + force = (known after apply)
                        }
                    }
                }
            }
          + spec       = {
              + destination          = {
                  + name      = (known after apply)
                  + namespace = "istio-system"
                  + server    = "https://kubernetes.default.svc"
                }
              + ignoreDifferences    = (known after apply)
              + info                 = [
                  + {
                      + name  = "ingress"
                      + value = "docs/networking-tailnet-ingress.md"
                    },
                  + {
                      + name  = "auth"
                      + value = "anonymous read-only; tailnet-only"
                    },
                ]
              + project              = "homelab"
              + revisionHistoryLimit = (known after apply)
              + source               = {
                  + chart          = (known after apply)
                  + directory      = {
                      + exclude = (known after apply)
                      + include = (known after apply)
                      + jsonnet = {
                          + extVars = (known after apply)
                          + libs    = (known after apply)
                          + tlas    = (known after apply)
                        }
                      + recurse = (known after apply)
                    }
                  + helm           = {
                      + apiVersions             = (known after apply)
                      + fileParameters          = (known after apply)
                      + ignoreMissingValueFiles = (known after apply)
                      + kubeVersion             = (known after apply)
                      + namespace               = (known after apply)
                      + parameters              = (known after apply)
                      + passCredentials         = (known after apply)
                      + releaseName             = (known after apply)
                      + skipCrds                = (known after apply)
                      + skipSchemaValidation    = (known after apply)
                      + skipTests               = (known after apply)
                      + valueFiles              = (known after apply)
                      + values                  = (known after apply)
                      + valuesObject            = (known after apply)
                      + version                 = (known after apply)
                    }
                  + kustomize      = {
                      + apiVersions               = (known after apply)
                      + commonAnnotations         = (known after apply)
                      + commonAnnotationsEnvsubst = (known after apply)
                      + commonLabels              = (known after apply)
                      + components                = (known after apply)
                      + forceCommonAnnotations    = (known after apply)
                      + forceCommonLabels         = (known after apply)
                      + ignoreMissingComponents   = (known after apply)
                      + images                    = (known after apply)
                      + kubeVersion               = (known after apply)
                      + labelIncludeTemplates     = (known after apply)
                      + labelWithoutSelector      = (known after apply)
                      + namePrefix                = (known after apply)
                      + nameSuffix                = (known after apply)
                      + namespace                 = (known after apply)
                      + patches                   = (known after apply)
                      + replicas                  = (known after apply)
                      + version                   = (known after apply)
                    }
                  + name           = (known after apply)
                  + path           = (known after apply)
                  + plugin         = {
                      + env        = (known after apply)
                      + name       = (known after apply)
                      + parameters = (known after apply)
                    }
                  + ref            = (known after apply)
                  + repoURL        = (known after apply)
                  + targetRevision = (known after apply)
                }
              + sourceHydrator       = {
                  + drySource  = {
                      + directory      = {
                          + exclude = (known after apply)
                          + include = (known after apply)
                          + jsonnet = {
                              + extVars = (known after apply)
                              + libs    = (known after apply)
                              + tlas    = (known after apply)
                            }
                          + recurse = (known after apply)
                        }
                      + helm           = {
                          + apiVersions             = (known after apply)
                          + fileParameters          = (known after apply)
                          + ignoreMissingValueFiles = (known after apply)
                          + kubeVersion             = (known after apply)
                          + namespace               = (known after apply)
                          + parameters              = (known after apply)
                          + passCredentials         = (known after apply)
                          + releaseName             = (known after apply)
                          + skipCrds                = (known after apply)
                          + skipSchemaValidation    = (known after apply)
                          + skipTests               = (known after apply)
                          + valueFiles              = (known after apply)
                          + values                  = (known after apply)
                          + valuesObject            = (known after apply)
                          + version                 = (known after apply)
                        }
                      + kustomize      = {
                          + apiVersions               = (known after apply)
                          + commonAnnotations         = (known after apply)
                          + commonAnnotationsEnvsubst = (known after apply)
                          + commonLabels              = (known after apply)
                          + components                = (known after apply)
                          + forceCommonAnnotations    = (known after apply)
                          + forceCommonLabels         = (known after apply)
                          + ignoreMissingComponents   = (known after apply)
                          + images                    = (known after apply)
                          + kubeVersion               = (known after apply)
                          + labelIncludeTemplates     = (known after apply)
                          + labelWithoutSelector      = (known after apply)
                          + namePrefix                = (known after apply)
                          + nameSuffix                = (known after apply)
                          + namespace                 = (known after apply)
                          + patches                   = (known after apply)
                          + replicas                  = (known after apply)
                          + version                   = (known after apply)
                        }
                      + path           = (known after apply)
                      + plugin         = {
                          + env        = (known after apply)
                          + name       = (known after apply)
                          + parameters = (known after apply)
                        }
                      + repoURL        = (known after apply)
                      + targetRevision = (known after apply)
                    }
                  + hydrateTo  = {
                      + targetBranch = (known after apply)
                    }
                  + syncSource = {
                      + path         = (known after apply)
                      + targetBranch = (known after apply)
                    }
                }
              + sources              = [
                  + {
                      + chart          = "kiali-operator"
                      + directory      = {
                          + exclude = (known after apply)
                          + include = (known after apply)
                          + jsonnet = {
                              + extVars = (known after apply)
                              + libs    = (known after apply)
                              + tlas    = (known after apply)
                            }
                          + recurse = (known after apply)
                        }
                      + helm           = {
                          + apiVersions             = (known after apply)
                          + fileParameters          = (known after apply)
                          + ignoreMissingValueFiles = (known after apply)
                          + kubeVersion             = (known after apply)
                          + namespace               = (known after apply)
                          + parameters              = (known after apply)
                          + passCredentials         = (known after apply)
                          + releaseName             = "kiali-operator"
                          + skipCrds                = (known after apply)
                          + skipSchemaValidation    = (known after apply)
                          + skipTests               = (known after apply)
                          + valueFiles              = [
                              + "$values/clusters/homelab/apps/kiali/values.yaml",
                            ]
                          + values                  = (known after apply)
                          + valuesObject            = (known after apply)
                          + version                 = (known after apply)
                        }
                      + kustomize      = {
                          + apiVersions               = (known after apply)
                          + commonAnnotations         = (known after apply)
                          + commonAnnotationsEnvsubst = (known after apply)
                          + commonLabels              = (known after apply)
                          + components                = (known after apply)
                          + forceCommonAnnotations    = (known after apply)
                          + forceCommonLabels         = (known after apply)
                          + ignoreMissingComponents   = (known after apply)
                          + images                    = (known after apply)
                          + kubeVersion               = (known after apply)
                          + labelIncludeTemplates     = (known after apply)
                          + labelWithoutSelector      = (known after apply)
                          + namePrefix                = (known after apply)
                          + nameSuffix                = (known after apply)
                          + namespace                 = (known after apply)
                          + patches                   = (known after apply)
                          + replicas                  = (known after apply)
                          + version                   = (known after apply)
                        }
                      + name           = (known after apply)
                      + path           = (known after apply)
                      + plugin         = {
                          + env        = (known after apply)
                          + name       = (known after apply)
                          + parameters = (known after apply)
                        }
                      + ref            = (known after apply)
                      + repoURL        = "https://kiali.org/helm-charts"
                      + targetRevision = "2.26.0"
                    },
                  + {
                      + chart          = (known after apply)
                      + directory      = {
                          + exclude = (known after apply)
                          + include = ".argocd-values-ref-placeholder.yaml"
                          + jsonnet = {
                              + extVars = (known after apply)
                              + libs    = (known after apply)
                              + tlas    = (known after apply)
                            }
                          + recurse = (known after apply)
                        }
                      + helm           = {
                          + apiVersions             = (known after apply)
                          + fileParameters          = (known after apply)
                          + ignoreMissingValueFiles = (known after apply)
                          + kubeVersion             = (known after apply)
                          + namespace               = (known after apply)
                          + parameters              = (known after apply)
                          + passCredentials         = (known after apply)
                          + releaseName             = (known after apply)
                          + skipCrds                = (known after apply)
                          + skipSchemaValidation    = (known after apply)
                          + skipTests               = (known after apply)
                          + valueFiles              = (known after apply)
                          + values                  = (known after apply)
                          + valuesObject            = (known after apply)
                          + version                 = (known after apply)
                        }
                      + kustomize      = {
                          + apiVersions               = (known after apply)
                          + commonAnnotations         = (known after apply)
                          + commonAnnotationsEnvsubst = (known after apply)
                          + commonLabels              = (known after apply)
                          + components                = (known after apply)
                          + forceCommonAnnotations    = (known after apply)
                          + forceCommonLabels         = (known after apply)
                          + ignoreMissingComponents   = (known after apply)
                          + images                    = (known after apply)
                          + kubeVersion               = (known after apply)
                          + labelIncludeTemplates     = (known after apply)
                          + labelWithoutSelector      = (known after apply)
                          + namePrefix                = (known after apply)
                          + nameSuffix                = (known after apply)
                          + namespace                 = (known after apply)
                          + patches                   = (known after apply)
                          + replicas                  = (known after apply)
                          + version                   = (known after apply)
                        }
                      + name           = (known after apply)
                      + path           = (known after apply)
                      + plugin         = {
                          + env        = (known after apply)
                          + name       = (known after apply)
                          + parameters = (known after apply)
                        }
                      + ref            = "values"
                      + repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                      + targetRevision = "main"
                    },
                  + {
                      + chart          = (known after apply)
                      + directory      = {
                          + exclude = (known after apply)
                          + include = (known after apply)
                          + jsonnet = {
                              + extVars = (known after apply)
                              + libs    = (known after apply)
                              + tlas    = (known after apply)
                            }
                          + recurse = (known after apply)
                        }
                      + helm           = {
                          + apiVersions             = (known after apply)
                          + fileParameters          = (known after apply)
                          + ignoreMissingValueFiles = (known after apply)
                          + kubeVersion             = (known after apply)
                          + namespace               = (known after apply)
                          + parameters              = (known after apply)
                          + passCredentials         = (known after apply)
                          + releaseName             = (known after apply)
                          + skipCrds                = (known after apply)
                          + skipSchemaValidation    = (known after apply)
                          + skipTests               = (known after apply)
                          + valueFiles              = (known after apply)
                          + values                  = (known after apply)
                          + valuesObject            = (known after apply)
                          + version                 = (known after apply)
                        }
                      + kustomize      = {
                          + apiVersions               = (known after apply)
                          + commonAnnotations         = (known after apply)
                          + commonAnnotationsEnvsubst = (known after apply)
                          + commonLabels              = (known after apply)
                          + components                = (known after apply)
                          + forceCommonAnnotations    = (known after apply)
                          + forceCommonLabels         = (known after apply)
                          + ignoreMissingComponents   = (known after apply)
                          + images                    = (known after apply)
                          + kubeVersion               = (known after apply)
                          + labelIncludeTemplates     = (known after apply)
                          + labelWithoutSelector      = (known after apply)
                          + namePrefix                = (known after apply)
                          + nameSuffix                = (known after apply)
                          + namespace                 = (known after apply)
                          + patches                   = (known after apply)
                          + replicas                  = (known after apply)
                          + version                   = (known after apply)
                        }
                      + name           = (known after apply)
                      + path           = (known after apply)
                      + plugin         = {
                          + env        = (known after apply)
                          + name       = (known after apply)
                          + parameters = (known after apply)
                        }
                      + ref            = (known after apply)
                      + repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                      + targetRevision = "main"
                    },
                ]
              + syncPolicy           = {
                  + automated                = {
                      + allowEmpty = false
                      + enabled    = true
                      + prune      = true
                      + selfHeal   = true
                    }
                  + managedNamespaceMetadata = {
                      + annotations = (known after apply)
                      + labels      = (known after apply)
                    }
                  + retry                    = {
                      + backoff = {
                          + duration    = "30s"
                          + factor      = 2
                          + maxDuration = "2m"
                        }
                      + limit   = 5
                      + refresh = (known after apply)
                    }
                  + syncOptions              = [
                      + "CreateNamespace=true",
                      + "ServerSideApply=true",
                    ]
                }
            }
        }

      + field_manager {
          + force_conflicts = true
          + name            = "terragrunt"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + id        = "argocd/kiali"
  + manifest  = {
      + apiVersion = "argoproj.io/v1alpha1"
      + kind       = "Application"
      + metadata   = {
          + labels    = {
              + "app.kubernetes.io/managed-by" = "terragrunt"
              + "app.kubernetes.io/part-of"    = "homelab"
            }
          + name      = "kiali"
          + namespace = "argocd"
        }
      + spec       = {
          + destination = {
              + name      = ""
              + namespace = "istio-system"
              + server    = "https://kubernetes.default.svc"
            }
          + info        = [
              + {
                  + name  = "ingress"
                  + value = "docs/networking-tailnet-ingress.md"
                },
              + {
                  + name  = "auth"
                  + value = "anonymous read-only; tailnet-only"
                },
            ]
          + project     = "homelab"
          + sources     = [
              + {
                  + chart          = "kiali-operator"
                  + helm           = {
                      + releaseName = "kiali-operator"
                      + valueFiles  = [
                          + "$values/clusters/homelab/apps/kiali/values.yaml",
                        ]
                    }
                  + path           = "."
                  + repoURL        = "https://kiali.org/helm-charts"
                  + targetRevision = "2.26.0"
                },
              + {
                  + directory      = {
                      + include = ".argocd-values-ref-placeholder.yaml"
                    }
                  + path           = "."
                  + ref            = "values"
                  + repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                  + targetRevision = "main"
                },
              + {
                  + kustomize      = {}
                  + path           = "clusters/homelab/apps/kiali"
                  + repoURL        = "https://github.com/Stuhlmuller/homelab.git"
                  + targetRevision = "main"
                },
            ]
          + syncPolicy  = {
              + automated   = {
                  + allowEmpty = false
                  + enabled    = true
                  + prune      = true
                  + selfHeal   = true
                }
              + retry       = {
                  + backoff = {
                      + duration    = "30s"
                      + factor      = "2"
                      + maxDuration = "2m"
                    }
                  + limit   = "5"
                }
              + syncOptions = [
                  + "CreateNamespace=true",
                  + "ServerSideApply=true",
                ]
            }
        }
    }
  + name      = "kiali"
  + namespace = "argocd"
~~~~

</details>

<details>
<summary>Argo CD Application: litellm</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: media-postgres</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: n8n</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: octobot</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: openclaw</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: platform-dns</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: platform-storage</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: policy-bot</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: prometheus</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: prowlarr</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: radarr</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: sonarr</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: tailscale</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>


<!-- terragrunt-plan:end -->
