### PR TITLE
fix: remove retired hummingbot state

### DIFF
--- a/clusters/homelab/apps/octobot/README.md
+++ b/clusters/homelab/apps/octobot/README.md
@@ -54,8 +54,8 @@ the tailnet.
 
 - Back up the PVCs before changing strategies, enabling real exchange accounts,
   or testing a major OctoBot upgrade.
-- This app replaces the earlier Hummingbot runtime. Hummingbot is no longer
-  present in repo-owned desired state.
+- The `retired-workload-cleanup` hook removes stale finance PVCs from the
+  retired trading runtime during Argo CD sync.
 - Prefer paper trading and backtesting until the configuration is proven.
 - Do not place exchange API keys in Git, Terragrunt inputs, Helm values,
   Kubernetes Secrets, or External Secrets without adding an explicit repository

--- a/clusters/homelab/apps/octobot/kustomization.yaml
+++ b/clusters/homelab/apps/octobot/kustomization.yaml
@@ -2,4 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace.yaml
+  - retired-workload-cleanup.yaml
   - virtualservice.yaml

--- a/clusters/homelab/apps/octobot/retired-workload-cleanup.yaml
+++ b/clusters/homelab/apps/octobot/retired-workload-cleanup.yaml
@@ -1,0 +1,210 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: retired-workload-cleanup
+  namespace: finance
+  labels:
+    app.kubernetes.io/name: retired-workload-cleanup
+    app.kubernetes.io/part-of: homelab-finance
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: retired-workload-cleanup
+  namespace: finance
+  labels:
+    app.kubernetes.io/name: retired-workload-cleanup
+    app.kubernetes.io/part-of: homelab-finance
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - delete
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: retired-workload-cleanup
+  namespace: finance
+  labels:
+    app.kubernetes.io/name: retired-workload-cleanup
+    app.kubernetes.io/part-of: homelab-finance
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: retired-workload-cleanup
+subjects:
+  - kind: ServiceAccount
+    name: retired-workload-cleanup
+    namespace: finance
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: retired-finance-workload-cleanup
+  labels:
+    app.kubernetes.io/name: retired-workload-cleanup
+    app.kubernetes.io/part-of: homelab-finance
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumes
+    verbs:
+      - delete
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: retired-finance-workload-cleanup
+  labels:
+    app.kubernetes.io/name: retired-workload-cleanup
+    app.kubernetes.io/part-of: homelab-finance
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: retired-finance-workload-cleanup
+subjects:
+  - kind: ServiceAccount
+    name: retired-workload-cleanup
+    namespace: finance
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: retired-workload-cleanup
+  namespace: finance
+  labels:
+    app.kubernetes.io/name: retired-workload-cleanup
+    app.kubernetes.io/part-of: homelab-finance
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: retired-workload-cleanup
+      app.kubernetes.io/part-of: homelab-finance
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 10.0.0.0/8
+      ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 6443
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: retired-workload-cleanup
+  namespace: finance
+  labels:
+    app.kubernetes.io/name: retired-workload-cleanup
+    app.kubernetes.io/part-of: homelab-finance
+  annotations:
+    checkov.io/skip1: CKV_K8S_38=Cleanup job needs a short-lived service account token to call the Kubernetes API.
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 3600
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: retired-workload-cleanup
+        app.kubernetes.io/part-of: homelab-finance
+    spec:
+      automountServiceAccountToken: true
+      restartPolicy: Never
+      serviceAccountName: retired-workload-cleanup
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        fsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: cleanup
+          image: alpine/k8s:1.33.1@sha256:7f8133af0dd210cb5b168f889c5bc77dd65ecc935f3e3cb72d1b98ff96bfed40
+          env:
+            - name: HOME
+              value: /tmp
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              selector="app.kubernetes.io/instance=hummingbot"
+
+              claims="$(kubectl -n finance get pvc -l "${selector}" -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')"
+              if [ -n "${claims}" ]; then
+                printf '%s\n' "${claims}" | while IFS= read -r claim; do
+                  [ -n "${claim}" ] || continue
+                  pvs="$(
+                    kubectl get pv -o jsonpath='{range .items[?(@.spec.claimRef.namespace=="finance")]}{.metadata.name}{"\t"}{.spec.claimRef.name}{"\n"}{end}' \
+                      | awk -v claim="${claim}" '$2 == claim {print $1}'
+                  )"
+
+                  kubectl -n finance delete pvc "${claim}" --ignore-not-found=true
+
+                  if [ -n "${pvs}" ]; then
+                    printf '%s\n' "${pvs}" | while IFS= read -r pv; do
+                      [ -n "${pv}" ] || continue
+                      kubectl delete pv "${pv}" --ignore-not-found=true
+                    done
+                  fi
+                done
+              fi
+
+              find /homelab -mindepth 1 -maxdepth 1 -type d \
+                \( -name 'finance-hummingbot-*' -o -name 'archived-finance-hummingbot-*' \) \
+                -print -exec rm -rf -- {} +
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: homelab-nfs
+              mountPath: /homelab
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: homelab-nfs
+          nfs:
+            server: 10.1.0.2
+            path: /homelab

