### PR TITLE
fix(grafana): repair Argo CD sync

### DIFF
--- a/clusters/homelab/apps/grafana/README.md
+++ b/clusters/homelab/apps/grafana/README.md
@@ -39,6 +39,9 @@ present. Local admin login remains available through `grafana-admin`.
 - The Helm release uses a `Recreate` deployment strategy because Grafana stores
   SQLite state on a single PVC. Avoid overlapping old and new pods against the
   same database during rollouts.
+- The Deployment carries the Argo CD `Replace=true` sync option so Argo replaces
+  the Deployment instead of server-side applying stale `rollingUpdate` fields
+  when reconciling the `Recreate` strategy.
 - Datasource provisioning deletes the old `Prometheus` and `Alertmanager`
   entries before recreating them with stable UIDs. This handles first-rollout
   databases that already contain Grafana-generated datasource UIDs.

--- a/clusters/homelab/apps/grafana/values.yaml
+++ b/clusters/homelab/apps/grafana/values.yaml
@@ -4,6 +4,8 @@ admin:
   passwordKey: password
 deploymentStrategy:
   type: Recreate
+annotations:
+  argocd.argoproj.io/sync-options: Replace=true
 extraSecretMounts:
   - name: grafana-azuread-sso
     secretName: grafana-azuread-sso

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -65,6 +65,9 @@ Grafana is the reviewed metrics UI. It uses Microsoft Entra SSO from
 `IaC/live/azuread-applications/grafana`, provisions Prometheus and Alertmanager
 datasources, Homelab and Argo CD dashboards, and Grafana-managed alerts from
 repo-owned values. Discord webhook URL comes from SSM through External Secrets.
+Its Helm-rendered Deployment uses a resource-level Argo CD `Replace=true` sync
+option because the app keeps a `Recreate` strategy for the single Grafana PVC,
+and server-side apply can otherwise preserve stale `rollingUpdate` fields.
 
 ## Kiali
 


### PR DESCRIPTION
## Summary

This fixes the Grafana Argo CD Application sync failure caused by the live Deployment retaining stale `spec.strategy.rollingUpdate` fields while the desired Helm values now use `deploymentStrategy.type: Recreate`.

Grafana itself was still running and healthy, but Argo CD could not complete sync. The failed sync left the Application `OutOfSync`/`SyncError`, which makes the GitOps control plane noisy and can hide future real Grafana drift behind the same repeated error.

## Root Cause

The Grafana Application is configured with `ServerSideApply=true`, and the chart now renders the Deployment with a `Recreate` strategy so the single Grafana PVC is not mounted by overlapping old and new pods. The live Deployment still had the old `rollingUpdate` shape from its earlier `RollingUpdate` strategy. Kubernetes rejects a Deployment update that specifies `rollingUpdate` while `type` is `Recreate`, so Argo CD repeatedly failed on `Deployment/grafana`.

## Fix

The Grafana Helm values now set a resource-level Argo CD sync option on the rendered Deployment:

```yaml
annotations:
  argocd.argoproj.io/sync-options: Replace=true
```

That keeps the broader Application on server-side apply while allowing Argo CD to replace the Grafana Deployment and clear the stale strategy fields. The Grafana README and knowledge-base application notes now document why this Deployment uses replace semantics.

## Validation

Validated locally with:

- `helm template grafana grafana --repo https://grafana.github.io/helm-charts --version 10.5.15 --namespace monitoring --values clusters/homelab/apps/grafana/values.yaml --show-only templates/deployment.yaml`
- `/opt/homebrew/bin/kubectl kustomize clusters/homelab/apps/grafana`
- `git diff --check`
- `PATH=/opt/homebrew/bin:$PATH scripts/ci/static-checks.sh`
- `PATH=/opt/homebrew/bin:$PATH scripts/ci/conftest-policies.sh`

The rendered Deployment includes `argocd.argoproj.io/sync-options: Replace=true` and `strategy.type: Recreate` without `rollingUpdate`.


<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `166f4259f33cb12bd7dcc10b2d5716de3633fda0`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

<details>
<summary>Argo CD bootstrap</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: argocd-image-updater</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: cert-manager</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: deluge</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: descheduler</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: external-secrets</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: grafana</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: hummingbot</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: istio</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: kiali</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: litellm</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: media-postgres</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: n8n</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: octobot</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: openclaw</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: platform-dns</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: platform-storage</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: policy-bot</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: prometheus</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: prowlarr</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: radarr</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: sonarr</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: tailscale</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>


<!-- terragrunt-plan:end -->
