### PR TITLE
fix(grafana): make alert cleanup best effort

### DIFF
--- a/clusters/homelab/apps/grafana-alert-cleanup/job.yaml
+++ b/clusters/homelab/apps/grafana-alert-cleanup/job.yaml
@@ -2,24 +2,24 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: grafana-alerting-cleanup-v4
+  name: grafana-alerting-cleanup-v5
   namespace: monitoring
   labels:
-    app.kubernetes.io/name: grafana-alerting-cleanup-v4
+    app.kubernetes.io/name: grafana-alerting-cleanup-v5
     app.kubernetes.io/part-of: homelab-monitoring
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: grafana-alerting-cleanup-v4
+  name: grafana-alerting-cleanup-v5
   namespace: monitoring
   labels:
-    app.kubernetes.io/name: grafana-alerting-cleanup-v4
+    app.kubernetes.io/name: grafana-alerting-cleanup-v5
     app.kubernetes.io/part-of: homelab-monitoring
 spec:
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: grafana-alerting-cleanup-v4
+      app.kubernetes.io/name: grafana-alerting-cleanup-v5
       app.kubernetes.io/part-of: homelab-monitoring
   policyTypes:
     - Egress
@@ -43,27 +43,27 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: grafana-alerting-cleanup-v4
+  name: grafana-alerting-cleanup-v5
   namespace: monitoring
   labels:
-    app.kubernetes.io/name: grafana-alerting-cleanup-v4
+    app.kubernetes.io/name: grafana-alerting-cleanup-v5
     app.kubernetes.io/part-of: homelab-monitoring
   annotations:
     argocd.argoproj.io/hook: Sync
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
 spec:
-  backoffLimit: 1
-  activeDeadlineSeconds: 900
+  backoffLimit: 0
+  activeDeadlineSeconds: 180
   ttlSecondsAfterFinished: 3600
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: grafana-alerting-cleanup-v4
+        app.kubernetes.io/name: grafana-alerting-cleanup-v5
         app.kubernetes.io/part-of: homelab-monitoring
     spec:
       automountServiceAccountToken: false
       restartPolicy: Never
-      serviceAccountName: grafana-alerting-cleanup-v4
+      serviceAccountName: grafana-alerting-cleanup-v5
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534
@@ -86,6 +86,7 @@ spec:
               import base64
               import json
               import os
+              import sys
               import time
               import urllib.error
               import urllib.request
@@ -110,7 +111,7 @@ spec:
                       method=method,
                   )
                   try:
-                      with urllib.request.urlopen(request, timeout=20) as response:
+                      with urllib.request.urlopen(request, timeout=10) as response:
                           body = response.read().decode()
                           if response.status not in ok:
                               raise RuntimeError(f"{method} {path} returned {response.status}: {body}")
@@ -122,45 +123,50 @@ spec:
                       raise RuntimeError(f"{method} {path} returned {error.code}: {body}") from error
 
               def wait_for_grafana():
-                  for attempt in range(1, 61):
+                  for attempt in range(1, 7):
                       try:
                           status, _ = call("GET", "/api/health", ok=(200,))
                           print(f"grafana health ready: {status}")
-                          return
+                          return True
                       except Exception as error:
-                          print(f"grafana health not ready ({attempt}/60): {error}")
+                          print(f"grafana health not ready ({attempt}/6): {error}")
                           time.sleep(10)
-                  raise RuntimeError("grafana did not become healthy within 10 minutes")
+                  return False
 
-              wait_for_grafana()
+              if not wait_for_grafana():
+                  print("grafana cleanup skipped: Grafana API route was not reachable")
+                  sys.exit(0)
 
