### PR TITLE
fix: allow compass chart repository

### DIFF
--- a/clusters/homelab/argocd/self-management/appproject.yaml
+++ b/clusters/homelab/argocd/self-management/appproject.yaml
@@ -21,6 +21,7 @@ spec:
     - https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner/
     - https://pkgs.tailscale.com/helmcharts
     - https://prometheus-community.github.io/helm-charts
+    - ghcr.io/adinhodovic/charts
     - ghcr.io/berriai
   destinations:
     - server: https://kubernetes.default.svc


### PR DESCRIPTION
## Summary
- allow `ghcr.io/adinhodovic/charts` in the `homelab` AppProject source repo allowlist
- unblocks the Compass Argo CD Application from using its OCI Helm chart source

## Validation
- `git diff --check`

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `16db921eab3d41812c34a2647d2263dfdad442c6`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
