### PR TITLE
feat: configure n8n webhook funnel

### DIFF
--- a/clusters/homelab/apps/README.md
+++ b/clusters/homelab/apps/README.md
@@ -22,9 +22,9 @@ in `clusters/homelab/apps/argocd-image-updater/imageupdater.yaml`; Image Updater
 opens pull requests for those values instead of relying on live-only overrides.
 
 Most first-rollout routes are tailnet-only. Public Tailscale Funnel routes must
-stay limited to reviewed webhook exceptions such as Policy Bot's
-`/api/github/hook` route, and every exception must be documented in
-`docs/networking-tailnet-ingress.md`.
+stay limited to reviewed webhook exceptions such as n8n's webhook prefixes and
+Policy Bot's `/api/github/hook` route, and every exception must be documented
+in `docs/networking-tailnet-ingress.md`.
 
 Do not add a route just because an upstream chart exposes a web UI. Prefer the
 least direct reviewed access path. For example, Grafana is the operator-facing

--- a/clusters/homelab/apps/n8n/README.md
+++ b/clusters/homelab/apps/n8n/README.md
@@ -26,9 +26,31 @@ persisted settings file instead of crashlooping on an accidental mismatch.
 
 ## Access Contract
 
-- Host: `https://n8n.stinkyboi.com`
-- Ingress: `istio-system/tailnet-gateway`
-- Public Funnel: disabled
+- Editor/UI host: `https://n8n.stinkyboi.com`
+- Editor/UI ingress: `istio-system/tailnet-gateway`
+- Public webhook Funnel host: `https://n8n-webhook.tail67beb.ts.net`
+- Public webhook paths: `/webhook`, `/webhook-test`, and `/webhook-waiting`
+
+`WEBHOOK_URL` is set to the public Funnel host so n8n advertises externally
+reachable webhook URLs. The editor base URL stays on the tailnet-only
+`n8n.stinkyboi.com` host. The Funnel route is declared as a Tailscale Ingress
+in `istio-system` and forwards only the webhook path prefixes to the Istio
+gateway, which then routes to the n8n service. Do not add the root path, editor
+routes, static assets, or API routes to the Funnel Ingress.
+
+The Tailscale tailnet policy must allow the operator proxy tag, currently
+`tag:k8s`, to use Funnel:
+
+```json
+{
+  "nodeAttrs": [
+    {
+      "target": ["tag:k8s"],
+      "attr": ["funnel"]
+    }
+  ]
+}
+```
 
 ## Database Readiness
 
@@ -41,3 +63,28 @@ StatefulSet and PVC.
 Switching from the older SQLite-backed desired state does not automatically
 import rows from `/home/node/.n8n/database.sqlite`. Export workflows and
 credentials before rollout if the existing SQLite contents must be preserved.
+
+## Validation
+
+```sh
+kubectl kustomize clusters/homelab/apps/n8n
+kubectl -n automation get deploy,svc,externalsecret n8n n8n-secrets
+kubectl -n istio-system get gateway n8n-webhook-funnel
+kubectl -n istio-system get ingress n8n-webhook-funnel
+kubectl -n tailscale get statefulset,pod -l tailscale.com/parent-resource=n8n-webhook-funnel
+curl -I https://n8n.stinkyboi.com/
+curl -sS -o /dev/null -w '%{http_code}\n' https://n8n-webhook.tail67beb.ts.net/webhook/__missing__
+```
+
+Expected route behavior: the editor host serves n8n through the tailnet, the
+Funnel host reaches n8n only under the webhook prefixes, and an unknown
+webhook path returns an n8n not-found response until a workflow registers that
+webhook.
+
+## Rollback
+
+Rollback removes public webhook exposure first by removing
+`ingress-funnel.yaml` and `gateway-funnel.yaml` from the kustomization and
+restoring `WEBHOOK_URL` to the tailnet editor host. Then sync the n8n Argo CD
+Application. Preserve both the n8n PVC and `n8n-postgres` PVC unless the
+operator explicitly chooses to rebuild from exports.

