### PR TITLE
feat(grafana): track GitHub PR statuses

### DIFF
--- a/clusters/homelab/apps/grafana/README.md
+++ b/clusters/homelab/apps/grafana/README.md
@@ -33,7 +33,8 @@ present. Local admin login remains available through `grafana-admin`.
 ## Code-Owned Configuration
 
 - `values.yaml` provisions the Prometheus and Alertmanager datasources with
-  stable UIDs, enables a `ServiceMonitor` for Grafana metrics, mounts
+  stable UIDs, provisions the GitHub Infinity datasource with the stable
+  `github` UID, enables a `ServiceMonitor` for Grafana metrics, mounts
   dashboards, configures Microsoft Entra SSO, and provisions Grafana-managed
   alerting resources.
 - The Helm release uses a `Recreate` deployment strategy because Grafana stores
@@ -47,12 +48,18 @@ present. Local admin login remains available through `grafana-admin`.
   databases that already contain Grafana-generated datasource UIDs.
 - `dashboards/homelab-overview.json` is the default Homelab overview dashboard.
   `dashboards/argocd-overview.json` is the Argo CD GitOps operations
-  dashboard. Kustomize packages both dashboards into the stable
-  `grafana-dashboard-homelab-overview` ConfigMap, which the Helm chart mounts
-  through the `homelab` dashboard provider.
+  dashboard. `dashboards/github-pr-status.json` tracks open pull request status
+  filters and recent failed GitHub Actions runs. Kustomize packages these
+  dashboards into the stable `grafana-dashboard-homelab-overview` ConfigMap,
+  which the Helm chart mounts through the `homelab` dashboard provider.
 - `values.yaml` imports pinned Grafana.com dashboard revisions for Kubernetes
   and Prometheus views that are maintained by the
   `dotdc/grafana-dashboards-kubernetes` project.
+- `values.yaml` installs the pinned Infinity datasource plugin so Grafana can
+  read public GitHub REST API endpoints from the server side. The GitHub
+  queries are intentionally unauthenticated because this repository is public;
+  keep the alert interval conservative unless a reviewed token-backed secret
+  contract is added later.
 - `externalsecret.yaml` references the Grafana admin username, admin password,
   Entra SSO values, and Discord webhook URL in AWS SSM Parameter Store. No
   secret values belong in this directory.
@@ -116,6 +123,8 @@ The first provisioned rules cover:
 - Argo CD application metrics missing from Prometheus for 10 minutes.
 - Argo CD Applications not `Healthy` for 10 minutes.
 - Argo CD Applications remaining explicitly `OutOfSync` for 30 minutes.
+- GitHub Actions workflow runs in `failure` or `timed_out` state during the
+  two-hour alert window.
 
 The provisioning file also deletes the retired OctoBot-specific deployment
 availability rule so Grafana only evaluates the generic workload alerts after
@@ -164,12 +173,13 @@ kubectl -n monitoring get pods -l app.kubernetes.io/name=grafana
 ```
 
 In Grafana, check that the `Prometheus` datasource is default, the
-`Alertmanager` datasource is healthy, the `Homelab Overview` and `Argo CD
-Overview` dashboards appear under the `Homelab` folder, the imported dashboards
-appear under the `Kubernetes` and `Monitoring` folders, the `Entra ID` login
-path works, and the seven `homelab-*` alert rules are present under Grafana
-Alerting. Use the Grafana contact point test action after the Discord webhook
-parameter and OpenClaw hook token have been populated in SSM.
+`Alertmanager` datasource is healthy, the `GitHub` datasource can query
+`https://api.github.com`, the `Homelab Overview`, `Argo CD Overview`, and
+`GitHub PR Status` dashboards appear under the `Homelab` folder, the imported
+dashboards appear under the `Kubernetes` and `Monitoring` folders, the
+`Entra ID` login path works, and the nine `homelab-*` alert rules are present
+under Grafana Alerting. Use the Grafana contact point test action after the
+Discord webhook parameter and OpenClaw hook token have been populated in SSM.
 
 ## Rollback
 

