### PR TITLE
fix(argocd): dedupe compass chart source

### DIFF
--- a/clusters/homelab/argocd/self-management/appproject.yaml
+++ b/clusters/homelab/argocd/self-management/appproject.yaml
@@ -15,7 +15,6 @@ spec:
     - https://charts.external-secrets.io
     - https://charts.jetstack.io
     - https://grafana.github.io/helm-charts
-    - ghcr.io/adinhodovic/charts
     - https://istio-release.storage.googleapis.com/charts
     - https://kiali.org/helm-charts
     - https://kubernetes-sigs.github.io/descheduler


### PR DESCRIPTION
## Summary
- remove the duplicate Compass OCI chart source entry from the homelab AppProject

## Validation
- kubectl kustomize clusters/homelab/argocd/self-management
- git diff --check
- bash scripts/ci/static-checks.sh

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `b483f16da52f53d7358d20041868f55f02f68765`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