--- a/clusters/homelab/apps/n8n/gateway-funnel.yaml
+++ b/clusters/homelab/apps/n8n/gateway-funnel.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.istio.io/v1beta1
+kind: Gateway
+metadata:
+  name: n8n-webhook-funnel
+  namespace: istio-system
+  annotations:
+    homelab.rst.io/public-funnel: "true"
+    homelab.rst.io/public-funnel-reviewed: "true"
+    homelab.rst.io/public-funnel-purpose: "n8n external webhook deliveries only."
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+    - port:
+        number: 80
+        name: http-n8n-webhook-funnel
+        protocol: HTTP
+      hosts:
+        - n8n-webhook.tail67beb.ts.net

--- a/clusters/homelab/apps/n8n/ingress-funnel.yaml
+++ b/clusters/homelab/apps/n8n/ingress-funnel.yaml
@@ -1,0 +1,39 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: n8n-webhook-funnel
+  namespace: istio-system
+  annotations:
+    tailscale.com/funnel: "true"
+    homelab.rst.io/public-funnel: "true"
+    homelab.rst.io/public-funnel-reviewed: "true"
+    homelab.rst.io/public-funnel-purpose: "n8n external webhook deliveries only."
+spec:
+  ingressClassName: tailscale
+  tls:
+    - hosts:
+        - n8n-webhook
+  rules:
+    - http:
+        paths:
+          - path: /webhook
+            pathType: Prefix
+            backend:
+              service:
+                name: istio-ingressgateway
+                port:
+                  name: http2
+          - path: /webhook-test
+            pathType: Prefix
+            backend:
+              service:
+                name: istio-ingressgateway
+                port:
+                  name: http2
+          - path: /webhook-waiting
+            pathType: Prefix
+            backend:
+              service:
+                name: istio-ingressgateway
+                port:
+                  name: http2

--- a/clusters/homelab/apps/n8n/kustomization.yaml
+++ b/clusters/homelab/apps/n8n/kustomization.yaml
@@ -4,4 +4,6 @@ resources:
   - namespace.yaml
   - externalsecret.yaml
   - authorizationpolicy.yaml
+  - gateway-funnel.yaml
+  - ingress-funnel.yaml
   - virtualservice.yaml

--- a/clusters/homelab/apps/n8n/values.yaml
+++ b/clusters/homelab/apps/n8n/values.yaml
@@ -61,7 +61,7 @@ controllers:
           N8N_PROXY_HOPS: "1"
           N8N_SECURE_COOKIE: "true"
           N8N_EDITOR_BASE_URL: https://n8n.stinkyboi.com
-          WEBHOOK_URL: https://n8n.stinkyboi.com/
+          WEBHOOK_URL: https://n8n-webhook.tail67beb.ts.net/
           DB_TYPE: postgresdb
           DB_POSTGRESDB_HOST: n8n-postgres.automation.svc.cluster.local
           DB_POSTGRESDB_PORT: "5432"

--- a/clusters/homelab/apps/n8n/virtualservice.yaml
+++ b/clusters/homelab/apps/n8n/virtualservice.yaml
@@ -8,10 +8,47 @@ metadata:
 spec:
   hosts:
     - n8n.stinkyboi.com
+    - n8n-webhook.tail67beb.ts.net
   gateways:
     - istio-system/tailnet-gateway
+    - istio-system/n8n-webhook-funnel
   http:
