### PR TITLE
fix: restore argocd access and deluge vpn

### DIFF
--- a/IaC/bootstrap/argocd/terragrunt.hcl
+++ b/IaC/bootstrap/argocd/terragrunt.hcl
@@ -7,7 +7,11 @@ locals {
   self_management_project_manifest     = "${get_terragrunt_dir()}/../../../clusters/homelab/argocd/self-management/appproject.yaml"
   oidc_sso_secret_name                 = "argocd-oidc-sso"
   oidc_sso_issuer                      = "https://login.microsoftonline.com/2aee152b-5281-40d0-8f4b-60faf40514ab/v2.0"
-  oidc_sso_admin_group                 = "argocd-admins"
+  oidc_sso_admin_groups = [
+    # Microsoft Entra emits the group object ID in the Dex groups claim.
+    "b200361e-a378-437a-9a47-731834f1524f",
+    "argocd-admins",
+  ]
   argocd_metrics = {
     enabled = true
   }
@@ -63,8 +67,10 @@ inputs = {
 
         rbac = {
           "policy.default" = "role:readonly"
-          "policy.csv"     = "g, ${local.oidc_sso_admin_group}, role:admin\n"
-          scopes           = "[groups, email]"
+          "policy.csv" = join("\n", concat([
+            for group in local.oidc_sso_admin_groups : "g, ${group}, role:admin"
+          ], [""]))
+          scopes = "[groups, email]"
         }
       }
 

--- a/clusters/homelab/apps/deluge/README.md
+++ b/clusters/homelab/apps/deluge/README.md
@@ -123,3 +123,14 @@ kubectl -n media exec deploy/deluge -c gluetun -- /gluetun-entrypoint healthchec
 
 If Gluetun is unhealthy, Deluge should lose readiness and torrent traffic should
 fail closed instead of bypassing the VPN.
+
+## Troubleshooting
+
+If `deluge-vpn` is ready and the Kubernetes Secret exists but the Gluetun
+container repeatedly fails startup health checks with DNS lookup timeouts, treat
+that as an unhealthy WireGuard tunnel rather than a missing Kubernetes secret.
+The usual repair is to generate a fresh AirVPN WireGuard profile, replace
+`/homelab/deluge/vpn/wireguard-config` in SSM, then bump
+`homelab.rst.io/wireguard-profile-ssm-version` in both `externalsecret.yaml`
+and `values.yaml` so External Secrets renders the new Secret and Argo CD rolls
+the Pod. Do not patch or restart the live Pod as the durable fix.

--- a/clusters/homelab/apps/deluge/externalsecret.yaml
+++ b/clusters/homelab/apps/deluge/externalsecret.yaml
@@ -4,7 +4,7 @@ metadata:
   name: deluge-vpn
   namespace: media
   annotations:
-    homelab.rst.io/wireguard-profile-ssm-version: "3"
+    homelab.rst.io/wireguard-profile-ssm-version: "4"
 spec:
   refreshPolicy: OnChange
   secretStoreRef:

--- a/clusters/homelab/apps/deluge/values.yaml
+++ b/clusters/homelab/apps/deluge/values.yaml
@@ -9,7 +9,7 @@ controllers:
       annotations:
         homelab.rst.io/rollout-strategy: "recreate-singleton"
         homelab.rst.io/wireguard-address-mode: "ipv4-only"
-        homelab.rst.io/wireguard-profile-ssm-version: "3"
+        homelab.rst.io/wireguard-profile-ssm-version: "4"
     strategy: Recreate
     initContainers:
       download-dirs:

--- a/docs/argocd-bootstrap.md
+++ b/docs/argocd-bootstrap.md
@@ -66,6 +66,12 @@ registration to emit group membership claims. Entra may omit the
 the Entra app registration, callback URL, client secret, and Argo CD RBAC for
 access control.
 
+Microsoft Entra can emit group object IDs rather than display names in the
+Dex `groups` claim. Keep the actual emitted admin group value in
+`local.oidc_sso_admin_groups` inside `IaC/bootstrap/argocd/terragrunt.hcl`;
+otherwise matching users fall back to `role:readonly` even when they belong to
+the intended Entra group.
+
 ## Validate Before Apply
 
 Run formatting and planning from the repo root or stack directory:

--- a/docs/knowledge-base/architecture/secrets-and-identity.md
+++ b/docs/knowledge-base/architecture/secrets-and-identity.md
@@ -39,8 +39,9 @@ roles need identity-based KMS permissions for both keys.
   provider discovery. Microsoft Entra group authorization is a token-claim
   behavior, not a requested OAuth scope: keep Dex scopes to `openid`,
   `profile`, and `email`, configure Entra to emit the `groups` claim for Argo
-  CD RBAC, and keep `insecureSkipEmailVerified: true` because Entra may omit
-  the `email_verified` claim.
+  CD RBAC, map the emitted admin group object ID in
+  `local.oidc_sso_admin_groups`, and keep `insecureSkipEmailVerified: true`
+  because Entra may omit the `email_verified` claim.
 - Argo CD Image Updater uses the `argocd-image-updater-git` ExternalSecret for
   GitHub App credentials that open image update pull requests through Git
   write-back. It refreshes on ExternalSecret changes; bump the non-secret

--- a/docs/knowledge-base/runbooks/argocd-bootstrap.md
+++ b/docs/knowledge-base/runbooks/argocd-bootstrap.md
@@ -39,6 +39,9 @@ Group-based RBAC depends on Entra emitting a token `groups` claim and Dex
 also sets `insecureSkipEmailVerified: true` because Entra can return an ID
 token without `email_verified`; access still depends on the Entra app
 registration, callback URL, client secret, and Argo CD RBAC.
+Microsoft Entra can emit group object IDs instead of display names, so
+`IaC/bootstrap/argocd/terragrunt.hcl` must map the actual emitted admin group
+value in `local.oidc_sso_admin_groups` or users stay on `role:readonly`.
 
 Dex startup uses the literal Entra issuer committed in
 `IaC/bootstrap/argocd/terragrunt.hcl`. Keep `/homelab/argocd/oidc/issuer`

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -58,6 +58,10 @@ the profile to IPv4 before Gluetun starts. Keep Deluge's AirVPN forwarded port
 fixed only for `listen_ports`; `outgoing_ports` should stay at Deluge's default
 random behavior, otherwise active torrents can report too few outgoing ports
 and fail to establish enough peer connections.
+If `deluge-vpn` is ready but Gluetun startup health checks fail with repeated
+DNS lookup timeouts through the tunnel, the likely repair is a fresh AirVPN
+WireGuard profile in SSM plus the matching annotation bump, not a live Pod
+patch or manual restart.
 
 ## Grafana
 


### PR DESCRIPTION
## Summary

This PR fixes the Argo CD SSO admin mapping discovered during the Deluge incident and carries the repo-owned rollout trigger for the Deluge VPN profile rotation.

Argo CD was accepting the OIDC login but leaving the operator effectively read-only. Live Dex logs showed Microsoft Entra emitted the admin group as the object ID `b200361e-a378-437a-9a47-731834f1524f`, while the Helm-managed Argo CD RBAC policy only granted `role:admin` to the friendly group name `argocd-admins`. As a result, users in the intended admin group fell through to `policy.default: role:readonly`.

The fix updates the bootstrap Terragrunt stack to grant admin access to the emitted Entra group object ID while preserving the friendly `argocd-admins` alias. The Argo CD bootstrap docs and knowledge-base identity notes now call out that Entra may emit object IDs in the Dex `groups` claim.

During the same investigation, Deluge was `Synced` but `Progressing`: the Deluge app and port sidecar were ready, `deluge-vpn` was synced, and the Kubernetes Secret existed, but the Gluetun restartable init sidecar repeatedly failed startup health checks with DNS lookup timeouts through the WireGuard tunnel. The SSM SecureString at `/homelab/deluge/vpn/wireguard-config` has been replaced with the operator-provided AirVPN profile without committing or printing the secret value. This PR bumps `homelab.rst.io/wireguard-profile-ssm-version` on both the `deluge-vpn` ExternalSecret and the Deluge pod template from `3` to `4` so External Secrets refreshes the Kubernetes Secret and Argo CD rolls the Pod after this reaches `main`.

The Deluge README and knowledge-base app notes also capture that this failure mode should be treated as an unhealthy WireGuard profile or VPN endpoint path, with remediation through SSM profile replacement plus annotation bump, not a live pod patch.

## Validation

- Validated the provided AirVPN file has the expected WireGuard profile structure without printing secret values.
- Replaced `/homelab/deluge/vpn/wireguard-config` in SSM as a SecureString; AWS returned parameter version `3`.
- `terragrunt hcl fmt --check`
- `terragrunt hcl validate`
- `kubectl kustomize clusters/homelab/apps/deluge`
- `helm template deluge bjw-s-labs/app-template --version 4.4.0 -f clusters/homelab/apps/deluge/values.yaml`
- `kubectl kustomize clusters/homelab/argocd/self-management`
- `git diff --check`
- `terragrunt plan` from `IaC/bootstrap/argocd`
  - Planned `0 to add, 1 to change, 0 to destroy`
  - Material Argo CD change is adding `g, b200361e-a378-437a-9a47-731834f1524f, role:admin` to `policy.csv`

## Operational notes

This PR does not commit the AirVPN profile. Deluge will not reload the new profile until this branch reaches `main` and Argo CD syncs the annotation bump through the declared GitOps path.


<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `1e45bd5bbcdc8870bc6df94df3e8da77e07ef131`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
