### PR TITLE
ci: use affected Terragrunt filters

### DIFF
--- a/.github/workflows/terragrunt-plan.yml
+++ b/.github/workflows/terragrunt-plan.yml
@@ -83,6 +83,7 @@ jobs:
         # actions/checkout@v5
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Install Nix

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -59,13 +59,20 @@ run the static checks and Conftest only.
   that unit refreshes managed KMS, IAM, and SSM resources that require the
   protected production apply role. They also skip `IaC/live/kubernetes-secrets`
   because that unit reads decrypted AWS SSM parameters.
+- Terragrunt plan and apply phases use `--filter-affected` so only units
+  changed between `main` and `HEAD` are queued. In CI, the helper script
+  prepares the local `main` ref for that comparison: pull request plans compare
+  against the PR base branch, while push applies compare against the previous
+  `main` SHA from the GitHub event. Manual apply dispatches compare against
+  `HEAD^`.
 - The protected post-merge apply runs the production phases explicitly:
   bootstrap Argo CD, apply SSM parameter declarations, apply Entra application
   registrations, apply Argo CD Application registrations serially, and finally
   materialize Kubernetes Secrets from SSM. Stack-wide apply phases use
-  Terragrunt's explicit `run --all --non-interactive -- apply ...` form so the
-  run queue is accepted in Actions and OpenTofu flags such as `-auto-approve`
-  are forwarded to OpenTofu instead of being parsed as Terragrunt CLI flags.
+  Terragrunt's explicit
+  `run --all --filter-affected --non-interactive -- apply ...` form so the run
+  queue is accepted in Actions and OpenTofu flags such as `-auto-approve` are
+  forwarded to OpenTofu instead of being parsed as Terragrunt CLI flags.
 
 References:
 
@@ -241,6 +248,10 @@ Kubernetes secret materialization stacks. To review those locally, assume the
 production apply role, install the kubeconfig, and run a focused
 `terragrunt plan` from the stack directory.
 
+The local scripts rely on your current `main` ref for Terragrunt's
+`--filter-affected` comparison. Update `main` first when you want local output
+to match the GitHub pull request or push diff.
+
 Set `TERRAGRUNT_PLAN_MARKDOWN=/path/to/terragrunt-plan.md` when running the PR
 plan script locally if you want the same rendered `plan.out` markdown that the
 workflow writes into pull request descriptions.
@@ -253,3 +264,6 @@ nix develop --command bash scripts/ci/static-checks.sh
 nix develop --command bash scripts/ci/conftest-policies.sh
 nix develop --command bash scripts/ci/terragrunt-apply.sh
 ```
+
+Manual apply dispatches compare against `HEAD^`; use the normal post-merge push
+path when the affected-unit range needs to span multiple commits.

--- a/docs/knowledge-base/operations/validation-gates.md
+++ b/docs/knowledge-base/operations/validation-gates.md
@@ -59,7 +59,7 @@ Implicit stack validation:
 
 ```sh
 cd IaC/live/argocd-apps
-terragrunt run --all --parallelism 1 --source-update plan -no-color
+terragrunt run --all --filter-affected --parallelism 1 --source-update -- plan -no-color
 ```
 
 The pull request workflow runs `scripts/ci/conftest-policies.sh` after the live

--- a/docs/knowledge-base/runbooks/ci-cd.md
+++ b/docs/knowledge-base/runbooks/ci-cd.md
@@ -39,10 +39,14 @@ Source: `docs/ci-cd.md`
   managed KMS, IAM, and SSM resources that require the protected apply role.
   They also skip `IaC/live/kubernetes-secrets`; protected apply runs those
   stacks after review.
+- Terragrunt plan and apply phases use `--filter-affected` so run queues are
+  limited to units changed between `main` and `HEAD`. In CI, the helper script
+  prepares `main` to mean the PR base branch for plans or the previous push SHA
+  for post-merge applies. Manual apply dispatches compare against `HEAD^`.
 - Stack-wide apply phases use Terragrunt's explicit
-  `run --all --non-interactive -- apply ...` form so the run queue is accepted
-  in Actions and OpenTofu flags such as `-auto-approve` are forwarded to
-  OpenTofu instead of being parsed as Terragrunt CLI flags.
+  `run --all --filter-affected --non-interactive -- apply ...` form so the run
+  queue is accepted in Actions and OpenTofu flags such as `-auto-approve` are
+  forwarded to OpenTofu instead of being parsed as Terragrunt CLI flags.
 
 ## Environments
 
@@ -88,6 +92,12 @@ nix develop --command bash scripts/ci/terragrunt-plan.sh
 nix develop --command bash scripts/ci/conftest-policies.sh
 nix develop --command bash scripts/ci/terragrunt-apply.sh
 ```
