### PR TITLE
fix: configure compass service sources

### DIFF
--- a/clusters/homelab/apps/compass/values.yaml
+++ b/clusters/homelab/apps/compass/values.yaml
@@ -26,6 +26,75 @@ config: |
       dedupe_www: true
       exclude_wildcard_hosts: true
     sources:
+      - type: static
+        name: tailnet
+        tags: [tailnet]
+        services:
+          - name: Argo CD
+            url: https://argocd.stinkyboi.com
+            description: GitOps control plane and application sync status.
+            icon: selfhst:argo-cd
+            tags: [platform, gitops]
+          - name: Compass
+            url: https://compass.stinkyboi.com
+            description: Homelab service catalog and operator launchpad.
+            icon: lucide:compass
+            tags: [platform, catalog]
+          - name: Deluge
+            url: https://deluge.stinkyboi.com
+            description: Tailnet-only torrent client behind the media VPN path.
+            icon: selfhst:deluge
+            tags: [media]
+          - name: Grafana
+            url: https://grafana.stinkyboi.com
+            description: Dashboards, alerts, and homelab observability.
+            icon: selfhst:grafana
+            tags: [monitoring]
+          - name: Kiali
+            url: https://kiali.stinkyboi.com
+            description: Read-only Istio mesh topology and traffic view.
+            icon: selfhst:kiali
+            tags: [monitoring, mesh]
+          - name: LiteLLM
+            url: https://litellm.stinkyboi.com
+            description: AI model gateway used by homelab agents.
+            icon: selfhst:litellm
+            tags: [ai]
+          - name: n8n
+            url: https://n8n.stinkyboi.com
+            description: Workflow automation editor and execution UI.
+            icon: selfhst:n8n
+            tags: [automation]
+          - name: OctoBot
+            url: https://octobot.stinkyboi.com
+            description: Finance bot UI for reviewed trading experiments.
+            icon: selfhst:octobot
+            tags: [finance]
+          - name: OpenClaw
+            url: https://openclaw.stinkyboi.com
+            description: Local agent gateway and homelab assistant runtime.
+            icon: lucide:bot
+            tags: [ai, agents]
+          - name: Policy Bot
+            url: https://policy-bot.stinkyboi.com
+            description: GitHub App policy evaluator and webhook receiver.
+            icon: lucide:shield-check
+            tags: [automation, github]
+          - name: Prowlarr
+            url: https://prowlarr.stinkyboi.com
+            description: Indexer manager for the media stack.
+            icon: selfhst:prowlarr
+            tags: [media]
+          - name: Radarr
+            url: https://radarr.stinkyboi.com
+            description: Movie library automation.
+            icon: selfhst:radarr
+            tags: [media]
+          - name: Sonarr
+            url: https://sonarr.stinkyboi.com
+            description: TV library automation.
+            icon: selfhst:sonarr
+            tags: [media]
       - type: kubernetes
         name: homelab
         tags: [kubernetes]


### PR DESCRIPTION
## Summary
- add a Compass static source for the current tailnet app routes so the dashboard renders services immediately
- keep the Kubernetes source enabled for future native Ingress/Gateway API resources

## Context
Compass Kubernetes discovery reads Kubernetes Ingress and Gateway API HTTPRoute/GRPCRoute resources. The homelab currently exposes most apps through Istio VirtualService, so the Kubernetes source has no route resources to render yet.

## Validation
- `git diff --check`

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `ef67ffb94a2ac9357391a99fc7619141a6edc18b`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
