### PR TITLE
fix(policy-bot): expose internal UI routes

### DIFF
--- a/IaC/live/argocd-apps/policy-bot/terragrunt.hcl
+++ b/IaC/live/argocd-apps/policy-bot/terragrunt.hcl
@@ -68,7 +68,7 @@ inputs = {
   info = [
     {
       name  = "public-webhook"
-      value = "Only /api/github/hook is exposed through Tailscale Funnel; UI and OAuth routes remain tailnet-only on policy-bot.stinkyboi.com"
+      value = "Only /api/github/hook is exposed through Tailscale Funnel; all other Policy Bot routes remain tailnet-only on policy-bot.stinkyboi.com"
     }
   ]
 }

--- a/clusters/homelab/apps/policy-bot/README.md
+++ b/clusters/homelab/apps/policy-bot/README.md
@@ -12,19 +12,17 @@ config.
 
 ## Routes
 
-- Tailnet operator UI and OAuth callback:
-  `https://policy-bot.stinkyboi.com/details/<org>/<repo>/<pull-request>`,
-  `/static/*`, and `/api/github/auth`.
+- Tailnet operator UI, details pages, static assets, OAuth callback, and normal
+  Policy Bot page routes: `https://policy-bot.stinkyboi.com`.
 - Public GitHub webhook:
   `https://policy-bot-hook.<tailnet-name>.ts.net/api/github/hook`.
-- Root routes are intentionally unrouted. Keep `/` private unless a later PR
-  documents why the full UI should be exposed.
 
 The public webhook uses a dedicated Tailscale `Ingress` with
 `tailscale.com/funnel: "true"`. Tailscale Operator currently treats Ingress
 paths as prefix matches, so the reviewed public surface is the
 `/api/github/hook` prefix and the backend must continue to reject unrelated
-paths itself.
+paths itself. Do not add the Policy Bot UI host or root route to the Funnel
+Ingress.
 
 The tailnet policy must allow the operator proxy tag, currently `tag:k8s`, to
 use Funnel:
@@ -74,13 +72,15 @@ rendered again.
 kubectl kustomize clusters/homelab/apps/policy-bot
 kubectl -n automation get deploy,pod,svc,ingress,externalsecret policy-bot policy-bot-hook-funnel policy-bot-config
 kubectl -n tailscale get statefulset,pod -l tailscale.com/parent-resource=policy-bot-hook-funnel
+curl -I https://policy-bot.stinkyboi.com/
 curl -I https://policy-bot.stinkyboi.com/details/example/example/1
 curl -sS -o /dev/null -w '%{http_code}\n' https://policy-bot-hook.<tailnet-name>.ts.net/api/github/hook
 ```
 
 Expected workload behavior: the Deployment has one available replica. Expected
-route behavior: the details URL redirects to `/api/github/auth`, the public hook
-returns `400` for an unsigned empty request, and
+route behavior: the internal host serves the normal Policy Bot UI paths, the
+details URL redirects to `/api/github/auth`, the public hook returns `400` for
+an unsigned empty request, and
 `https://policy-bot-hook.<tailnet-name>.ts.net/` is not routed.
 
 ## Rollback

--- a/clusters/homelab/apps/policy-bot/virtualservice.yaml
+++ b/clusters/homelab/apps/policy-bot/virtualservice.yaml
@@ -11,14 +11,7 @@ spec:
   gateways:
     - istio-system/tailnet-gateway
   http:
-    - match:
-        - uri:
-            exact: /api/github/auth
-        - uri:
-            prefix: /details
-        - uri:
-            prefix: /static
-      route:
+    - route:
         - destination:
             host: policy-bot.automation.svc.cluster.local
             port:

--- a/docs/knowledge-base/runbooks/tailnet-ingress.md
+++ b/docs/knowledge-base/runbooks/tailnet-ingress.md
@@ -16,7 +16,8 @@ address from tailnet clients. DNS is not managed by this repo yet.
 ## Current Route Rules
 
 - Argo CD, Grafana, Kiali, Deluge, Prowlarr, Radarr, Sonarr, LiteLLM,
-  OpenClaw, n8n, Policy Bot UI, and OctoBot UI are tailnet-only.
+  OpenClaw, n8n, Policy Bot UI and normal routes, and OctoBot UI are
+  tailnet-only.
 - Policy Bot GitHub webhook is the reviewed public Funnel exception:
   `https://policy-bot-hook.<tailnet-name>.ts.net/api/github/hook`.
 - Prometheus is intentionally not exposed; Grafana is the metrics UI and Kiali

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -203,15 +203,16 @@ rollout when existing SQLite contents must be preserved.
 ## Policy Bot
 
 Policy Bot is an in-flight stateless automation workload. The tailnet UI lives
-at `https://policy-bot.stinkyboi.com/details/<org>/<repo>/<pull-request>`.
+at `https://policy-bot.stinkyboi.com`, including the root page, details pages,
+static assets, and OAuth callback.
 The public GitHub webhook is:
 
 ```text
 https://policy-bot-hook.<tailnet-name>.ts.net/api/github/hook
 ```
 
-Root routes stay unrouted. The public route depends on Tailscale Funnel for
-`tag:k8s` and Policy Bot's own webhook HMAC validation.
+Only the webhook route is public. The public route depends on Tailscale Funnel
+for `tag:k8s` and Policy Bot's own webhook HMAC validation.
 
 The Deployment runs one replica after the GitHub App ID, private key, OAuth
 client ID, and OAuth client secret placeholders are replaced in SSM. Scale it

--- a/docs/networking-tailnet-ingress.md
+++ b/docs/networking-tailnet-ingress.md
@@ -30,7 +30,7 @@ that must be added through a separate Terragrunt/OpenTofu entry point.
 | litellm | `https://litellm.stinkyboi.com` | disabled |
 | openclaw | `https://openclaw.stinkyboi.com` | disabled |
 | n8n | `https://n8n.stinkyboi.com` | disabled |
