### PR TITLE
fix: use ingress resources for compass discovery

### DIFF
--- a/clusters/homelab/apps/compass/ingress-discovery.yaml
+++ b/clusters/homelab/apps/compass/ingress-discovery.yaml
@@ -1,5 +1,15 @@
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: compass-discovery
+  labels:
+    app.kubernetes.io/name: compass
+    app.kubernetes.io/part-of: homelab
+spec:
+  controller: homelab.stinkyboi.com/compass-discovery
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
 metadata:
   name: compass-discovery-argocd
   namespace: monitoring
@@ -12,11 +22,21 @@ metadata:
     compass.adinhodovic.com/primary-tag: kubernetes
     compass.adinhodovic.com/tags: platform,gitops
 spec:
-  hostnames:
-    - argocd.stinkyboi.com
+  ingressClassName: compass-discovery
+  rules:
+    - host: argocd.stinkyboi.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: compass
+                port:
+                  number: 8080
 ---
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
+apiVersion: networking.k8s.io/v1
+kind: Ingress
 metadata:
   name: compass-discovery-compass
   namespace: monitoring
@@ -29,11 +49,21 @@ metadata:
     compass.adinhodovic.com/primary-tag: kubernetes
     compass.adinhodovic.com/tags: platform,catalog
 spec:
-  hostnames:
-    - compass.stinkyboi.com
+  ingressClassName: compass-discovery
+  rules:
+    - host: compass.stinkyboi.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: compass
+                port:
+                  number: 8080
 ---
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
+apiVersion: networking.k8s.io/v1
+kind: Ingress
 metadata:
   name: compass-discovery-deluge
   namespace: monitoring
@@ -46,11 +76,21 @@ metadata:
     compass.adinhodovic.com/primary-tag: kubernetes
     compass.adinhodovic.com/tags: media
 spec:
-  hostnames:
-    - deluge.stinkyboi.com
+  ingressClassName: compass-discovery
+  rules:
+    - host: deluge.stinkyboi.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: compass
+                port:
+                  number: 8080
 ---
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
+apiVersion: networking.k8s.io/v1
+kind: Ingress
 metadata:
   name: compass-discovery-grafana
   namespace: monitoring
@@ -63,11 +103,21 @@ metadata:
     compass.adinhodovic.com/primary-tag: kubernetes
     compass.adinhodovic.com/tags: monitoring
 spec:
-  hostnames:
-    - grafana.stinkyboi.com
+  ingressClassName: compass-discovery
+  rules:
+    - host: grafana.stinkyboi.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: compass
+                port:
+                  number: 8080
 ---
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
+apiVersion: networking.k8s.io/v1
+kind: Ingress
 metadata:
   name: compass-discovery-kiali
   namespace: monitoring
@@ -80,11 +130,21 @@ metadata:
     compass.adinhodovic.com/primary-tag: kubernetes
     compass.adinhodovic.com/tags: monitoring,mesh
 spec:
-  hostnames:
-    - kiali.stinkyboi.com
+  ingressClassName: compass-discovery
+  rules:
+    - host: kiali.stinkyboi.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: compass
+                port:
+                  number: 8080
 ---
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
+apiVersion: networking.k8s.io/v1
+kind: Ingress
 metadata:
   name: compass-discovery-litellm
   namespace: monitoring
@@ -97,11 +157,21 @@ metadata:
     compass.adinhodovic.com/primary-tag: kubernetes
     compass.adinhodovic.com/tags: ai
 spec:
-  hostnames:
-    - litellm.stinkyboi.com
+  ingressClassName: compass-discovery
+  rules:
+    - host: litellm.stinkyboi.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: compass
+                port:
+                  number: 8080
 ---
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
+apiVersion: networking.k8s.io/v1
+kind: Ingress
 metadata:
   name: compass-discovery-n8n
   namespace: monitoring
@@ -114,11 +184,21 @@ metadata:
     compass.adinhodovic.com/primary-tag: kubernetes
     compass.adinhodovic.com/tags: automation
 spec:
-  hostnames:
-    - n8n.stinkyboi.com
+  ingressClassName: compass-discovery
+  rules:
+    - host: n8n.stinkyboi.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: compass
+                port:
+                  number: 8080
 ---
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
+apiVersion: networking.k8s.io/v1
+kind: Ingress
 metadata:
   name: compass-discovery-octobot
   namespace: monitoring
@@ -131,11 +211,21 @@ metadata:
     compass.adinhodovic.com/primary-tag: kubernetes
     compass.adinhodovic.com/tags: finance
 spec:
