### PR TITLE
feat: advertise Tailscale LAN route

### DIFF
--- a/clusters/homelab/apps/tailscale/README.md
+++ b/clusters/homelab/apps/tailscale/README.md
@@ -35,7 +35,8 @@ readiness, or proxy Pod startup, roll back by reverting the chart
 
 `exit-node-connector.yaml` creates a cluster-scoped Tailscale `Connector` named
 `homelab-exit-node`. The operator creates one proxy device with hostname
-`homelab-exit-node`, tags it as `tag:k8s`, and advertises it as an exit node.
+`homelab-exit-node`, tags it as `tag:k8s`, advertises it as an exit node, and
+advertises the homelab LAN route `10.1.0.0/24`.
 
 Tailnet policy must allow the operator tag to own `tag:k8s`:
 
@@ -46,18 +47,21 @@ Tailnet policy must allow the operator tag to own `tag:k8s`:
 }
 ```
 
-To avoid manual approval after every recreation, auto-approve exit-node
-advertisement for `tag:k8s` in the Tailscale policy:
+To avoid manual approval after every recreation, auto-approve exit-node and
+subnet-route advertisement for `tag:k8s` in the Tailscale policy:
 
 ```json
 "autoApprovers": {
-  "exitNode": ["tag:k8s"]
+  "exitNode": ["tag:k8s"],
+  "routes": {
+    "10.1.0.0/24": ["tag:k8s"]
+  }
 }
 ```
 
 If auto-approval is not configured, approve `homelab-exit-node` as an exit node
-from the Machines page in the Tailscale admin console after Argo CD syncs this
-app.
+and approve the `10.1.0.0/24` route from the Machines page in the Tailscale
+admin console after Argo CD syncs this app.
 
 ## Validation
 
@@ -76,6 +80,8 @@ kubectl -n tailscale get statefulset,pod -l tailscale.com/parent-resource=homela
 ```
 
 Expected result: the connector reports `ISEXITNODE` as `true`, the connector
-condition is ready, and one operator-managed proxy Pod is running in the
-`tailscale` namespace. Then select `homelab-exit-node` as the exit node from a
-tailnet client and confirm the client egress IP changes to the homelab network.
+condition is ready, the advertised route includes `10.1.0.0/24`, and one
+operator-managed proxy Pod is running in the `tailscale` namespace. Then select
+`homelab-exit-node` as the exit node from a tailnet client and confirm the
+client egress IP changes to the homelab network while local homelab LAN
+addresses remain reachable.

--- a/clusters/homelab/apps/tailscale/exit-node-connector.yaml
+++ b/clusters/homelab/apps/tailscale/exit-node-connector.yaml
@@ -15,4 +15,4 @@ spec:
   exitNode: true
   subnetRouter:
     advertiseRoutes:
-      - 10.1.0.199/32
+      - 10.1.0.0/24

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -47,8 +47,9 @@ run the static checks and Conftest only.
   Kubernetes API endpoint without conflicting with the action's own login
   flags.
 - The workflow relies on the repo-owned `homelab-exit-node` connector's
-  advertised `10.1.0.199/32` subnet route for Kubernetes API access. It does
-  not select the connector as a full exit node, so public AWS STS/KMS calls keep
+  advertised `10.1.0.0/24` subnet route for Kubernetes API access, with
+  Tailscale grants limiting the CI runner tags to `10.1.0.199:6443`. It does not
+  select the connector as a full exit node, so public AWS STS/KMS calls keep
   using the GitHub-hosted runner's normal network path and DNS resolver.
 - Plans are not uploaded as artifacts because Terraform/OpenTofu plans can
   include sensitive state context. Trusted same-repository PR plans render the
@@ -121,17 +122,16 @@ admin panel permits tag scoping. In the tailnet policy, grant those tags only
 the cluster API path they need.
 
 The repository-owned `homelab-exit-node` Connector is tagged `tag:k8s`, acts as