--- a/clusters/homelab/apps/grafana/dashboards/github-pr-status.json
+++ b/clusters/homelab/apps/grafana/dashboards/github-pr-status.json
@@ -1,0 +1,1004 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": [
+        "homelab"
+      ],
+      "targetBlank": false,
+      "title": "Homelab dashboards",
+      "type": "dashboards"
+    }
+  ],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "github"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "noValue": "0",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "count"
+          ],
+          "fields": "/^PR$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "number",
+              "text": "PR",
+              "type": "number"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "github"
+          },
+          "filters": [],
+          "format": "table",
+          "global_query_id": "",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "items",
+          "source": "url",
+          "type": "json",
+          "url": "https://api.github.com/search/issues",
+          "url_options": {
+            "body_content_type": "application/json",
+            "body_form": [],
+            "body_graphql_query": "",
+            "body_graphql_variables": "",
+            "body_type": "raw",
+            "data": "",
+            "headers": [
+              {
+                "key": "Accept",
+                "value": "application/vnd.github+json"
+              },
+              {
+                "key": "X-GitHub-Api-Version",
+                "value": "2026-03-10"
+              }
+            ],
+            "method": "GET",
+            "params": [
+              {
+                "key": "q",
+                "value": "repo:Stuhlmuller/homelab is:pr is:open"
+              },
+              {
+                "key": "per_page",
+                "value": "100"
+              },
+              {
+                "key": "sort",
+                "value": "updated"
+              },
+              {
+                "key": "order",
+                "value": "desc"
+              }
+            ]
+          }
+        }
+      ],
+      "title": "Open PRs",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "github"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "noValue": "0",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "count"
+          ],
+          "fields": "/^PR$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "number",
+              "text": "PR",
+              "type": "number"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "github"
+          },
+          "filters": [],
+          "format": "table",
+          "global_query_id": "",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "items",
+          "source": "url",
+          "type": "json",
+          "url": "https://api.github.com/search/issues",
+          "url_options": {
+            "body_content_type": "application/json",
+            "body_form": [],
+            "body_graphql_query": "",
+            "body_graphql_variables": "",
+            "body_type": "raw",
+            "data": "",
+            "headers": [
+              {
+                "key": "Accept",
+                "value": "application/vnd.github+json"
+              },
+              {
+                "key": "X-GitHub-Api-Version",
+                "value": "2026-03-10"
+              }
+            ],
+            "method": "GET",
+            "params": [
+              {
+                "key": "q",
+                "value": "repo:Stuhlmuller/homelab is:pr is:open status:failure"
+              },
+              {
+                "key": "per_page",
+                "value": "100"
+              },
+              {
+                "key": "sort",
+                "value": "updated"
+              },
+              {
+                "key": "order",
+                "value": "desc"
+              }
+            ]
+          }
+        }
+      ],
+      "title": "PRs Failing Checks",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "github"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "noValue": "0",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "count"
+          ],
+          "fields": "/^PR$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "number",
+              "text": "PR",
+              "type": "number"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "github"
+          },
+          "filters": [],
+          "format": "table",
+          "global_query_id": "",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "items",
+          "source": "url",
+          "type": "json",
+          "url": "https://api.github.com/search/issues",
+          "url_options": {
+            "body_content_type": "application/json",
+            "body_form": [],
+            "body_graphql_query": "",
+            "body_graphql_variables": "",
+            "body_type": "raw",
+            "data": "",
+            "headers": [
+              {
+                "key": "Accept",
+                "value": "application/vnd.github+json"
+              },
+              {
+                "key": "X-GitHub-Api-Version",
+                "value": "2026-03-10"
+              }
+            ],
+            "method": "GET",
+            "params": [
+              {
+                "key": "q",
+                "value": "repo:Stuhlmuller/homelab is:pr is:open status:pending"
+              },
+              {
+                "key": "per_page",
+                "value": "100"
+              },
+              {
+                "key": "sort",
+                "value": "updated"
+              },
+              {
+                "key": "order",
+                "value": "desc"
+              }
+            ]
+          }
+        }
+      ],
+      "title": "PRs Pending Checks",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "github"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "noValue": "0",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "count"
+          ],
+          "fields": "/^run_id$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "id",
+              "text": "run_id",
+              "type": "number"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "github"
+          },
+          "filters": [],
+          "format": "table",
+          "global_query_id": "",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "workflow_runs",
+          "source": "url",
+          "type": "json",
+          "url": "https://api.github.com/repos/Stuhlmuller/homelab/actions/runs",
+          "url_options": {
+            "body_content_type": "application/json",
+            "body_form": [],
+            "body_graphql_query": "",
+            "body_graphql_variables": "",
+            "body_type": "raw",
+            "data": "",
+            "headers": [
+              {
+                "key": "Accept",
+                "value": "application/vnd.github+json"
+              },
+              {
+                "key": "X-GitHub-Api-Version",
+                "value": "2026-03-10"
+              }
+            ],
+            "method": "GET",
+            "params": [
+              {
+                "key": "status",
+                "value": "failure"
+              },
+              {
+                "key": "created",
+                "value": ">=${__timeFrom:date:iso}"
+              },
+              {
+                "key": "per_page",
+                "value": "100"
+              }
+            ]
+          }
+        }
+      ],
+      "title": "Failed Actions Runs",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "github"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "URL"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "targetBlank": true,
+                    "title": "Open",
+                    "url": "${__value.raw}"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
+      "id": 5,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Updated"
+          }
+        ]
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "number",
+              "text": "PR",
+              "type": "number"
+            },
+            {
+              "selector": "title",
+              "text": "Title",
+              "type": "string"
+            },
+            {
+              "selector": "user.login",
+              "text": "Author",
+              "type": "string"
+            },
+            {
+              "selector": "updated_at",
+              "text": "Updated",
+              "type": "string"
+            },
+            {
+              "selector": "html_url",
+              "text": "URL",
+              "type": "string"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "github"
+          },
+          "filters": [],
+          "format": "table",
+          "global_query_id": "",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "items",
+          "source": "url",
+          "type": "json",
+          "url": "https://api.github.com/search/issues",
+          "url_options": {
+            "body_content_type": "application/json",
+            "body_form": [],
+            "body_graphql_query": "",
+            "body_graphql_variables": "",
+            "body_type": "raw",
+            "data": "",
+            "headers": [
+              {
+                "key": "Accept",
+                "value": "application/vnd.github+json"
+              },
+              {
+                "key": "X-GitHub-Api-Version",
+                "value": "2026-03-10"
+              }
+            ],
+            "method": "GET",
+            "params": [
+              {
+                "key": "q",
+                "value": "repo:Stuhlmuller/homelab is:pr is:open"
+              },
+              {
+                "key": "per_page",
+                "value": "20"
+              },
+              {
+                "key": "sort",
+                "value": "updated"
+              },
+              {
+                "key": "order",
+                "value": "desc"
+              }
+            ]
+          }
+        }
+      ],
+      "title": "Open Pull Requests",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "github"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "URL"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "targetBlank": true,
+                    "title": "Open",
+                    "url": "${__value.raw}"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 5
+      },
+      "id": 6,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Updated"
+          }
+        ]
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "number",
+              "text": "PR",
+              "type": "number"
+            },
+            {
+              "selector": "title",
+              "text": "Title",
+              "type": "string"
+            },
+            {
+              "selector": "user.login",
+              "text": "Author",
+              "type": "string"
+            },
+            {
+              "selector": "updated_at",
+              "text": "Updated",
+              "type": "string"
+            },
+            {
+              "selector": "html_url",
+              "text": "URL",
+              "type": "string"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "github"
+          },
+          "filters": [],
+          "format": "table",
+          "global_query_id": "",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "items",
+          "source": "url",
+          "type": "json",
+          "url": "https://api.github.com/search/issues",
+          "url_options": {
+            "body_content_type": "application/json",
+            "body_form": [],
+            "body_graphql_query": "",
+            "body_graphql_variables": "",
+            "body_type": "raw",
+            "data": "",
+            "headers": [
+              {
+                "key": "Accept",
+                "value": "application/vnd.github+json"
+              },
+              {
+                "key": "X-GitHub-Api-Version",
+                "value": "2026-03-10"
+              }
+            ],
+            "method": "GET",
+            "params": [
+              {
+                "key": "q",
+                "value": "repo:Stuhlmuller/homelab is:pr is:open status:failure"
+              },
+              {
+                "key": "per_page",
+                "value": "20"
+              },
+              {
+                "key": "sort",
+                "value": "updated"
+              },
+              {
+                "key": "order",
+                "value": "desc"
+              }
+            ]
+          }
+        }
+      ],
+      "title": "Open PRs With Failing Checks",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "github"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "URL"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "targetBlank": true,
+                    "title": "Open",
+                    "url": "${__value.raw}"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "id": 7,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Created"
+          }
+        ]
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "id",
+              "text": "run_id",
+              "type": "number"
+            },
+            {
+              "selector": "name",
+              "text": "Workflow",
+              "type": "string"
+            },
+            {
+              "selector": "display_title",
+              "text": "Title",
+              "type": "string"
+            },
+            {
+              "selector": "head_branch",
+              "text": "Branch",
+              "type": "string"
+            },
+            {
+              "selector": "event",
+              "text": "Event",
+              "type": "string"
+            },
+            {
+              "selector": "conclusion",
+              "text": "Conclusion",
+              "type": "string"
+            },
+            {
+              "selector": "created_at",
+              "text": "Created",
+              "type": "string"
+            },
+            {
+              "selector": "html_url",
+              "text": "URL",
+              "type": "string"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "github"
+          },
+          "filters": [],
+          "format": "table",
+          "global_query_id": "",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "workflow_runs",
+          "source": "url",
+          "type": "json",
+          "url": "https://api.github.com/repos/Stuhlmuller/homelab/actions/runs",
+          "url_options": {
+            "body_content_type": "application/json",
+            "body_form": [],
+            "body_graphql_query": "",
+            "body_graphql_variables": "",
+            "body_type": "raw",
+            "data": "",
+            "headers": [
+              {
+                "key": "Accept",
+                "value": "application/vnd.github+json"
+              },
+              {
+                "key": "X-GitHub-Api-Version",
+                "value": "2026-03-10"
+              }
+            ],
+            "method": "GET",
+            "params": [
+              {
+                "key": "status",
+                "value": "failure"
+              },
+              {
+                "key": "created",
+                "value": ">=${__timeFrom:date:iso}"
+              },
+              {
+                "key": "per_page",
+                "value": "20"
+              }
+            ]
+          }
+        }
+      ],
+      "title": "Recent Failed GitHub Actions Runs",
+      "type": "table"
+    }
+  ],
+  "refresh": "10m",
+  "schemaVersion": 41,
+  "tags": [
+    "homelab",
+    "github",
+    "ci-cd"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "GitHub PR Status",
+  "uid": "github-pr-status",
+  "version": 1,
+  "weekStart": ""
+}