+
+Local runs use the current `main` ref for Terragrunt's affected-unit
+comparison. Refresh `main` before reproducing a GitHub plan or apply diff.
+
+Manual apply dispatches compare against `HEAD^`; use the normal post-merge push
+path when the affected range needs to span multiple commits.
 
 Run apply only after the same checks have passed and the change has been
 reviewed.

--- a/docs/knowledge-base/runbooks/validation.md
+++ b/docs/knowledge-base/runbooks/validation.md
@@ -16,11 +16,11 @@ nix develop --command bash scripts/ci/static-checks.sh
 cd IaC/live/aws-ssm-parameters
 terragrunt plan
 cd IaC/live/argocd-apps
-terragrunt run --all plan -no-color
+terragrunt run --all --filter-affected --parallelism 1 --source-update -- plan -no-color
 ```
 
-Expected app-registration plan currently references 18 requested Argo CD
-Applications plus `platform-dns`, `platform-storage`, and `media-postgres`.
+Expected app-registration plans include the Argo CD Application units affected
+by `main...HEAD`; unaffected units are skipped by the Terragrunt run queue.
 
 ## Render And Diff
 

--- a/docs/validation-runbook.md
+++ b/docs/validation-runbook.md
@@ -16,13 +16,12 @@ nix develop --command bash scripts/ci/static-checks.sh
 cd IaC/live/aws-ssm-parameters
 terragrunt plan
 cd IaC/live/argocd-apps
-terragrunt run --all plan -no-color
+terragrunt run --all --filter-affected --parallelism 1 --source-update -- plan -no-color
 ```
 
-Expected result: 18 requested Argo CD Applications plus the support
-Applications `platform-dns`, `platform-storage`, and `media-postgres` are
-planned, and every upstream relationship appears in a Terragrunt `dependencies`
-block.
+Expected result: the Argo CD Application units affected by `main...HEAD` are
+planned, their dependencies remain ordered by Terragrunt `dependencies` blocks,
+and unaffected units are skipped by the run queue.
 
 Render or dry-run GitOps sources:
 

--- a/scripts/ci/terragrunt-apply.sh
+++ b/scripts/ci/terragrunt-apply.sh
@@ -1,17 +1,22 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${script_dir}/terragrunt-filter-base.sh"
+
+prepare_terragrunt_filter_base
+
 echo "::group::Argo CD bootstrap apply"
 (
-  cd IaC/bootstrap/argocd
-  terragrunt --log-disable apply -no-color -auto-approve
+  cd IaC/bootstrap
+  terragrunt run --all --filter-affected --non-interactive --parallelism 1 -- apply -no-color -auto-approve
 )
 echo "::endgroup::"
 
 echo "::group::AWS SSM parameter declaration apply"
 (
   cd IaC/live/aws-ssm-parameters
-  terragrunt --log-disable apply -no-color -auto-approve
+  terragrunt run --all --filter-affected --non-interactive --parallelism 1 -- apply -no-color -auto-approve
 )
 echo "::endgroup::"
 
@@ -38,7 +43,7 @@ echo "::group::AzureAD application registration apply"
 if azuread_credentials_available; then
   (
     cd IaC/live/azuread-applications
-    terragrunt run --all --non-interactive --parallelism 1 --source-update -- apply -no-color -auto-approve
+    terragrunt run --all --filter-affected --non-interactive --parallelism 1 --source-update -- apply -no-color -auto-approve
   )
 elif azuread_stack_changed; then
   echo "AzureAD credentials are required because IaC/live/azuread-applications changed or the apply diff could not be determined." >&2