-| policy-bot UI | `https://policy-bot.stinkyboi.com` | disabled |
+| policy-bot UI and normal routes | `https://policy-bot.stinkyboi.com` | disabled |
 | octobot UI | `https://octobot.stinkyboi.com` | disabled |
 | policy-bot GitHub webhook | `https://policy-bot-hook.<tailnet-name>.ts.net/api/github/hook` | enabled for `/api/github/hook` only |
 
@@ -124,9 +124,9 @@ or remove it from kustomization.yaml, then sync the policy-bot Application.
 Data exposed: webhook request body and headers sent by GitHub.
 ```
 
-The Policy Bot details UI, static assets, and OAuth callback stay on
-`https://policy-bot.stinkyboi.com` through the tailnet-only Istio gateway. The
-root path stays unrouted.
+The Policy Bot UI, details routes, static assets, OAuth callback, and root path
+stay on `https://policy-bot.stinkyboi.com` through the tailnet-only Istio
+gateway. Only `/api/github/hook` is exposed through Funnel.
 
 ## Future Funnel Webhook Exception Template
 

--- a/docs/validation-runbook.md
+++ b/docs/validation-runbook.md
@@ -95,12 +95,14 @@ webhook URL:
 argocd app get policy-bot
 kubectl -n automation get deploy,svc,ingress,externalsecret policy-bot policy-bot-hook-funnel policy-bot-config
 kubectl -n tailscale get statefulset,pod -l tailscale.com/parent-resource=policy-bot-hook-funnel
+curl -I https://policy-bot.stinkyboi.com/
 curl -I https://policy-bot.stinkyboi.com/details/example/example/1
 curl -sS -o /dev/null -w '%{http_code}\n' https://policy-bot-hook.<tailnet-name>.ts.net/api/github/hook
 ```
 
-Expected result: details redirect to `/api/github/auth`, the public hook returns
-`400` for an unsigned empty request, and the Funnel root is not routed.
+Expected result: the internal host serves normal Policy Bot UI routes, details
+redirect to `/api/github/auth`, the public hook returns `400` for an unsigned
+empty request, and the Funnel root is not routed.
 
 Stateful apps auto-sync by default, but they must not be considered ready until
 `platform-storage` is synced, the `nfs-default` StorageClass is verified, and
@@ -201,6 +203,6 @@ to PostgreSQL.
 | NFS provisioner missing | Restore `platform-storage` readiness first; do not rely on stateful apps until PVC validation passes. |
 | Media PostgreSQL unavailable | Hold Sonarr, Radarr, and Prowlarr; verify `media-postgres-auth`, `media-postgres-arr-env`, the StatefulSet, and the six logical databases before app sync. |
 | Tailscale unavailable | Do not expose tailnet VirtualServices as ready, even if workloads are healthy. |
-| Policy Bot webhook unreachable | Confirm the Tailscale `funnel` node attribute for `tag:k8s`, then inspect the `policy-bot-hook-funnel` Ingress and the operator-managed proxy Pod; do not expose additional Policy Bot routes. |
+| Policy Bot webhook unreachable | Confirm the Tailscale `funnel` node attribute for `tag:k8s`, then inspect the `policy-bot-hook-funnel` Ingress and the operator-managed proxy Pod; do not expose additional Funnel routes. |
 | Image updater misconfiguration | Remove the affected `applicationRefs` image entry or write-back target from `clusters/homelab/apps/argocd-image-updater/imageupdater.yaml`, then fix the repository desired state. |
 | Argo CD app unhealthy | Record status, operator action, and rollback decision in `docs/argocd-app-onboarding.md`. |


### PR DESCRIPTION
## Summary

This change makes the internal Policy Bot hostname serve the normal application page while preserving the narrow public webhook exposure through Tailscale Funnel.

Policy Bot previously routed only a small set of internal Istio paths on `policy-bot.stinkyboi.com`: `/details`, `/static`, and `/api/github/auth`. Visiting the root page on the internal FQDN returned no matching route, which made the normal Policy Bot page inaccessible even from the tailnet. At the same time, the dedicated Funnel ingress was already correctly limited to `/api/github/hook` for GitHub webhook delivery.

The root cause was the restrictive `match` block in the `policy-bot-tailnet` VirtualService. Istio only forwarded the explicitly listed paths, so ordinary UI routes on the same internal hostname were dropped before they reached the Policy Bot service.

## Changes

- Removed the restrictive path matches from the internal Policy Bot VirtualService so `https://policy-bot.stinkyboi.com` forwards all Policy Bot routes to the service.
- Kept the Tailscale Funnel ingress limited to `/api/github/hook` on `policy-bot-hook.<tailnet-name>.ts.net`.
- Updated the Policy Bot README, networking and validation runbooks, Argo CD app info text, and Obsidian knowledge-base notes to document the split: all normal UI routes are internal-only, while only hooks are public through Funnel.

## Validation

- `kubectl kustomize clusters/homelab/apps/policy-bot`
- `terragrunt hcl format --check`
- `terragrunt hcl validate`
- `bash scripts/ci/conftest-policies.sh` - 2499 tests passed
- `bash scripts/ci/static-checks.sh` - exited 0
- Commit hook suite passed during signed commit creation

Checkov completed with zero Terraform, Kubernetes, and secrets failures. It also logged local DNS warnings while trying to fetch Prisma guideline metadata from `api0.prismacloud.io`; those warnings did not fail the scan.

No live cluster mutation was performed.


<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `41cae265ab632e1c0ecbdcec8892b4ad294dd71d`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
