### PR TITLE
feat: add compass dashboard

### DIFF
--- a/IaC/live/argocd-apps/compass/.terraform.lock.hcl
+++ b/IaC/live/argocd-apps/compass/.terraform.lock.hcl
@@ -1,0 +1,61 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/helm" {
+  version = "3.1.2"
+  hashes = [
+    "h1:/VUREiyZMl1eVhfP93ei2++icqCplwhbgnBOTkTtzzA=",
+    "h1:25CzVj9GuKGfw88HtwqL0WOInaLiF5KX78Z5OqIjDuk=",
+    "h1:4VdWEsHM8KAGvOK61o7Cixh2HJUGgU94z0G6ul3g4/o=",
+    "h1:6jUglYAslvNAMz9z2IRtN+8WfscWiuKT87g4+RrqJos=",
+    "h1:EMClfcSNrMMzgnILRDIerdXw3OAULaQl9z6sCijLvmA=",
+    "h1:FlpAxSdWRdIPGGxk6ZjPA+AO0/4uPzozOoXWqXyrJkM=",
+    "h1:IGtUsOqG58bvvnoUU2mscSX9ct6Eh5FuNBLqsj25cac=",
+    "h1:MaE3Sdms+azLMaJ/qyOMwB/oGRNZoLDXe9xOO++caLI=",
+    "h1:dOv8CvGY3rt0kxZSMAqZ+T3MVeGZv1QJHIHnJ/+vixM=",
+    "h1:m2OmZjs/dOY12WISyYbluIQsGfHlUUAhStHzWRT4nvw=",
+    "h1:mIPjqiF8i/UYvT07TnaUEWb+qevw+Lsll1aG1vDvHgs=",
+    "h1:o5JvcYdIL1yrGdEinnhxGt1kZ2isNj4IFebczxkg0tU=",
+    "h1:rmBw/eGqLcufwhYL1bXon4JB25yCh+umWCqMTsswhsM=",
+    "h1:swgKOvFXEm2/Io9oBV7/kzoN4czPfZ2+3OYBSm8LquE=",
+    "h1:uhk06wDUO/8jOH2XLfVzfbuNGTnY9Q0LQOPI6GmgJtc=",
+    "zh:159f79c708c60338503bcdee64977b93c11c1a4fa62fb96e70dadc1909e58f51",
+    "zh:1c126fa68dc6b6cae1a944eb305be856ce623a636dd7bf7751e6b2dba69a28b4",
+    "zh:2c6cf5c667bbfde908e8284d861c0d75786576d5a85ae914356837bed9a75348",
+    "zh:32a515c7eb3c7e9d4b1f6e191fac05004cdff56396eb3e2c84f0ae1e31b897e8",
+    "zh:4991c33b11d6d9c3ec7daabf6de5917ef5660e3402150b36e6da7196c4f336f1",
+    "zh:4e346bb727b155054a59538c966f0874ff8732917d974099ce51a29cdfacafdc",
+    "zh:590bfc70b4b466d5dccd5eca229a956c76b113ac8dc4cebf60919396aef26bdb",
+    "zh:7b4906da5f41466651f5eba630e4644d43767423c6a846a4189519dd7d6605f4",
+    "zh:a023f1c4c8d547de26d2f8a3347feae7beb17927eb0d08a4bc6edb6639be49b6",
+    "zh:ae873346811ac7946ae229b73cff670541bcf37eadc5b31a2d4feed1659de715",
+    "zh:b85e4f9245e9766476e6890dcfa13c238dbf59c905f730c41f53b7890b91993b",
+    "zh:c644abe6f05cee80d07bbacdadd8df9a376b25f44e2aa7b1d7631fab4e3625f8",
+    "zh:cdeb911f0ceb6e8b8b2f58dc40ce05edf7bf670cee0ad9e37eb90208869e7062",
+    "zh:ecb5302f085a0c29aa3b63aea54c435c3302e39bd605ffedd08c2d8ce2ccba99",
+    "zh:ff62b1e9267d5ee55013051563ceeaa7ec1f77b38afceaac28555f3545571ade",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/kubernetes" {
+  version     = "3.1.0"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:0M9Nu8YersHl84pfFTRiW5UfmoxQC3xKJ+Zkt5WjEv8=",
+    "zh:06f1310b47ff31593766b4b664a508276e57f911c9e0237c6cb197a590e2d799",
+    "zh:54aad7284e03c49996477f777c20b75ad12acbd68e80e86ecd1bd1ae6cfa5bea",
+    "zh:5ad86522ff9343ac8a2b8b595ba7280de82966dd6feb6aa87b6b9103b694bf82",
+    "zh:6506c8356b82f8c03f937efc68eee7a4ded1c77791552b530d3edf245ea97df4",
+    "zh:6dab1c6eb3cb5c1738e1ca8c2c54e3ca30ef3a83dd3453491edbe2ff525e1392",
+    "zh:754a9aef6d8456bae74bc2ab5a62c4c2146f0d79c4a817abe9d93567d1df26ef",
+    "zh:75689548a4731f2f9f9ebe5fef971f3ee1464f1a0c4505f86ee1ef07cc228a0e",
+    "zh:7e25f27dcbf73c5c83e9ee38a6e8110a8f889c902fc907e01a0820148d12604a",
+    "zh:a080838edc0ebec1b556432fb1fde310effaa5ba5f504d105abbe6762e2acf07",
+    "zh:a448d00988e100e201453b98d0098959c9b8e5dd34fbb33fe45793de0ae3d90e",
+    "zh:d4b4da8b49e86d8dec76a147e9f9f1b541fa59607236c4e62105205edff5fc14",
+    "zh:e712b9f90d9e29fa67990ef67cb9391db408414fb4c2261bc7522ecfba740fc0",
+    "zh:e8c6b874b9e8f03411f1fb38d6273bec8037a007b32d11fd75b18f8befcbde03",
+    "zh:f505fa05dee07f3d904208b9b9b8b13fd386093ae8243f2d7ce131f279310268",
+    "zh:fc3c74b661a1c86b3dd78b0f3bd9256123f6b270c3627975a6f9dc231bf7a59c",
+  ]
+}