-  hostnames:
-    - octobot.stinkyboi.com
+  ingressClassName: compass-discovery
+  rules:
+    - host: octobot.stinkyboi.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: compass
+                port:
+                  number: 8080
 ---
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
+apiVersion: networking.k8s.io/v1
+kind: Ingress
 metadata:
   name: compass-discovery-openclaw
   namespace: monitoring
@@ -148,11 +238,21 @@ metadata:
     compass.adinhodovic.com/primary-tag: kubernetes
     compass.adinhodovic.com/tags: ai,agents
 spec:
-  hostnames:
-    - openclaw.stinkyboi.com
+  ingressClassName: compass-discovery
+  rules:
+    - host: openclaw.stinkyboi.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: compass
+                port:
+                  number: 8080
 ---
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
+apiVersion: networking.k8s.io/v1
+kind: Ingress
 metadata:
   name: compass-discovery-policy-bot
   namespace: monitoring
@@ -165,11 +265,21 @@ metadata:
     compass.adinhodovic.com/primary-tag: kubernetes
     compass.adinhodovic.com/tags: automation,github
 spec:
-  hostnames:
-    - policy-bot.stinkyboi.com
+  ingressClassName: compass-discovery
+  rules:
+    - host: policy-bot.stinkyboi.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: compass
+                port:
+                  number: 8080
 ---
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
+apiVersion: networking.k8s.io/v1
+kind: Ingress
 metadata:
   name: compass-discovery-prowlarr
   namespace: monitoring
@@ -182,11 +292,21 @@ metadata:
     compass.adinhodovic.com/primary-tag: kubernetes
     compass.adinhodovic.com/tags: media
 spec:
-  hostnames:
-    - prowlarr.stinkyboi.com
+  ingressClassName: compass-discovery
+  rules:
+    - host: prowlarr.stinkyboi.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: compass
+                port:
+                  number: 8080
 ---
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
+apiVersion: networking.k8s.io/v1
+kind: Ingress
 metadata:
   name: compass-discovery-radarr
   namespace: monitoring
@@ -199,11 +319,21 @@ metadata:
     compass.adinhodovic.com/primary-tag: kubernetes
     compass.adinhodovic.com/tags: media
 spec:
-  hostnames:
-    - radarr.stinkyboi.com
+  ingressClassName: compass-discovery
+  rules:
+    - host: radarr.stinkyboi.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: compass
+                port:
+                  number: 8080
 ---
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
+apiVersion: networking.k8s.io/v1
+kind: Ingress
 metadata:
   name: compass-discovery-sonarr
   namespace: monitoring
@@ -216,5 +346,15 @@ metadata:
     compass.adinhodovic.com/primary-tag: kubernetes
     compass.adinhodovic.com/tags: media
 spec:
-  hostnames:
-    - sonarr.stinkyboi.com
+  ingressClassName: compass-discovery
+  rules:
+    - host: sonarr.stinkyboi.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: compass
+                port:
+                  number: 8080

--- a/clusters/homelab/apps/compass/kustomization.yaml
+++ b/clusters/homelab/apps/compass/kustomization.yaml
@@ -2,5 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - authorizationpolicy.yaml
-  - httproutes.yaml
+  - ingress-discovery.yaml
   - virtualservice.yaml

--- a/docs/networking-tailnet-ingress.md
+++ b/docs/networking-tailnet-ingress.md
@@ -77,10 +77,11 @@ routes with read-only RBAC, disables operator debug routes, and does not persist
 application state.
 
 Because the homelab's reviewed ingress path is still Istio `VirtualService`,
-Compass also owns discovery-only Gateway API `HTTPRoute` resources in the
-`monitoring` namespace. Those resources carry the same hostnames and Compass
-metadata for catalog discovery, but they do not replace the Istio
-`VirtualService` resources that route traffic through `tailnet-gateway`.
+Compass also owns discovery-only `Ingress` resources in the `monitoring`
+namespace. Those resources use the inert `compass-discovery` IngressClass and
+carry the same hostnames and Compass metadata for catalog discovery, but they
+do not replace the Istio `VirtualService` resources that route traffic through
+`tailnet-gateway`.
 
 ## Homelab VPN Exit Node And LAN Route
 


### PR DESCRIPTION
## Summary
- replace the Compass discovery-only Gateway API `HTTPRoute` resources with ordinary Kubernetes `Ingress` resources
- add an inert `compass-discovery` IngressClass so these are catalog/discovery objects, not the real traffic path
- keep Istio `VirtualService` documented as the actual tailnet routing source

## Context
Compass can discover Kubernetes Ingresses and Gateway API routes. The current cluster did not appear to roll forward after adding HTTPRoutes, so this uses the built-in Kubernetes Ingress API instead.

## Validation
- `git diff --check`

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `f53883c7e6455be8274ffdf5f3263cfb3c827000`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
