### PR TITLE
fix(grafana): rerun alert cleanup hook

### DIFF
--- a/clusters/homelab/apps/grafana-alert-cleanup/job.yaml
+++ b/clusters/homelab/apps/grafana-alert-cleanup/job.yaml
@@ -2,34 +2,37 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: grafana-alerting-cleanup-v2
+  name: grafana-alerting-cleanup-v3
   namespace: monitoring
   labels:
-    app.kubernetes.io/name: grafana-alerting-cleanup-v2
+    app.kubernetes.io/name: grafana-alerting-cleanup-v3
     app.kubernetes.io/part-of: homelab-monitoring
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: grafana-alerting-cleanup-v2
+  name: grafana-alerting-cleanup-v3
   namespace: monitoring
   labels:
-    app.kubernetes.io/name: grafana-alerting-cleanup-v2
+    app.kubernetes.io/name: grafana-alerting-cleanup-v3
     app.kubernetes.io/part-of: homelab-monitoring
 spec:
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: grafana-alerting-cleanup-v2
+      app.kubernetes.io/name: grafana-alerting-cleanup-v3
       app.kubernetes.io/part-of: homelab-monitoring
   policyTypes:
     - Egress
   egress:
     - to:
-        - ipBlock:
-            cidr: 0.0.0.0/0
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: grafana
       ports:
         - protocol: TCP
-          port: 443
+          port: 3000
+        - protocol: TCP
+          port: 80
     - to:
         - namespaceSelector:
             matchLabels:
@@ -43,10 +46,10 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: grafana-alerting-cleanup-v2
+  name: grafana-alerting-cleanup-v3
   namespace: monitoring
   labels:
-    app.kubernetes.io/name: grafana-alerting-cleanup-v2
+    app.kubernetes.io/name: grafana-alerting-cleanup-v3
     app.kubernetes.io/part-of: homelab-monitoring
   annotations:
     argocd.argoproj.io/hook: Sync
@@ -57,12 +60,12 @@ spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: grafana-alerting-cleanup-v2
+        app.kubernetes.io/name: grafana-alerting-cleanup-v3
         app.kubernetes.io/part-of: homelab-monitoring
     spec:
       automountServiceAccountToken: false
       restartPolicy: Never
-      serviceAccountName: grafana-alerting-cleanup-v2
+      serviceAccountName: grafana-alerting-cleanup-v3
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534
@@ -75,7 +78,7 @@ spec:
           image: python:3.13-alpine@sha256:420cd0bf0f3998275875e02ecd5808168cf0843cbb4d3c536432f729247b2acc
           env:
             - name: GRAFANA_URL
-              value: https://grafana.stinkyboi.com
+              value: http://grafana.monitoring.svc.cluster.local
           command:
             - python
             - -c

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -79,7 +79,9 @@ The Infinity plugin is pinned with the Grafana release ZIP syntax in
 Grafana treats it as the plugin ID and fails startup with a plugin-catalog 404.
 The stale-alert cleanup is isolated in
 `clusters/homelab/apps/grafana-alert-cleanup`, where the Job waits for Grafana
-health before calling the provisioning API. Do not embed one-shot Grafana API
+health through the in-cluster Grafana service before calling the provisioning
+API. Bump the cleanup resource names when re-running the hook; hook-only edits
+do not reliably create Argo CD autosync drift. Do not embed one-shot Grafana API
 cleanup hooks in the Prometheus app.
 Its Helm-rendered Deployment uses a resource-level Argo CD `Replace=true` sync
 option because the app keeps a `Recreate` strategy for the single Grafana PVC,


### PR DESCRIPTION
## Summary
- bump grafana-alert-cleanup resources to v3 so Argo CD sees normal resource drift and reruns the Sync hook
- use the in-cluster Grafana service instead of the public Grafana route for the cleanup API calls
- document why cleanup hook reruns need a resource-name bump in the knowledge base

## Validation
- kubectl kustomize clusters/homelab/apps/grafana-alert-cleanup
- kubectl diff -k clusters/homelab/apps/grafana-alert-cleanup
- bash scripts/ci/static-checks.sh

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `c9bf0b8402e064643a54d2c27c2595044bb2c685`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
