### PR TITLE
fix(grafana): allow cleanup hook traffic

### DIFF
--- a/clusters/homelab/apps/grafana/authorizationpolicy.yaml
+++ b/clusters/homelab/apps/grafana/authorizationpolicy.yaml
@@ -13,5 +13,7 @@ spec:
         - source:
             principals:
               - cluster.local/ns/istio-system/sa/istio-ingressgateway
+              - cluster.local/ns/monitoring/sa/grafana-alerting-cleanup-v3
+              - cluster.local/ns/monitoring/sa/grafana-alerting-cleanup-v4
               - cluster.local/ns/monitoring/sa/kiali-service-account
               - cluster.local/ns/monitoring/sa/prometheus-kube-prometheus-prometheus

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -81,9 +81,11 @@ The stale-alert cleanup is isolated in
 `clusters/homelab/apps/grafana-alert-cleanup`, where the Job waits for Grafana
 health through the public Grafana route before calling the provisioning API.
 The public route keeps cleanup traffic on the same Istio AuthorizationPolicy
-path as normal ingressgateway traffic. Bump the cleanup resource names when
-re-running the hook; hook-only edits do not reliably create Argo CD autosync
-drift. Do not embed one-shot Grafana API cleanup hooks in the Prometheus app.
+path as normal ingressgateway traffic. Grafana's AuthorizationPolicy also keeps
+the cleanup hook service accounts allowed so stale direct-service retries can
+drain after hook revisions. Bump the cleanup resource names when re-running the
+hook; hook-only edits do not reliably create Argo CD autosync drift. Do not
+embed one-shot Grafana API cleanup hooks in the Prometheus app.
 Its Helm-rendered Deployment uses a resource-level Argo CD `Replace=true` sync
 option because the app keeps a `Recreate` strategy for the single Grafana PVC,
 and server-side apply can otherwise preserve stale `rollingUpdate` fields.


### PR DESCRIPTION
## Summary
- allow the grafana-alert-cleanup hook service accounts through Grafana's Istio AuthorizationPolicy
- keep stale v3 cleanup retries able to drain so Argo CD can advance to current main
- document the cleanup hook authorization behavior in the knowledge base

## Validation
- kubectl kustomize clusters/homelab/apps/grafana
- kubectl diff -k clusters/homelab/apps/grafana
- bash scripts/ci/static-checks.sh

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `d47d51f27516b569b4baf492d52022d33075ff3f`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