--- a/clusters/homelab/apps/grafana/kustomization.yaml
+++ b/clusters/homelab/apps/grafana/kustomization.yaml
@@ -9,6 +9,7 @@ configMapGenerator:
   - name: grafana-dashboard-homelab-overview
     files:
       - argocd-overview.json=dashboards/argocd-overview.json
+      - github-pr-status.json=dashboards/github-pr-status.json
       - homelab-overview.json=dashboards/homelab-overview.json
     options:
       labels:

--- a/clusters/homelab/apps/grafana/values.yaml
+++ b/clusters/homelab/apps/grafana/values.yaml
@@ -46,6 +46,8 @@ podAnnotations:
   homelab.rst.io/discord-webhook-ssm-version: "2"
   homelab.rst.io/openclaw-alert-hook-ssm-version: "1"
   homelab.rst.io/alerting-provisioning-version: "3"
+plugins:
+  - yesoreyeram-infinity-datasource@3.8.0
 initChownData:
   enabled: false
 serviceMonitor:
@@ -65,6 +67,8 @@ datasources:
       - name: Prometheus
         orgId: 1
       - name: Alertmanager
+        orgId: 1
+      - name: GitHub
         orgId: 1
     prune: true
     datasources:
@@ -91,6 +95,16 @@ datasources:
         jsonData:
           httpMethod: POST
           timeInterval: 30s