-              status, body = call(
-                  "GET",
-                  "/api/v1/provisioning/alert-rules/homelab-argocd-app-out-of-sync",
-                  ok=(200, 404),
-              )
-              if status == 200:
-                  rule = json.loads(body)
-                  changed = False
-                  for item in rule.get("data", []):
-                      model = item.get("model") or {}
-                      if model.get("expr") == 'argocd_app_info{sync_status!="Synced"}':
-                          model["expr"] = 'argocd_app_info{sync_status="OutOfSync"}'
-                          changed = True
-                  if changed:
-                      call("PUT", "/api/v1/provisioning/alert-rules/homelab-argocd-app-out-of-sync", rule)
-                      print("updated homelab-argocd-app-out-of-sync")
+              try:
+                  status, body = call(
+                      "GET",
+                      "/api/v1/provisioning/alert-rules/homelab-argocd-app-out-of-sync",
+                      ok=(200, 404),
+                  )
+                  if status == 200:
+                      rule = json.loads(body)
+                      changed = False
+                      for item in rule.get("data", []):
+                          model = item.get("model") or {}
+                          if model.get("expr") == 'argocd_app_info{sync_status!="Synced"}':
+                              model["expr"] = 'argocd_app_info{sync_status="OutOfSync"}'
+                              changed = True
+                      if changed:
+                          call("PUT", "/api/v1/provisioning/alert-rules/homelab-argocd-app-out-of-sync", rule)
+                          print("updated homelab-argocd-app-out-of-sync")
+                      else:
+                          print("argocd rule already updated")
                   else:
-                      print("argocd rule already updated")
-              else:
-                  print("argocd rule already absent")
+                      print("argocd rule already absent")
 
-              status, _ = call(
-                  "DELETE",
-                  "/api/v1/provisioning/alert-rules/homelab-octobot-deployment-unavailable",
-                  ok=(200, 202, 204, 404),
-              )
-              print(f"delete homelab-octobot-deployment-unavailable: {status}")
+                  status, _ = call(
+                      "DELETE",
+                      "/api/v1/provisioning/alert-rules/homelab-octobot-deployment-unavailable",
+                      ok=(200, 202, 204, 404),
+                  )
+                  print(f"delete homelab-octobot-deployment-unavailable: {status}")
+              except Exception as error:
+                  print(f"grafana cleanup skipped after API error: {error}")
           volumeMounts:
             - name: grafana-admin
               mountPath: /var/run/grafana-admin

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -83,9 +83,11 @@ health through the public Grafana route before calling the provisioning API.
 The public route keeps cleanup traffic on the same Istio AuthorizationPolicy
 path as normal ingressgateway traffic. Grafana's AuthorizationPolicy also keeps
 the cleanup hook service accounts allowed so stale direct-service retries can
-drain after hook revisions. Bump the cleanup resource names when re-running the
-hook; hook-only edits do not reliably create Argo CD autosync drift. Do not
-embed one-shot Grafana API cleanup hooks in the Prometheus app.
+drain after hook revisions. The cleanup is best-effort: if Grafana's API route
+is unavailable, the hook exits successfully and records the skip instead of
+leaving the Argo CD app in `SyncFailed`. Bump the cleanup resource names when
+re-running the hook; hook-only edits do not reliably create Argo CD autosync
+drift. Do not embed one-shot Grafana API cleanup hooks in the Prometheus app.
 Its Helm-rendered Deployment uses a resource-level Argo CD `Replace=true` sync
 option because the app keeps a `Recreate` strategy for the single Grafana PVC,
 and server-side apply can otherwise preserve stale `rollingUpdate` fields.


### PR DESCRIPTION
## Summary
- bump grafana-alert-cleanup to v5 so Argo CD gets a fresh hook run
- make the one-shot Grafana API cleanup best-effort so an unreachable Grafana route records a skip instead of leaving the app SyncFailed
- shorten hook runtime and remove retry backoff for deterministic Argo CD recovery

## Validation
- kubectl kustomize clusters/homelab/apps/grafana-alert-cleanup
- kubectl diff -k clusters/homelab/apps/grafana-alert-cleanup
- bash scripts/ci/static-checks.sh

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `b3730e363c27e59a8feb78290ad1e38c5db73603`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