--- a/IaC/live/argocd-apps/compass/terragrunt.hcl
+++ b/IaC/live/argocd-apps/compass/terragrunt.hcl
@@ -1,0 +1,95 @@
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "../../../modules/argocd-application-kubernetes"
+}
+
+dependencies {
+  paths = [
+    "../cert-manager",
+    "../istio",
+    "../tailscale",
+    "../prometheus"
+  ]
+}
+
+locals {
+  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
+  target_revision = "main"
+}
+
+inputs = {
+  metadata = {
+    name      = "compass"
+    namespace = "argocd"
+    labels = {
+      "app.kubernetes.io/managed-by" = "terragrunt"
+      "app.kubernetes.io/part-of"    = "homelab"
+    }
+  }
+
+  project = "homelab"
+
+  destination = {
+    server    = "https://kubernetes.default.svc"
+    namespace = "monitoring"
+  }
+
+  sources = [
+    {
+      repo_url        = "ghcr.io/adinhodovic/charts"
+      chart           = "compass"
+      target_revision = "0.6.0"
+      helm = {
+        release_name = "compass"
+        value_files  = ["$values/clusters/homelab/apps/compass/values.yaml"]
+      }
+    },
+    {
+      repo_url        = local.repo_url
+      target_revision = local.target_revision
+      ref             = "values"
+      directory = {
+        include = ".argocd-values-ref-placeholder.yaml"
+      }
+    },
+    {
+      repo_url        = local.repo_url
+      target_revision = local.target_revision
+      path            = "clusters/homelab/apps/compass"
+      kustomize       = {}
+    }
+  ]
+
+  sync_policy = {
+    automated = {
+      prune     = true
+      self_heal = true
+    }
+    sync_options = [
+      "CreateNamespace=true",
+      "ServerSideApply=true"
+    ]
+    retry = {
+      limit = "5"
+      backoff = {
+        duration     = "30s"
+        factor       = "2"
+        max_duration = "2m"
+      }
+    }
+  }
+
+  info = [
+    {
+      name  = "ingress"
+      value = "https://compass.stinkyboi.com via tailnet-only Istio gateway"
+    },
+    {
+      name  = "state"
+      value = "stateless Kubernetes service discovery dashboard"
+    }
+  ]
+}

--- a/clusters/homelab/apps/argocd-image-updater/imageupdater.yaml
+++ b/clusters/homelab/apps/argocd-image-updater/imageupdater.yaml
@@ -70,6 +70,23 @@ spec:
             helm:
               name: controllers.octobot.containers.app.image.repository
               tag: controllers.octobot.containers.app.image.tag