+      - name: GitHub
+        orgId: 1
+        uid: github
+        type: yesoreyeram-infinity-datasource
+        access: proxy
+        editable: false
+        version: 1
+        jsonData:
+          allowedHosts:
+            - https://api.github.com
 dashboardProviders:
   dashboardproviders.yaml:
     apiVersion: 1
@@ -193,14 +207,14 @@ alerting:
               authorization_scheme: Bearer
               authorization_credentials: $OPENCLAW_ALERT_HOOK_TOKEN
               maxAlerts: "10"
-              title: '{{ template "default.title" . }}'
+              title: '{{ "{{" }} template "default.title" . {{ "}}" }}'
               message: |
                 Grafana alert notification from homelab.
 
-                Status: {{ .Status }}
-                Title: {{ template "default.title" . }}
+                Status: {{ "{{" }} .Status {{ "}}" }}
+                Title: {{ "{{" }} template "default.title" . {{ "}}" }}
 
-                {{ template "default.message" . }}
+                {{ "{{" }} template "default.message" . {{ "}}" }}
 
                 Triage this alert directly. If it is actionable, inspect live state when available and fix through the homelab GitOps workflow.
   policies.yaml:
@@ -219,6 +233,10 @@ alerting:
           - project
           - health_status
           - sync_status