-    - route:
+    - name: public-webhooks
+      match:
+        - gateways:
+            - istio-system/n8n-webhook-funnel
+          uri:
+            exact: /webhook
+        - gateways:
+            - istio-system/n8n-webhook-funnel
+          uri:
+            prefix: /webhook/
+        - gateways:
+            - istio-system/n8n-webhook-funnel
+          uri:
+            exact: /webhook-test
+        - gateways:
+            - istio-system/n8n-webhook-funnel
+          uri:
+            prefix: /webhook-test/
+        - gateways:
+            - istio-system/n8n-webhook-funnel
+          uri:
+            exact: /webhook-waiting
+        - gateways:
+            - istio-system/n8n-webhook-funnel
+          uri:
+            prefix: /webhook-waiting/
+      route:
+        - destination:
+            host: n8n.automation.svc.cluster.local
+            port:
+              number: 5678
+    - name: tailnet-ui
+      match:
+        - gateways:
+            - istio-system/tailnet-gateway
+      route:
         - destination:
             host: n8n.automation.svc.cluster.local
             port:

--- a/docs/knowledge-base/runbooks/rollback.md
+++ b/docs/knowledge-base/runbooks/rollback.md
@@ -48,6 +48,10 @@ written workflows, users, credentials metadata, or execution history to
 PostgreSQL. Preserve both the PostgreSQL PVC and n8n PVC unless intentionally
 rebuilding from exports.
 
+n8n public webhook exposure is independent of stored workflow data. Remove
+`n8n-webhook-funnel`, its Gateway, and the public `WEBHOOK_URL` before rolling
+back the app.
+
 Policy Bot is stateless. Roll back its public exposure by removing
 `policy-bot-hook-funnel` first.
 

--- a/docs/knowledge-base/runbooks/tailnet-ingress.md
+++ b/docs/knowledge-base/runbooks/tailnet-ingress.md
@@ -16,9 +16,12 @@ address from tailnet clients. DNS is not managed by this repo yet.
 ## Current Route Rules
 
 - Argo CD, Grafana, Kiali, Deluge, Prowlarr, Radarr, Sonarr, LiteLLM,
-  OpenClaw, n8n, Policy Bot UI and normal routes, and OctoBot UI are
+  OpenClaw, n8n editor/UI, Policy Bot UI and normal routes, and OctoBot UI are
   tailnet-only.
-- Policy Bot GitHub webhook is the reviewed public Funnel exception:
+- n8n webhooks are a reviewed public Funnel exception:
+  `https://n8n-webhook.tail67beb.ts.net` for `/webhook`, `/webhook-test`, and
+  `/webhook-waiting` only.
+- Policy Bot GitHub webhook is another reviewed public Funnel exception:
   `https://policy-bot-hook.<tailnet-name>.ts.net/api/github/hook`.
 - Prometheus is intentionally not exposed; Grafana is the metrics UI and Kiali
   is the read-only mesh UI.

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -17,7 +17,7 @@ private keys, raw certificate material, private kubeconfigs, or private
 hostnames.
 
 Most routes are tailnet-only. Public Funnel is limited to reviewed webhook
-exceptions such as Policy Bot's `/api/github/hook`.
+exceptions such as n8n's webhook prefixes and Policy Bot's `/api/github/hook`.
 
 ## Platform DNS
 
@@ -199,6 +199,13 @@ instance key.
 The PostgreSQL desired state preserves the old SQLite file on the PVC but does
 not automatically import rows from it. Export workflows and credentials before
 rollout when existing SQLite contents must be preserved.
+
+n8n keeps the editor and API on `https://n8n.stinkyboi.com`, but advertises
+workflow webhook URLs through `https://n8n-webhook.tail67beb.ts.net`. The
+Funnel route is limited to `/webhook`, `/webhook-test`, and
+`/webhook-waiting`, and forwards through the Istio ingress gateway so the n8n
+workload AuthorizationPolicy can continue allowing only the gateway service
+account.
 
 ## Policy Bot
 