+    - namePattern: compass
+      writeBackConfig:
+        # checkov:skip=CKV_SECRET_6: Image Updater credential reference, not secret material.
+        method: git:secret:argocd/argocd-image-updater-git
+        gitConfig:
+          repository: https://github.com/Stuhlmuller/homelab.git
+          branch: main
+          writeBackTarget: helmvalues:/clusters/homelab/apps/compass/values.yaml
+          pullRequest:
+            github: {}
+      images:
+        - alias: compass
+          imageName: adinhodovic/compass:0.x
+          manifestTargets:
+            helm:
+              name: image.repository
+              tag: image.tag
     - namePattern: litellm
       writeBackConfig:
         # checkov:skip=CKV_SECRET_6: Image Updater credential reference, not secret material.

--- a/clusters/homelab/apps/compass/authorizationpolicy.yaml
+++ b/clusters/homelab/apps/compass/authorizationpolicy.yaml
@@ -1,0 +1,17 @@
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: compass-allow-required-clients
+  namespace: monitoring
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: compass
+      app.kubernetes.io/instance: compass
+  action: ALLOW
+  rules:
+    - from:
+        - source:
+            principals:
+              - cluster.local/ns/istio-system/sa/istio-ingressgateway
+              - cluster.local/ns/monitoring/sa/prometheus-kube-prometheus-prometheus

--- a/clusters/homelab/apps/compass/kustomization.yaml
+++ b/clusters/homelab/apps/compass/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - authorizationpolicy.yaml
+  - virtualservice.yaml

--- a/clusters/homelab/apps/compass/values.yaml
+++ b/clusters/homelab/apps/compass/values.yaml
@@ -1,0 +1,49 @@
+config: |
+  organization:
+    name: Homelab
+    description: Services and operator links discovered from the cluster.
+    logo: lucide:compass
+
+  ui:
+    default_group_by: tags
+
+  debug:
+    enabled: false
+
+  header_links:
+    - label: Grafana
+      url: https://grafana.stinkyboi.com
+      icon: selfhst:grafana
+    - label: Argo CD
+      url: https://argocd.stinkyboi.com
+      icon: selfhst:argo-cd
+    - label: Kiali
+      url: https://kiali.stinkyboi.com
+      icon: selfhst:kiali
+
+  services:
+    filters:
+      dedupe_www: true
+      exclude_wildcard_hosts: true
+    sources:
+      - type: kubernetes
+        name: homelab
+        tags: [kubernetes]
+        kubernetes:
+          namespaces: []
+          auto_discover_all: true
+
+image:
+  repository: adinhodovic/compass
+  tag: "0.7.0"
+
+resources:
+  requests:
+    cpu: 25m
+    memory: 64Mi
+  limits:
+    memory: 256Mi
+
+serviceMonitor:
+  enabled: true
+  scrapeInterval: 30s

--- a/clusters/homelab/apps/compass/virtualservice.yaml
+++ b/clusters/homelab/apps/compass/virtualservice.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: compass-tailnet
+  namespace: monitoring
+  annotations:
+    homelab.rst.io/public-funnel: "false"
+spec:
+  hosts:
+    - compass.stinkyboi.com
+  gateways:
+    - istio-system/tailnet-gateway
+  http:
+    - route:
+        - destination:
+            host: compass.monitoring.svc.cluster.local
+            port:
+              number: 8080

--- a/docs/argocd-app-onboarding.md
+++ b/docs/argocd-app-onboarding.md
@@ -24,6 +24,7 @@ requested workloads.
 | prometheus | requested | `monitoring` | `clusters/homelab/apps/prometheus` | `IaC/live/argocd-apps/prometheus` | Yes | external-secrets, platform-storage |
 | grafana | requested | `monitoring` | `clusters/homelab/apps/grafana` | `IaC/live/argocd-apps/grafana` | Yes | external-secrets, cert-manager, istio, tailscale, prometheus, platform-storage |
 | kiali | requested | `monitoring` | `clusters/homelab/apps/kiali` | `IaC/live/argocd-apps/kiali` | Yes | istio, tailscale, prometheus, grafana |
+| compass | requested | `monitoring` | `clusters/homelab/apps/compass` | `IaC/live/argocd-apps/compass` | Yes | cert-manager, istio, tailscale, prometheus |
 | descheduler | requested | `kube-system` | `clusters/homelab/apps/descheduler` | `IaC/live/argocd-apps/descheduler` | Yes | prometheus |
 | deluge | requested | `media` | `clusters/homelab/apps/deluge` | `IaC/live/argocd-apps/deluge` | Yes | cert-manager, istio, tailscale, platform-storage |
 | prowlarr | requested | `media` | `clusters/homelab/apps/prowlarr` | `IaC/live/argocd-apps/prowlarr` | Yes | cert-manager, istio, media-postgres, tailscale, platform-storage |