+          - workflow_name
+          - head_branch
+          - run_event
+          - conclusion
         group_wait: 30s
         group_interval: 5m
         repeat_interval: 4h
@@ -400,7 +418,7 @@ alerting:
                   expr: kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff"} > 0
                   instant: true
                   intervalMs: 1000
-                  legendFormat: '{{ namespace }}/{{ pod }} {{ container }} {{ reason }}'
+                  legendFormat: '{{ "{{" }} namespace {{ "}}" }}/{{ "{{" }} pod {{ "}}" }} {{ "{{" }} container {{ "}}" }} {{ "{{" }} reason {{ "}}" }}'
                   maxDataPoints: 43200
                   range: false
                   refId: A
@@ -756,3 +774,244 @@ alerting:
             labels:
               severity: warning
               managed_by: grafana-provisioning
+      - orgId: 1
+        name: homelab-github
+        folder: Homelab
+        interval: 10m
+        rules:
+          - uid: homelab-github-actions-run-failed
+            title: GitHub Actions workflow run failed
+            condition: C
+            data:
+              - refId: A
+                datasourceUid: github
+                relativeTimeRange:
+                  from: 7200
+                  to: 0
+                model:
+                  datasource:
+                    type: yesoreyeram-infinity-datasource
+                    uid: github
+                  columns:
+                    - selector: id
+                      text: run_id
+                      type: number
+                    - selector: name
+                      text: workflow_name
+                      type: string
+                    - selector: head_branch
+                      text: head_branch
+                      type: string
+                    - selector: event
+                      text: run_event
+                      type: string
+                    - selector: conclusion
+                      text: conclusion
+                      type: string
+                    - selector: html_url
+                      text: html_url
+                      type: string
+                  filters: []
+                  format: table
+                  global_query_id: ""
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  parser: backend
+                  refId: A
+                  root_selector: workflow_runs
+                  source: url
+                  type: json
+                  url: https://api.github.com/repos/Stuhlmuller/homelab/actions/runs
+                  url_options:
+                    body_content_type: application/json
+                    body_form: []
+                    body_graphql_query: ""
+                    body_graphql_variables: ""
+                    body_type: raw
+                    data: ""
+                    headers:
+                      - key: Accept
+                        value: application/vnd.github+json
+                      - key: X-GitHub-Api-Version
+                        value: "2026-03-10"
+                    method: GET
+                    params:
+                      - key: status
+                        value: failure
+                      - key: created
+                        value: ">=${__timeFrom:date:iso}"
+                      - key: per_page
+                        value: "10"
+              - refId: B
+                datasourceUid: __expr__
+                relativeTimeRange:
+                  from: 0
+                  to: 0
+                model:
+                  datasource:
+                    type: __expr__
+                    uid: __expr__
+                  expression: A
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  reducer: last
+                  refId: B
+                  type: reduce
+              - refId: C
+                datasourceUid: __expr__
+                relativeTimeRange:
+                  from: 0
+                  to: 0
+                model:
+                  conditions:
+                    - evaluator:
+                        params:
+                          - 0
+                        type: gt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                          - C
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                  datasource:
+                    type: __expr__
+                    uid: __expr__
+                  expression: B
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  refId: C
+                  type: threshold
+            dashboardUid: github-pr-status
+            panelId: 4
+            noDataState: OK
+            execErrState: Alerting
+            for: 1m
+            annotations:
+              summary: A GitHub Actions workflow run failed in Stuhlmuller/homelab during the alert window.
+              runbook_url: https://github.com/Stuhlmuller/homelab/blob/main/docs/ci-cd.md
+            labels:
+              severity: critical
+              managed_by: grafana-provisioning
+              source: github-actions
+          - uid: homelab-github-actions-run-timed-out
+            title: GitHub Actions workflow run timed out
+            condition: C
+            data:
+              - refId: A
+                datasourceUid: github
+                relativeTimeRange:
+                  from: 7200
+                  to: 0
+                model:
+                  datasource:
+                    type: yesoreyeram-infinity-datasource
+                    uid: github
+                  columns:
+                    - selector: id
+                      text: run_id
+                      type: number
+                    - selector: name
+                      text: workflow_name
+                      type: string
+                    - selector: head_branch
+                      text: head_branch
+                      type: string
+                    - selector: event
+                      text: run_event
+                      type: string
+                    - selector: conclusion
+                      text: conclusion
+                      type: string
+                    - selector: html_url
+                      text: html_url
+                      type: string
+                  filters: []
+                  format: table
+                  global_query_id: ""
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  parser: backend
+                  refId: A
+                  root_selector: workflow_runs
+                  source: url
+                  type: json
+                  url: https://api.github.com/repos/Stuhlmuller/homelab/actions/runs
+                  url_options:
+                    body_content_type: application/json
+                    body_form: []
+                    body_graphql_query: ""
+                    body_graphql_variables: ""
+                    body_type: raw
+                    data: ""
+                    headers:
+                      - key: Accept
+                        value: application/vnd.github+json
+                      - key: X-GitHub-Api-Version
+                        value: "2026-03-10"
+                    method: GET
+                    params:
+                      - key: status
+                        value: timed_out
+                      - key: created
+                        value: ">=${__timeFrom:date:iso}"
+                      - key: per_page
+                        value: "10"
+              - refId: B
+                datasourceUid: __expr__
+                relativeTimeRange:
+                  from: 0
+                  to: 0
+                model:
+                  datasource:
+                    type: __expr__
+                    uid: __expr__
+                  expression: A
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  reducer: last
+                  refId: B
+                  type: reduce
+              - refId: C
+                datasourceUid: __expr__
+                relativeTimeRange:
+                  from: 0
+                  to: 0
+                model:
+                  conditions:
+                    - evaluator:
+                        params:
+                          - 0
+                        type: gt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                          - C
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                  datasource:
+                    type: __expr__
+                    uid: __expr__
+                  expression: B
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  refId: C
+                  type: threshold
+            dashboardUid: github-pr-status
+            panelId: 4
+            noDataState: OK
+            execErrState: Alerting
+            for: 1m
+            annotations:
+              summary: A GitHub Actions workflow run timed out in Stuhlmuller/homelab during the alert window.
+              runbook_url: https://github.com/Stuhlmuller/homelab/blob/main/docs/ci-cd.md
+            labels:
+              severity: critical
+              managed_by: grafana-provisioning
+              source: github-actions

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -16,6 +16,20 @@ This repository uses GitHub Actions for the review and rollout path:
 Forked pull requests never receive AWS, Tailscale, or Kubernetes secrets. They
 run the static checks and Conftest only.
 