--- a/docs/knowledge-base/workloads/inventory.md
+++ b/docs/knowledge-base/workloads/inventory.md
@@ -39,7 +39,7 @@ trading workload with a tailnet-only UI.
 | `sonarr` | `media` | `clusters/homelab/apps/sonarr` | `IaC/live/argocd-apps/sonarr` | persistent config and PostgreSQL databases on `nfs-default`; TV and downloads on QNAP `/media` | cert-manager, istio, tailscale, deluge, media-postgres, prowlarr, platform-storage |
 | `litellm` | `ai` | `clusters/homelab/apps/litellm` | `IaC/live/argocd-apps/litellm` | optional persistent config or DB state | external-secrets, cert-manager, istio, tailscale, platform-storage |
 | `openclaw` | `ai` | `clusters/homelab/apps/openclaw` | `IaC/live/argocd-apps/openclaw` | persistent runtime state, SSM-backed gateway auth, Discord channel config, SSM-backed GitHub App credentials, Codex OAuth credentials on PVC, and explicit agent resource profile | external-secrets, cert-manager, istio, tailscale, litellm, platform-storage |
-| `n8n` | `automation` | `clusters/homelab/apps/n8n` | `IaC/live/argocd-apps/n8n` | persistent workflows, credential metadata, users, and execution history in n8n-postgres; instance settings and file-backed runtime data on PVC; SSM key bootstraps fresh PVCs only | external-secrets, cert-manager, istio, tailscale, platform-storage, n8n-postgres |
+| `n8n` | `automation` | `clusters/homelab/apps/n8n` | `IaC/live/argocd-apps/n8n` | persistent workflows, credential metadata, users, and execution history in n8n-postgres; instance settings and file-backed runtime data on PVC; SSM key bootstraps fresh PVCs only; public Funnel is limited to webhook prefixes | external-secrets, cert-manager, istio, tailscale, platform-storage, n8n-postgres |
 | `policy-bot` | `automation` | `clusters/homelab/apps/policy-bot` | `IaC/live/argocd-apps/policy-bot` | stateless GitHub App policy evaluator; one replica after SSM placeholders are replaced | external-secrets, cert-manager, istio, tailscale |
 | `octobot` | `finance` | `clusters/homelab/apps/octobot` | `IaC/live/argocd-apps/octobot` | UI-configured bot state, tentacles, exchange credentials after operator setup, logs, and tailnet-only UI route | cert-manager, istio, tailscale, platform-storage |
 
@@ -51,11 +51,13 @@ namespaces. The source of truth is `docs/runtime-isolation.md` plus the
 
 - `ai` uses a namespace default-deny policy and explicit inbound allows for the
   tailnet gateway to `litellm` and `openclaw`, plus `openclaw` to `litellm`.
-- `automation` currently restricts `n8n` inbound access to the tailnet gateway.
-  `n8n-postgres` has a NetworkPolicy that documents n8n-only database access,
-  but the current flannel CNI does not enforce NetworkPolicy yet. The namespace
-  is not default-denied because Policy Bot Funnel traffic and database
-  source-identity validation still need live validation after rollout.
+- `automation` currently restricts `n8n` workload access to the Istio gateway;
+  the reviewed public n8n webhook Funnel forwards into that gateway instead of
+  directly to the workload. `n8n-postgres` has a NetworkPolicy that documents
+  n8n-only database access, but the current flannel CNI does not enforce
+  NetworkPolicy yet. The namespace is not default-denied because Policy Bot
+  Funnel traffic and database source-identity validation still need live
+  validation after rollout.
 - `monitoring` restricts Grafana, Prometheus, Alertmanager, and
   kube-state-metrics by service account. The Prometheus operator remains
   unselected until its webhook/control-plane paths are modeled.

--- a/docs/networking-tailnet-ingress.md
+++ b/docs/networking-tailnet-ingress.md
@@ -29,7 +29,8 @@ that must be added through a separate Terragrunt/OpenTofu entry point.
 | sonarr | `https://sonarr.stinkyboi.com` | disabled |
 | litellm | `https://litellm.stinkyboi.com` | disabled |
 | openclaw | `https://openclaw.stinkyboi.com` | disabled |
