### PR TITLE
fix: align policy bot shared policy path

### DIFF
--- a/clusters/homelab/apps/policy-bot/externalsecret.yaml
+++ b/clusters/homelab/apps/policy-bot/externalsecret.yaml
@@ -42,7 +42,7 @@ spec:
           sessions:
             key: "{{ .sessions_key }}"
           options:
-            policy_path: .policy.yml
+            policy_path: policy.yml
             shared_repository: .github
             status_check_context: policy-bot
   data:


### PR DESCRIPTION
## Summary
- point Policy Bot at the shared repository's existing `policy.yml` file instead of `.policy.yml`
- keep the shared repository and status context unchanged

## Validation
- inspected the live Policy Bot endpoints (`/` returns 200, PR details redirect to GitHub auth)
- confirmed personal-website PRs remain pending on `policy-bot: main`, matching the suspected missing shared policy path


<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `ec4fca80fa8fef8f2fa8867c054171d959342e3c`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