+## Monitoring
+
+Grafana owns the repository dashboard for the GitHub review path. The
+`GitHub PR Status` dashboard in `clusters/homelab/apps/grafana` uses the
+provisioned `GitHub` Infinity datasource to query public GitHub REST API
+endpoints for open pull requests, pull requests with failing or pending status
+checks, and recent failed workflow runs.
+
+Grafana-managed alerts poll the GitHub Actions workflow-runs endpoint every
+ten minutes and notify through the normal homelab alert route when a run enters
+`failure` or `timed_out` state during the two-hour alert window. Because these
+reads are unauthenticated public API calls, do not shorten the polling interval
+unless the repository adds a reviewed token-backed secret contract for Grafana.
+
 ## Security Model
 
 - Workflows use `pull_request` and `push`; they do not use
@@ -80,6 +94,8 @@ References:
 - [Tailscale GitHub Action](https://tailscale.com/docs/integrations/github/github-action)
 - [Tailscale grants syntax](https://tailscale.com/docs/reference/syntax/grants)
 - [GitHub OIDC with AWS](https://docs.github.com/en/actions/how-tos/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services)
+- [GitHub Actions workflow runs REST API](https://docs.github.com/en/rest/actions/workflow-runs)
+- [GitHub issue and pull request search filters](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/filtering-and-searching-issues-and-pull-requests)
 - [nix-community/cache-nix-action](https://github.com/nix-community/cache-nix-action)
 - [Conftest](https://www.conftest.dev/)
 - [Checkov GitHub Actions integration](https://www.checkov.io/4.Integrations/GitHub%20Actions.html)

--- a/docs/knowledge-base/runbooks/ci-cd.md
+++ b/docs/knowledge-base/runbooks/ci-cd.md
@@ -51,6 +51,17 @@ Source: `docs/ci-cd.md`
   queue is accepted in Actions and OpenTofu flags such as `-auto-approve` are
   forwarded to OpenTofu instead of being parsed as Terragrunt CLI flags.
 
+## Monitoring
+
+Grafana's `GitHub PR Status` dashboard uses the provisioned GitHub Infinity
+datasource to read public GitHub REST API endpoints for open pull requests,
+pull requests with failing or pending status checks, and recent failed workflow
+runs. Grafana-managed alerts poll GitHub Actions every ten minutes and notify
+through the normal homelab route when workflow runs enter `failure` or
+`timed_out` during the two-hour alert window. Keep these queries
+unauthenticated and conservatively scheduled unless a reviewed token-backed
+secret contract is added.
+
 ## Environments
 
 - `homelab-plan`: same-repository PR live plans.

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -63,13 +63,17 @@ and fail to establish enough peer connections.
 
 Grafana is the reviewed metrics UI. It uses Microsoft Entra SSO from
 `IaC/live/azuread-applications/grafana`, provisions Prometheus and Alertmanager
-datasources, Homelab and Argo CD dashboards, and Grafana-managed alerts from
-repo-owned values. Discord webhook URL and the OpenClaw alert hook token come
-from SSM through External Secrets. Grafana sends alert notifications both to
-Discord and directly to OpenClaw's authenticated `/hooks/agent` endpoint.
+datasources, a public GitHub API Infinity datasource, Homelab, Argo CD, and
+GitHub PR status dashboards, and Grafana-managed alerts from repo-owned values.
+Discord webhook URL and the OpenClaw alert hook token come from SSM through
+External Secrets. Grafana sends alert notifications both to Discord and
+directly to OpenClaw's authenticated `/hooks/agent` endpoint.
 Alerting-only provisioning changes bump
 `homelab.rst.io/alerting-provisioning-version` so Grafana restarts and applies
 rule additions, updates, and deletions.
+The GitHub dashboard and Actions failure alerts use unauthenticated public REST
+API reads against `Stuhlmuller/homelab`, so keep polling conservative unless a
+token-backed secret contract is added.
 Its Helm-rendered Deployment uses a resource-level Argo CD `Replace=true` sync
 option because the app keeps a `Recreate` strategy for the single Grafana PVC,
 and server-side apply can otherwise preserve stale `rollingUpdate` fields.

--- a/docs/knowledge-base/workloads/inventory.md
+++ b/docs/knowledge-base/workloads/inventory.md
@@ -30,7 +30,7 @@ trading workload with a tailnet-only UI.
 | `istio` | `istio-system` | `clusters/homelab/apps/istio` | `IaC/live/argocd-apps/istio` | controller state only | cert-manager |
 | `tailscale` | `tailscale` | `clusters/homelab/apps/tailscale` | `IaC/live/argocd-apps/tailscale` | controller state only | external-secrets, istio |
 | `prometheus` | `monitoring` | `clusters/homelab/apps/prometheus` | `IaC/live/argocd-apps/prometheus` | persistent metrics and Argo CD scrape config | external-secrets, platform-storage |
-| `grafana` | `monitoring` | `clusters/homelab/apps/grafana` | `IaC/live/argocd-apps/grafana` | persistent config, dashboards, alert rules, and Discord alerting webhook secret | external-secrets, cert-manager, istio, tailscale, prometheus, platform-storage |
+| `grafana` | `monitoring` | `clusters/homelab/apps/grafana` | `IaC/live/argocd-apps/grafana` | persistent config, dashboards, alert rules, public GitHub API PR/status polling, and Discord alerting webhook secret | external-secrets, cert-manager, istio, tailscale, prometheus, platform-storage |
 | `kiali` | `monitoring` | `clusters/homelab/apps/kiali` | `IaC/live/argocd-apps/kiali` | controller state only; read-only mesh UI | istio, tailscale, prometheus, grafana |
 | `descheduler` | `kube-system` | `clusters/homelab/apps/descheduler` | `IaC/live/argocd-apps/descheduler` | controller state only | prometheus |
 | `deluge` | `media` | `clusters/homelab/apps/deluge` | `IaC/live/argocd-apps/deluge` | persistent config on `nfs-default`; shared downloads on QNAP `/media`; SSM-backed WireGuard profile via `deluge-vpn` | cert-manager, istio, tailscale, platform-storage |


### PR DESCRIPTION
# Summary

Adds a repo-owned Grafana view for the GitHub review path and provisions alerts
for failing GitHub Actions runs.

## Issue

Grafana already covered in-cluster health, Argo CD health, and workload
failures, but it did not show whether the homelab repository had open pull
requests with pending or failing checks. Failed GitHub Actions runs could
therefore sit outside the normal homelab alert route unless someone checked the
repository manually.

## Cause And Effect

The existing Grafana configuration only used Prometheus and Alertmanager
datasources. That worked for Kubernetes and Argo CD signals, but GitHub Actions
run state lives in GitHub's API rather than in the cluster metrics pipeline.
Operators had a blind spot between a PR opening, Actions failing, and a human
noticing the failed run.

## Root Cause

There was no provisioned GitHub datasource, no dashboard for pull request check
state, and no Grafana-managed rule querying GitHub workflow-run state.

## Fix

This change installs the pinned Grafana Infinity datasource plugin, provisions a
stable `GitHub` datasource limited to `https://api.github.com`, and adds a
`GitHub PR Status` dashboard under the existing Homelab dashboard provider. The
dashboard tracks open pull requests, pull requests with failing or pending
checks, and recent failed Actions runs.

It also adds Grafana-managed alerts for workflow runs in `failure` and
`timed_out` state during the two-hour alert window. Alerts use the existing
homelab notification route, so Discord and OpenClaw receive the same signal as
other Grafana-managed alerts. The GitHub polling remains unauthenticated and
conservative because the repository is public and there is not yet a reviewed
token-backed secret contract.

The related Grafana README, CI/CD runbook, and Obsidian knowledge-base notes
now document the GitHub monitoring path, validation expectations, and
rate-limit tradeoff.

## Validation

- `jq empty clusters/homelab/apps/grafana/dashboards/github-pr-status.json`
- Ruby YAML parse for `clusters/homelab/apps/grafana/values.yaml` and
  `clusters/homelab/apps/grafana/kustomization.yaml`
- `kubectl kustomize clusters/homelab/apps/grafana`
- `helm template grafana grafana --repo https://grafana.github.io/helm-charts --version 10.5.15 --namespace monitoring --values clusters/homelab/apps/grafana/values.yaml`
- `bash scripts/ci/static-checks.sh`
- Pre-commit hooks during signed commit

Notes: the Grafana chart render reports the upstream chart deprecation warning.
Checkov completed with zero failed checks, but its optional Prisma guideline
metadata fetch logged DNS warnings in the local sandbox.


<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `7e75e2c73e47ba929727aca84d2c6fbf158decb9`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->