-| n8n | `https://n8n.stinkyboi.com` | disabled |
+| n8n editor/UI | `https://n8n.stinkyboi.com` | disabled |
+| n8n webhooks | `https://n8n-webhook.tail67beb.ts.net/webhook...` | enabled for `/webhook`, `/webhook-test`, and `/webhook-waiting` only |
 | policy-bot UI and normal routes | `https://policy-bot.stinkyboi.com` | disabled |
 | octobot UI | `https://octobot.stinkyboi.com` | disabled |
 | policy-bot GitHub webhook | `https://policy-bot-hook.<tailnet-name>.ts.net/api/github/hook` | enabled for `/api/github/hook` only |
@@ -43,13 +44,13 @@ Istio terminates HTTPS with the `stinkyboi-com-tls` certificate in
 not referenced by the ingress wildcard certificate.
 
 Validation on 2026-05-24 found no enabled first-rollout Funnel routes. Policy
-Bot adds the first reviewed Funnel exception for GitHub webhook delivery only.
-The `policy-bot-hook-funnel` Tailscale Ingress is annotated with
-`homelab.rst.io/public-funnel: "true"` and
-`homelab.rst.io/public-funnel-reviewed: "true"`; the Policy Bot UI
-VirtualService remains annotated with `homelab.rst.io/public-funnel: "false"`.
-Every other Istio gateway and VirtualService route manifest remains
-tailnet-only.
+Bot later added a reviewed Funnel exception for GitHub webhook delivery, and
+n8n now adds a reviewed Funnel exception for workflow webhook delivery. The
+`policy-bot-hook-funnel` and `n8n-webhook-funnel` Tailscale Ingresses are
+annotated with `homelab.rst.io/public-funnel: "true"` and
+`homelab.rst.io/public-funnel-reviewed: "true"`; the Policy Bot UI and n8n
+editor routes remain private. Every other Istio gateway and VirtualService
+route manifest remains tailnet-only.
 
 The Istio ingressgateway Service is a Tailscale `LoadBalancer` and sets
 `allocateLoadBalancerNodePorts: false` so the gateway is not exposed through
@@ -127,6 +128,27 @@ Data exposed: webhook request body and headers sent by GitHub.
 The Policy Bot UI, details routes, static assets, OAuth callback, and root path
 stay on `https://policy-bot.stinkyboi.com` through the tailnet-only Istio
 gateway. Only `/api/github/hook` is exposed through Funnel.
+
+## n8n Webhook Funnel Exception
+
+n8n must advertise webhook URLs that external SaaS systems can call. The
+reviewed public route is:
+
+```text
+Owning application: n8n
+Public paths: /webhook, /webhook-test, /webhook-waiting
+Purpose: n8n workflow webhook deliveries from external systems.
+Source system: workflow-specific SaaS integrations and HTTP clients configured in n8n.
+Authentication or signature check: workflow-specific n8n webhook credentials, node-level signing, or path entropy where configured.
+Tailscale Funnel hostname: n8n-webhook.tail67beb.ts.net
+Rollback command: revert clusters/homelab/apps/n8n/ingress-funnel.yaml, clusters/homelab/apps/n8n/gateway-funnel.yaml, and the WEBHOOK_URL change, then sync the n8n Application.
+Data exposed: request bodies and headers sent to active n8n webhook workflows.
+```
+
+The n8n editor, REST API, static assets, and root path stay on
+`https://n8n.stinkyboi.com` through the tailnet-only Istio gateway. The Funnel
+Ingress forwards only webhook path prefixes to the Istio gateway, and the n8n
+VirtualService only routes those prefixes on the public webhook gateway.
 
 ## Future Funnel Webhook Exception Template
 