-the current bootstrap exit node, and advertises `10.1.0.199/32` as the
-dedicated Kubernetes API route. Auto-approve the narrow route for `tag:k8s`
-when possible, and use grants to keep CI access limited to the API endpoint and
-port:
+the current bootstrap exit node, and advertises `10.1.0.0/24` as the homelab
+LAN route. Auto-approve the subnet route for `tag:k8s` when possible, and use
+grants to keep CI access limited to the Kubernetes API endpoint and port:
 
 ```json
 {
   "autoApprovers": {
     "exitNode": ["tag:k8s"],
     "routes": {
-      "10.1.0.199/32": ["tag:k8s"]
+      "10.1.0.0/24": ["tag:k8s"]
     }
   },
   "tagOwners": {

--- a/docs/knowledge-base/runbooks/ci-cd.md
+++ b/docs/knowledge-base/runbooks/ci-cd.md
@@ -74,11 +74,11 @@ CI uses tags:
 - `tag:github-actions-terragrunt-plan`
 - `tag:github-actions-terragrunt-apply`
 
-Use the repo-owned `homelab-exit-node` connector's advertised `10.1.0.199/32`
-route to reach the Kubernetes API. Do not select it as a full exit node in CI:
-Terragrunt still needs public AWS STS/KMS access, and routing that traffic
-through the tailnet path has caused runner DNS timeouts against `127.0.0.53`.
-Keep grants limited to TCP `6443`.
+Use the repo-owned `homelab-exit-node` connector's advertised `10.1.0.0/24`
+route to reach the Kubernetes API at `10.1.0.199:6443`. Do not select it as a
+full exit node in CI: Terragrunt still needs public AWS STS/KMS access, and
+routing that traffic through the tailnet path has caused runner DNS timeouts
+against `127.0.0.53`. Keep CI grants limited to TCP `6443` on the API host.
 
 ## Local Equivalents
 

--- a/docs/knowledge-base/runbooks/tailnet-ingress.md
+++ b/docs/knowledge-base/runbooks/tailnet-ingress.md
@@ -36,8 +36,9 @@ External Secrets.
 
 The `tailscale` Application installs the Tailscale operator and the
 `homelab-exit-node` Connector. The connector advertises itself as an exit node
-with tag `tag:k8s` and advertises `10.1.0.199/32` for CI access to the
-Kubernetes API.
+with tag `tag:k8s` and advertises `10.1.0.0/24` so tailnet clients can reach
+the homelab LAN. CI grants stay limited to `10.1.0.199:6443` for Kubernetes API
+access.
 
 Validation:
 

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -221,4 +221,5 @@ add a forward-auth layer first.
 The Tailscale app owns operator support resources, the privileged `tailscale`
 namespace, the `operator-oauth` ExternalSecret, and the `homelab-exit-node`
 Connector. Tailnet policy must allow `tag:k8s-operator` to own `tag:k8s` and
-auto-approve exit-node advertisement when possible.
+auto-approve exit-node and `10.1.0.0/24` subnet-route advertisement when
+possible.

--- a/docs/networking-tailnet-ingress.md
+++ b/docs/networking-tailnet-ingress.md
@@ -69,7 +69,7 @@ paper trading, and operator-reviewed live trading; exchange credentials and
 strategy state are configured through OctoBot and persist on its NFS-backed
 volumes, not in public repository files.
 
-## Homelab VPN Exit Node And API Route
+## Homelab VPN Exit Node And LAN Route
 
 Tailscale also provides the homelab VPN exit path. The `tailscale` Argo CD
 Application installs the upstream Tailscale Kubernetes Operator and applies the
@@ -80,12 +80,14 @@ The connector is cluster-scoped, creates one operator-managed proxy device, and
 advertises that device as a Tailscale exit node with hostname
 `homelab-exit-node` and tag `tag:k8s`. Tailnet clients can select that device as
 their exit node to route internet-bound traffic through the homelab cluster
-egress path. It also advertises the single-host `10.1.0.199/32` route so CI/CD
-runners can reach the Kubernetes API without exposing the rest of the LAN.
+egress path. It also advertises the `10.1.0.0/24` homelab LAN route so tailnet
+clients can reach local network services through the same operator-managed
+device. CI/CD grants still restrict GitHub-hosted runners to the Kubernetes API
+at `10.1.0.199:6443`.
 
 This repository cannot approve tailnet routes by itself. The tailnet policy must
 allow `tag:k8s-operator` to own `tag:k8s`, and either auto-approve exit-node
-and `10.1.0.199/32` route advertisement for `tag:k8s`, or rely on an admin
+and `10.1.0.0/24` route advertisement for `tag:k8s`, or rely on an admin
 manually approving `homelab-exit-node` and the advertised route in the Tailscale
 Machines page after sync.
 
@@ -98,11 +100,11 @@ kubectl -n tailscale get statefulset,pod -l tailscale.com/parent-resource=homela
 ```
 
 Expected result: the connector reports exit-node status and the