--- a/docs/knowledge-base/workloads/inventory.md
+++ b/docs/knowledge-base/workloads/inventory.md
@@ -32,6 +32,7 @@ trading workload with a tailnet-only UI.
 | `prometheus` | `monitoring` | `clusters/homelab/apps/prometheus` | `IaC/live/argocd-apps/prometheus` | persistent metrics and Argo CD scrape config | external-secrets, platform-storage |
 | `grafana` | `monitoring` | `clusters/homelab/apps/grafana` | `IaC/live/argocd-apps/grafana` | persistent config, dashboards, alert rules, public GitHub API PR/status polling, and Discord alerting webhook secret | external-secrets, cert-manager, istio, tailscale, prometheus, platform-storage |
 | `kiali` | `monitoring` | `clusters/homelab/apps/kiali` | `IaC/live/argocd-apps/kiali` | controller state only; read-only mesh UI | istio, tailscale, prometheus, grafana |
+| `compass` | `monitoring` | `clusters/homelab/apps/compass` | `IaC/live/argocd-apps/compass` | stateless Kubernetes service discovery dashboard with tailnet-only UI | cert-manager, istio, tailscale, prometheus |
 | `descheduler` | `kube-system` | `clusters/homelab/apps/descheduler` | `IaC/live/argocd-apps/descheduler` | controller state only | prometheus |
 | `deluge` | `media` | `clusters/homelab/apps/deluge` | `IaC/live/argocd-apps/deluge` | persistent config on `nfs-default`; shared downloads on QNAP `/media`; SSM-backed WireGuard profile via `deluge-vpn` | cert-manager, istio, tailscale, platform-storage |
 | `prowlarr` | `media` | `clusters/homelab/apps/prowlarr` | `IaC/live/argocd-apps/prowlarr` | persistent config and PostgreSQL databases | cert-manager, istio, media-postgres, tailscale, platform-storage |
@@ -59,8 +60,9 @@ namespaces. The source of truth is `docs/runtime-isolation.md` plus the
   Funnel traffic and database source-identity validation still need live
   validation after rollout.
 - `monitoring` restricts Grafana, Prometheus, Alertmanager, and
-  kube-state-metrics by service account. The Prometheus operator remains
-  unselected until its webhook/control-plane paths are modeled.
+  kube-state-metrics by service account. Compass allows only the tailnet gateway
+  and Prometheus scraper. The Prometheus operator remains unselected until its
+  webhook/control-plane paths are modeled.
 - `media` stays out of ambient while Deluge Gluetun/WireGuard and the media app
   ingress model need a repo-owned waypoint or equivalent policy design.
 

--- a/docs/networking-tailnet-ingress.md
+++ b/docs/networking-tailnet-ingress.md
@@ -23,6 +23,7 @@ that must be added through a separate Terragrunt/OpenTofu entry point.
 | argocd | `https://argocd.stinkyboi.com` | disabled |
 | grafana | `https://grafana.stinkyboi.com` | disabled |
 | kiali | `https://kiali.stinkyboi.com` | disabled |
+| compass | `https://compass.stinkyboi.com` | disabled |
 | deluge | `https://deluge.stinkyboi.com` | disabled |
 | prowlarr | `https://prowlarr.stinkyboi.com` | disabled |
 | radarr | `https://radarr.stinkyboi.com` | disabled |
@@ -69,6 +70,11 @@ OctoBot exposes its UI only through the tailnet Istio route at
 paper trading, and operator-reviewed live trading; exchange credentials and
 strategy state are configured through OctoBot and persist on its NFS-backed
 volumes, not in public repository files.
+
+Compass exposes the service catalog only through the tailnet Istio route at
+`https://compass.stinkyboi.com`. It discovers Kubernetes ingress and Gateway API
+routes with read-only RBAC, disables operator debug routes, and does not persist
+application state.
 
 ## Homelab VPN Exit Node And LAN Route
 


### PR DESCRIPTION
## Summary
- add Compass as a tailnet-only Argo CD application in the monitoring namespace
- configure Kubernetes service discovery, read-only mesh ingress policy, and Prometheus scraping
- document the route, workload inventory, and onboarding entry

## Validation
- `git diff --cached --check`
- Full local validation was unavailable in this runtime: no `nix`, `tofu`, `terragrunt`, `kubectl`, `helm`, or `kustomize` binaries are installed.

## Notes
- Compass app release is pinned to `adinhodovic/compass:0.7.0`; the OCI Helm chart is pinned to `0.6.0`, which is the chart version advertised in the upstream chart metadata.
- Upstream project: https://github.com/adinhodovic/compass

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `cf22551850e81d9f4daf363c616b5df2a15dc58f`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
