### PR TITLE
fix(grafana): route cleanup through ingress

### DIFF
--- a/clusters/homelab/apps/grafana-alert-cleanup/job.yaml
+++ b/clusters/homelab/apps/grafana-alert-cleanup/job.yaml
@@ -2,37 +2,34 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: grafana-alerting-cleanup-v3
+  name: grafana-alerting-cleanup-v4
   namespace: monitoring
   labels:
-    app.kubernetes.io/name: grafana-alerting-cleanup-v3
+    app.kubernetes.io/name: grafana-alerting-cleanup-v4
     app.kubernetes.io/part-of: homelab-monitoring
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: grafana-alerting-cleanup-v3
+  name: grafana-alerting-cleanup-v4
   namespace: monitoring
   labels:
-    app.kubernetes.io/name: grafana-alerting-cleanup-v3
+    app.kubernetes.io/name: grafana-alerting-cleanup-v4
     app.kubernetes.io/part-of: homelab-monitoring
 spec:
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: grafana-alerting-cleanup-v3
+      app.kubernetes.io/name: grafana-alerting-cleanup-v4
       app.kubernetes.io/part-of: homelab-monitoring
   policyTypes:
     - Egress
   egress:
     - to:
-        - podSelector:
-            matchLabels:
-              app.kubernetes.io/name: grafana
+        - ipBlock:
+            cidr: 0.0.0.0/0
       ports:
         - protocol: TCP
-          port: 3000
-        - protocol: TCP
-          port: 80
+          port: 443
     - to:
         - namespaceSelector:
             matchLabels:
@@ -46,26 +43,27 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: grafana-alerting-cleanup-v3
+  name: grafana-alerting-cleanup-v4
   namespace: monitoring
   labels:
-    app.kubernetes.io/name: grafana-alerting-cleanup-v3
+    app.kubernetes.io/name: grafana-alerting-cleanup-v4
     app.kubernetes.io/part-of: homelab-monitoring
   annotations:
     argocd.argoproj.io/hook: Sync
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
 spec:
   backoffLimit: 1
+  activeDeadlineSeconds: 900
   ttlSecondsAfterFinished: 3600
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: grafana-alerting-cleanup-v3
+        app.kubernetes.io/name: grafana-alerting-cleanup-v4
         app.kubernetes.io/part-of: homelab-monitoring
     spec:
       automountServiceAccountToken: false
       restartPolicy: Never
-      serviceAccountName: grafana-alerting-cleanup-v3
+      serviceAccountName: grafana-alerting-cleanup-v4
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534
@@ -78,7 +76,9 @@ spec:
           image: python:3.13-alpine@sha256:420cd0bf0f3998275875e02ecd5808168cf0843cbb4d3c536432f729247b2acc
           env:
             - name: GRAFANA_URL
-              value: http://grafana.monitoring.svc.cluster.local
+              value: https://grafana.stinkyboi.com
+            - name: PYTHONUNBUFFERED
+              value: "1"
           command:
             - python
             - -c

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -79,10 +79,11 @@ The Infinity plugin is pinned with the Grafana release ZIP syntax in
 Grafana treats it as the plugin ID and fails startup with a plugin-catalog 404.
 The stale-alert cleanup is isolated in
 `clusters/homelab/apps/grafana-alert-cleanup`, where the Job waits for Grafana
-health through the in-cluster Grafana service before calling the provisioning
-API. Bump the cleanup resource names when re-running the hook; hook-only edits
-do not reliably create Argo CD autosync drift. Do not embed one-shot Grafana API
-cleanup hooks in the Prometheus app.
+health through the public Grafana route before calling the provisioning API.
+The public route keeps cleanup traffic on the same Istio AuthorizationPolicy
+path as normal ingressgateway traffic. Bump the cleanup resource names when
+re-running the hook; hook-only edits do not reliably create Argo CD autosync
+drift. Do not embed one-shot Grafana API cleanup hooks in the Prometheus app.
 Its Helm-rendered Deployment uses a resource-level Argo CD `Replace=true` sync
 option because the app keeps a `Recreate` strategy for the single Grafana PVC,
 and server-side apply can otherwise preserve stale `rollingUpdate` fields.


### PR DESCRIPTION
## Summary
- bump grafana-alert-cleanup to v4 so Argo CD gets a fresh normal-resource diff and hook run
- route the cleanup job through the public Grafana ingress path that Grafana's Istio AuthorizationPolicy already allows
- add an active deadline and unbuffered output for easier hook diagnosis

## Validation
- kubectl kustomize clusters/homelab/apps/grafana-alert-cleanup
- kubectl diff -k clusters/homelab/apps/grafana-alert-cleanup
- bash scripts/ci/static-checks.sh

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `fdf7a0d9d71e19283c7cb9706158e1d4d2591c3f`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