--- a/docs/rollback-argocd-apps.md
+++ b/docs/rollback-argocd-apps.md
@@ -44,6 +44,11 @@ has already written workflows, users, credentials metadata, or execution
 history to PostgreSQL. Preserve both the PostgreSQL PVC and the n8n
 `/home/node/.n8n` PVC unless intentionally rebuilding from exports.
 
+n8n public webhook exposure is independent of its stored workflow data. Remove
+`n8n-webhook-funnel`, the `n8n-webhook-funnel` Gateway, and the public
+`WEBHOOK_URL` first, then roll back the app while preserving both n8n PVCs
+unless intentionally rebuilding from exports.
+
 Policy Bot is stateless. Roll back its public exposure by removing the
 `policy-bot-hook-funnel` Ingress first, then roll back the Deployment and
 ExternalSecret if the GitHub App should stop evaluating pull requests.

--- a/docs/runtime-isolation.md
+++ b/docs/runtime-isolation.md
@@ -48,7 +48,7 @@ The current service access contract is:
 | `litellm` | `ai` | `cluster.local/ns/istio-system/sa/istio-ingressgateway` | Tailnet UI/API ingress. |
 | `litellm` | `ai` | `cluster.local/ns/ai/sa/openclaw` | OpenClaw model gateway calls. |
 | `openclaw` | `ai` | `cluster.local/ns/istio-system/sa/istio-ingressgateway` | Tailnet UI ingress. |
-| `n8n` | `automation` | `cluster.local/ns/istio-system/sa/istio-ingressgateway` | Tailnet UI and webhook ingress through the private gateway. |
+| `n8n` | `automation` | `cluster.local/ns/istio-system/sa/istio-ingressgateway` | Tailnet UI ingress and reviewed n8n webhook Funnel traffic forwarded through the Istio gateway. |
 | `grafana` | `monitoring` | `cluster.local/ns/istio-system/sa/istio-ingressgateway` | Tailnet UI ingress. |
 | `grafana` | `monitoring` | `cluster.local/ns/monitoring/sa/kiali-service-account` | Kiali dashboard links and health checks. |
 | `grafana` | `monitoring` | `cluster.local/ns/monitoring/sa/prometheus-kube-prometheus-prometheus` | Prometheus scrapes Grafana metrics. |

--- a/docs/validation-runbook.md
+++ b/docs/validation-runbook.md
@@ -130,6 +130,19 @@ the PVC, and an authenticated connection to the `n8n` database documented in
 `clusters/homelab/apps/n8n-postgres/README.md` before treating n8n as migrated
 to PostgreSQL.
 
+n8n webhooks use the reviewed Tailscale Funnel route at
+`https://n8n-webhook.tail67beb.ts.net`. After sync, verify the Tailscale
+Ingress and operator proxy exist, then check that the editor host remains on
+the tailnet-only route and the public host only reaches n8n under webhook path
+prefixes:
+
+```sh
+kubectl -n istio-system get gateway,ingress n8n-webhook-funnel
+kubectl -n tailscale get statefulset,pod -l tailscale.com/parent-resource=n8n-webhook-funnel
+curl -I https://n8n.stinkyboi.com/
+curl -sS -o /dev/null -w '%{http_code}\n' https://n8n-webhook.tail67beb.ts.net/webhook/__missing__
+```
+
 ## Current Validation Record
 
 - Read-only `showmount -e 10.1.0.2` verified the QNAP `/homelab` export is
@@ -152,8 +165,10 @@ to PostgreSQL.
 - Repository secret scan found no raw secret material. Matches were expected
   ExternalSecret names, AWS SSM paths, documentation references, and existing
   placeholder environment variable names.