@@ -52,13 +57,13 @@ echo "::endgroup::"
 echo "::group::Argo CD Application registration apply"
 (
   cd IaC/live/argocd-apps
-  terragrunt run --all --non-interactive --parallelism 1 --source-update -- apply -no-color -auto-approve
+  terragrunt run --all --filter-affected --non-interactive --parallelism 1 --source-update -- apply -no-color -auto-approve
 )
 echo "::endgroup::"
 
 echo "::group::Kubernetes secret materialization apply"
 (
   cd IaC/live/kubernetes-secrets
-  terragrunt run --all --non-interactive --parallelism 1 --source-update -- apply -no-color -auto-approve
+  terragrunt run --all --filter-affected --non-interactive --parallelism 1 --source-update -- apply -no-color -auto-approve
 )
 echo "::endgroup::"

--- a/scripts/ci/terragrunt-filter-base.sh
+++ b/scripts/ci/terragrunt-filter-base.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+prepare_terragrunt_filter_base() {
+  if [[ "${CI:-}" != "true" ]]; then
+    return 0
+  fi
+
+  local base_ref="${TERRAGRUNT_FILTER_BASE_SHA:-${APPLY_BASE_SHA:-}}"
+  local head_ref="${TERRAGRUNT_FILTER_HEAD_SHA:-${APPLY_HEAD_SHA:-${GITHUB_SHA:-HEAD}}}"
+
+  if [[ -z "$base_ref" && -n "${GITHUB_BASE_REF:-}" ]]; then
+    base_ref="origin/${GITHUB_BASE_REF}"
+  fi
+
+  if [[ -z "$base_ref" && "${GITHUB_EVENT_NAME:-}" == "workflow_dispatch" ]]; then
+    base_ref="HEAD^"
+  fi
+
+  if [[ -z "$base_ref" ]]; then
+    base_ref="origin/main"
+  fi
+
+  if [[ -z "$base_ref" || "$base_ref" =~ ^0+$ ]]; then
+    echo "::warning::No usable Terragrunt --filter-affected base ref was available; using the existing main ref."
+    return 0
+  fi
+
+  if ! git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
+    echo "::warning::Terragrunt --filter-affected base ${base_ref} is unavailable; using the existing main ref."
+    return 0
+  fi
+
+  if git rev-parse --verify --quiet "${head_ref}^{commit}" >/dev/null; then
+    git switch --detach --quiet "$head_ref"
+  fi
+
+  git branch --force main "$base_ref"
+}

--- a/scripts/ci/terragrunt-plan.sh
+++ b/scripts/ci/terragrunt-plan.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${script_dir}/terragrunt-filter-base.sh"
+
 plan_markdown="${TERRAGRUNT_PLAN_MARKDOWN:-${RUNNER_TEMP:-/tmp}/terragrunt-plan.md}"
 mkdir -p "$(dirname "$plan_markdown")"
+
+clear_plan_outs() {
+  find "$@" -name plan.out -type f -delete
+}
 
 render_plan_out() {
   local title="$1"
@@ -21,6 +28,29 @@ render_plan_out() {
   } >>"$plan_markdown"
 }
 