--- a/docs/knowledge-base/architecture/storage-and-state.md
+++ b/docs/knowledge-base/architecture/storage-and-state.md
@@ -37,10 +37,8 @@ ready, but they must not be treated as production-ready until:
 ## Stateful Apps
 
 The current stateful set includes Prometheus, Grafana, Deluge, media-postgres,
-n8n-postgres, Prowlarr, Radarr, Sonarr, LiteLLM, OpenClaw, n8n, and OctoBot.
-Hummingbot and Freqtrade are historical unless reintroduced by a future
-desired-state change. See [[workloads/inventory]] for ownership and dependency
-notes.
+n8n-postgres, Prowlarr, Radarr, Sonarr, LiteLLM, OpenClaw, n8n, and OctoBot. See
+[[workloads/inventory]] for ownership and dependency notes.
 
 ## Source Files
 

--- a/docs/knowledge-base/operations/continuous-improvement.md
+++ b/docs/knowledge-base/operations/continuous-improvement.md
@@ -59,19 +59,6 @@ policy`.
 ## Open Findings
 
 - **Status:** open
-- **Area:** storage
-- **Evidence:** after Hummingbot was removed from repo-owned desired state,
-  read-only checks on 2026-05-29 reported no `argocd/hummingbot` Application
-  and no Hummingbot Deployment, Service, ExternalSecret, or VirtualService, but
-  six bound `finance` namespace PVCs still matched
-  `app.kubernetes.io/instance=hummingbot`.
-- **Risk:** orphaned rollback PVCs can linger outside GitOps ownership and keep
-  old trading config, logs, certificates, scripts, and controller files around
-  longer than intended.
-- **Next step:** make an explicit data-retention decision, verify backup or
-  archival needs, then remove the orphaned PVCs through a reviewed repo-owned
-  cleanup path instead of ad hoc `kubectl delete`.
-- **Status:** open
 - **Area:** agent runtime
 - **Evidence:** OpenClaw pod currently runs on an NFS-backed PVC where files can
   appear as `nobody:nogroup`; PR #296 configures workspace scratch paths and

--- a/docs/knowledge-base/runbooks/argocd-app-onboarding.md
+++ b/docs/knowledge-base/runbooks/argocd-app-onboarding.md
@@ -16,8 +16,7 @@ under `clusters/homelab/apps/<app>` or `clusters/homelab/platform/<service>`.
 
 The current app onboarding runbook includes the requested apps plus support
 Applications. Kiali is the read-only Istio mesh UI, and OctoBot is the current
-finance namespace app. Hummingbot and Freqtrade are historical unless a future
-change reintroduces them.
+finance namespace app.
 
 ## Support Applications
 

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -105,9 +105,8 @@ are configured through the UI and stored on the PVCs. Start with paper trading;
 before enabling live trading, document backtest and paper-trading evidence and
 confirm withdrawal access is disabled at the exchange.
 
-The older Hummingbot workload and its PVC-only rollback Application have been
-removed from repo-owned desired state. Reintroducing Hummingbot requires a new
-GitOps app path, Argo CD registration, storage decision, and secret contract.
+The `retired-workload-cleanup` hook in the OctoBot app removes stale finance
+PVCs from the retired trading runtime during Argo CD sync.
 
 ## OpenClaw
 

--- a/docs/knowledge-base/workloads/inventory.md
+++ b/docs/knowledge-base/workloads/inventory.md
@@ -9,8 +9,7 @@ units as the source of truth when they disagree with this note.
 ## Import Note
 
 This note reflects the current working tree. OctoBot is the finance namespace
-trading workload with a tailnet-only UI. Hummingbot is no longer present in
-repo-owned desired state.
+trading workload with a tailnet-only UI.
 
 ## Platform And Support Applications
 
@@ -62,12 +61,6 @@ namespaces. The source of truth is `docs/runtime-isolation.md` plus the
   unselected until its webhook/control-plane paths are modeled.
 - `media` stays out of ambient while Deluge Gluetun/WireGuard and the media app
   ingress model need a repo-owned waypoint or equivalent policy design.
-
-## In-Flight Or Historical Rows
-
-- `hummingbot` and `freqtrade` appear only in historical notes. Treat them as
-  retired unless a future change intentionally reintroduces them with new
-  desired-state paths and docs.
 
 ## Update Checklist
 


### PR DESCRIPTION
## Summary
- add an OctoBot Argo CD PostSync cleanup hook for retired finance workload state
- delete matching Hummingbot PVCs, retained PVs, and NFS subdirectories through the repo-owned GitOps path
- remove stale Hummingbot references from current workload docs/open findings

## Validation
- `npx --yes yaml-lint clusters/homelab/apps/octobot/retired-workload-cleanup.yaml clusters/homelab/apps/octobot/kustomization.yaml`
- embedded cleanup shell: `sh -n`
- `git diff --check`

## Notes
- The only remaining `hummingbot` strings are the cleanup selector and NFS directory match patterns needed to remove the retired state.

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `3549738e1eb73d19b6a32e2e260266d2eb91d5ad`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