-- First-rollout Funnel review found no enabled public Funnel paths; route
-  manifests use `homelab.rst.io/public-funnel: "false"`.
+- First-rollout Funnel review found no enabled public Funnel paths. Later
+  reviewed exceptions must carry `homelab.rst.io/public-funnel: "true"` and
+  `homelab.rst.io/public-funnel-reviewed: "true"` and be documented in
+  `docs/networking-tailnet-ingress.md`.
 - Prometheus direct tailnet ingress is intentionally absent from desired state;
   Grafana is the reviewed operator-facing metrics UI.
 - First live rollout on 2026-05-24 applied AWS SSM Parameter Store placeholders
@@ -204,5 +219,6 @@ to PostgreSQL.
 | Media PostgreSQL unavailable | Hold Sonarr, Radarr, and Prowlarr; verify `media-postgres-auth`, `media-postgres-arr-env`, the StatefulSet, and the six logical databases before app sync. |
 | Tailscale unavailable | Do not expose tailnet VirtualServices as ready, even if workloads are healthy. |
 | Policy Bot webhook unreachable | Confirm the Tailscale `funnel` node attribute for `tag:k8s`, then inspect the `policy-bot-hook-funnel` Ingress and the operator-managed proxy Pod; do not expose additional Funnel routes. |
+| n8n webhook unreachable | Confirm the Tailscale `funnel` node attribute for `tag:k8s`, then inspect the `n8n-webhook-funnel` Ingress, Gateway, VirtualService, and operator-managed proxy Pod; keep editor/API routes off Funnel. |
 | Image updater misconfiguration | Remove the affected `applicationRefs` image entry or write-back target from `clusters/homelab/apps/argocd-image-updater/imageupdater.yaml`, then fix the repository desired state. |
 | Argo CD app unhealthy | Record status, operator action, and rollback decision in `docs/argocd-app-onboarding.md`. |


### PR DESCRIPTION
## Summary

This PR configures n8n to advertise external webhook URLs through a reviewed
Tailscale Funnel endpoint while keeping the editor and API on the existing
tailnet-only host.

n8n previously used `https://n8n.stinkyboi.com/` as `WEBHOOK_URL`. That host is
private to the tailnet, which is the right boundary for the editor UI but not a
working callback URL for external SaaS systems that need to deliver workflow
webhooks. The effect is that workflows can generate webhook URLs that external
senders cannot reach unless the sender is also inside the tailnet.

The root cause was that n8n had only one ingress contract: the private
`n8n.stinkyboi.com` Istio route. The repo already had a reviewed pattern for
public webhook-only Funnel exposure through Policy Bot, but n8n had not been
split into private editor access plus public webhook delivery.

## Fix

- Set n8n `WEBHOOK_URL` to `https://n8n-webhook.tail67beb.ts.net/`.
- Add a Tailscale Funnel Ingress named `n8n-webhook-funnel`.
- Add an Istio Gateway for the public n8n webhook host.
- Update the n8n VirtualService so only `/webhook`, `/webhook-test`, and
  `/webhook-waiting` route through the public webhook gateway.
- Keep `https://n8n.stinkyboi.com` as the editor/UI base URL and private
  tailnet route.
- Document validation, rollback, runtime isolation, and knowledge-base context.

Funnel traffic is forwarded through the existing Istio ingress gateway instead
of directly to the n8n workload, so the n8n AuthorizationPolicy can continue to
allow only `cluster.local/ns/istio-system/sa/istio-ingressgateway`.

## Validation

- `kubectl kustomize clusters/homelab/apps/n8n`
- `helm template n8n app-template --repo https://bjw-s-labs.github.io/helm-charts --version 4.4.0 --namespace automation -f clusters/homelab/apps/n8n/values.yaml`
- `bash scripts/ci/static-checks.sh`
- `kubectl diff --server-side --force-conflicts --field-manager=argocd-controller -k clusters/homelab/apps/n8n`

Checkov reported zero failed Terraform, Kubernetes, and secrets checks. Local
Checkov also warned that it could not resolve Prisma Cloud guideline metadata,
which does not affect the pass/fail result.


<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `5f5bbf3aa143284e4790543194ec818249ecc3bf`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