-`10.1.0.199/32` subnet route, its ready condition is true, and a single
-Tailscale proxy Pod is running. Then select `homelab-exit-node` on a client and
-verify the public egress IP changes to the homelab network. Keep local-network
-access enabled on clients that still need nearby LAN access while using the exit
-node.
+`10.1.0.0/24` subnet route, its ready condition is true, and a single Tailscale
+proxy Pod is running. Then select `homelab-exit-node` on a client and verify the
+public egress IP changes to the homelab network while homelab LAN addresses in
+`10.1.0.0/24` remain reachable. Keep local-network access enabled on clients
+that still need their nearby LAN access while using the exit node.
 
 ## Policy Bot Webhook Funnel Exception
 


### PR DESCRIPTION
## Summary

This change updates the repo-owned Tailscale Kubernetes Operator Connector so
`homelab-exit-node` advertises the full `10.1.0.0/24` homelab LAN instead of
only the Kubernetes API host route. The exit node remains tagged as `tag:k8s`
and still advertises itself as a Tailscale exit node.

## Issue

Tailnet clients using the homelab exit-node path could reach the narrowly
advertised Kubernetes API route, but the desired operator contract did not make
the rest of the local `10.1.0.0/24` network reachable through the same
Tailscale-managed device. That left local network access dependent on manual
client-side or tailnet-side behavior rather than the repository-owned desired
state.

## Cause And Effect

The Connector was configured with `10.1.0.199/32`, which is useful for CI and
cluster API access but does not advertise the rest of the homelab LAN. Users
selecting `homelab-exit-node` as their exit node would not get an explicit
subnet route for services on nearby homelab addresses such as NAS and node
addresses in the same `/24`.

## Root Cause

The original exit-node rollout modeled the minimum route needed for GitHub
Actions to reach the Kubernetes API. The route never grew with the operational
requirement that the exit node also provide local network access across the
entire homelab LAN.

## Fix

- Changed `clusters/homelab/apps/tailscale/exit-node-connector.yaml` to
  advertise `10.1.0.0/24`.
- Updated the Tailscale README and tailnet ingress runbook to document route
  approval for `10.1.0.0/24`.
- Updated the CI/CD docs and knowledge base to keep GitHub Actions access
  constrained to `10.1.0.199:6443` even though the Connector now advertises the
  wider subnet route.

After Argo CD syncs the Tailscale application, the tailnet policy still needs
to auto-approve the `10.1.0.0/24` route for `tag:k8s`, or an admin needs to
approve the route manually in the Tailscale Machines page.

## Validation

- `git diff --cached --check`
- Ruby YAML parse check confirming `exitNode=true` and
  `advertiseRoutes=["10.1.0.0/24"]`
- `yamllint` on the Tailscale YAML files; it returned only existing
  document-start warnings for files that already omit `---`
- `checkov --quiet --compact --skip-download -f clusters/homelab/apps/tailscale/exit-node-connector.yaml`
- Commit hooks: trailing whitespace, end-of-file fix, large-file check, YAML
  check, codespell, Checkov diff, Checkov secrets, and zizmor where applicable

Full `kubectl kustomize` and Nix-backed static checks were not run locally
because this shell does not have `kubectl` or `nix` on PATH.


<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `3ae279eca20d6d002a5afeedd6d55cb6008405c2`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

<details>
<summary>Argo CD bootstrap</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: argocd-image-updater</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: cert-manager</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: deluge</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: descheduler</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: external-secrets</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: grafana</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: hummingbot</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: istio</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: kiali</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: litellm</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: media-postgres</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: n8n</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: octobot</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: openclaw</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: platform-dns</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: platform-storage</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: policy-bot</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: prometheus</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: prowlarr</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: radarr</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: sonarr</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>

<details>
<summary>Argo CD Application: tailscale</summary>

~~~~text

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
~~~~

</details>


<!-- terragrunt-plan:end -->