+render_plan_out_if_present() {
+  local title="$1"
+  local unit_dir="$2"
+
+  if [[ -f "${unit_dir}/plan.out" ]]; then
+    render_plan_out "$title" "$unit_dir"
+    return 0
+  fi
+
+  return 1
+}
+
+append_plan_note() {
+  local message="$1"
+
+  {
+    printf '> %s\n\n' "$message"
+  } >>"$plan_markdown"
+}
+
+prepare_terragrunt_filter_base
+clear_plan_outs IaC/bootstrap IaC/live/argocd-apps
+
 {
   printf '## Terragrunt Plan Output\n\n'
   printf 'Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.\n\n'
@@ -32,25 +62,34 @@ render_plan_out() {
 
 echo "::group::Argo CD bootstrap plan"
 (
-  cd IaC/bootstrap/argocd
-  terragrunt --log-disable plan -lock=false -no-color
+  cd IaC/bootstrap
+  terragrunt run --all --filter-affected --parallelism 1 -- plan -lock=false -no-color
 )
 echo "::endgroup::"
-render_plan_out "Argo CD bootstrap" "IaC/bootstrap/argocd"
+if ! render_plan_out_if_present "Argo CD bootstrap" "IaC/bootstrap/argocd"; then
+  append_plan_note "No affected Argo CD bootstrap units were planned."
+fi
 
 echo "IaC/live/aws-ssm-parameters is intentionally excluded from PR plans because it manages KMS, IAM, and secret declarations that require the protected production apply role."
 
 echo "::group::Argo CD Application registration plan"
 (
   cd IaC/live/argocd-apps
-  terragrunt run --all --parallelism 1 --source-update -- plan -lock=false -no-color
+  terragrunt run --all --filter-affected --parallelism 1 --source-update -- plan -lock=false -no-color
 )
 echo "::endgroup::"
 
+planned_app_count=0
 while IFS= read -r unit_file; do
   unit_dir="$(dirname "$unit_file")"
   unit_name="$(basename "$unit_dir")"
-  render_plan_out "Argo CD Application: ${unit_name}" "$unit_dir"
+  if render_plan_out_if_present "Argo CD Application: ${unit_name}" "$unit_dir"; then
+    planned_app_count=$((planned_app_count + 1))
+  fi
 done < <(find IaC/live/argocd-apps -mindepth 2 -maxdepth 2 -name terragrunt.hcl -print | sort)
+
+if [[ "$planned_app_count" -eq 0 ]]; then
+  append_plan_note "No affected Argo CD Application registration units were planned."
+fi
 
 echo "IaC/live/kubernetes-secrets is intentionally excluded from PR plans because it reads decrypted SSM parameters."


### PR DESCRIPTION
## Issue

The Terragrunt plan and apply workflows were still queueing broad stack runs even when a pull request or merge only affected a subset of Terragrunt units. That kept the CI lane heavier than necessary and increased the chance of touching shared OpenTofu backend state for unrelated units.

## Cause And Effect

Terragrunt 0.99.4 supports `--filter-affected`, but the existing CI scripts used `run --all` without affected filtering for the Argo CD Application, AzureAD, Kubernetes secret, and related stack phases. In GitHub Actions this means a small app-registration change can still ask Terragrunt to inspect the whole stack. For post-merge applies, using `--filter-affected` directly also needs care because Terragrunt compares `main...HEAD`; on `main` itself that comparison can collapse to an accidental no-op unless CI prepares the local `main` ref.

## Fix

This change adds a shared `scripts/ci/terragrunt-filter-base.sh` helper that prepares the local Terragrunt comparison base in CI. Pull request plans compare against the PR base branch, push applies compare against the previous `main` SHA from the GitHub event, and manual apply dispatches fall back to `HEAD^`.

The plan and apply scripts now call Terragrunt with `run --all --filter-affected` while preserving the existing serial execution, `--source-update`, and non-interactive apply behavior. The plan script also clears stale `plan.out` files and only renders plan output for units that actually produced a plan, so the PR body stays honest when affected filtering selects no units.

The CI/CD runbooks and knowledge-base notes were updated to document the affected-unit behavior and the local reproduction caveat that `main` must be current when running the scripts outside GitHub Actions.

## Validation

- `bash -n scripts/ci/terragrunt-filter-base.sh scripts/ci/terragrunt-plan.sh scripts/ci/terragrunt-apply.sh`
- YAML parsing for `.github/workflows/terragrunt-plan.yml` and `.github/workflows/terragrunt-apply.yml`
- `git diff --check`
- `/opt/homebrew/bin/terragrunt hcl fmt --check`
- `/opt/homebrew/bin/terragrunt hcl validate`
- `PATH=/opt/homebrew/bin:$PATH TERRAGRUNT_PLAN_MARKDOWN=/private/tmp/terragrunt-plan-filter-smoke.md bash scripts/ci/terragrunt-plan.sh`
- `/nix/var/nix/profiles/default/bin/nix develop --command bash scripts/ci/static-checks.sh`
- `/nix/var/nix/profiles/default/bin/nix develop --command bash scripts/ci/conftest-policies.sh`
- Pre-commit hooks during the signed commit: trailing whitespace, EOF, large files, YAML, codespell, Checkov Diff, Checkov Secrets, and zizmor

I did not run `scripts/ci/terragrunt-apply.sh` locally because it executes production `apply -auto-approve`; the non-mutating checks above covered syntax, policy, static rendering, and affected plan selection.


<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `d47a48e65059e9f3361f21880763f96992dff797`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
