### PR TITLE
fix(ci): destroy deleted terragrunt units

### DIFF
--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -85,11 +85,20 @@ unless the repository adds a reviewed token-backed secret contract for Grafana.
   against the PR base branch, while push applies compare against the previous
   `main` SHA from the GitHub event. Manual apply dispatches compare against
   `HEAD^`.
+- Deleted Terragrunt units are handled separately because the current checkout
+  no longer contains the directory that owns their state. The plan and apply
+  scripts diff the base and head refs for deleted `IaC/**/terragrunt.hcl`
+  files, create temporary empty Terragrunt units at those deleted paths, and
+  reuse `IaC/root.hcl` so `path_relative_to_include()` points each fake unit at
+  the original backend key. Pull request plans list the remote-state resources
+  and save a destroy plan without rendering potentially sensitive values.
+  Production apply lists the same state resources, applies the saved destroy
+  plan, and then continues with the current checkout.
 - The protected post-merge apply runs the production phases explicitly:
-  bootstrap Argo CD, apply SSM parameter declarations, apply Entra application
-  registrations, apply Argo CD Application registrations serially, and finally
-  materialize Kubernetes Secrets from SSM. Stack-wide apply phases use
-  Terragrunt's explicit
+  destroy resources from deleted Terragrunt unit state, bootstrap Argo CD, apply
+  SSM parameter declarations, apply Entra application registrations, apply Argo
+  CD Application registrations serially, and finally materialize Kubernetes
+  Secrets from SSM. Stack-wide apply phases use Terragrunt's explicit
   `run --all --filter-affected --non-interactive -- apply ...` form so the run
   queue is accepted in Actions and OpenTofu flags such as `-auto-approve` are
   forwarded to OpenTofu instead of being parsed as Terragrunt CLI flags.
@@ -271,7 +280,9 @@ production apply role, install the kubeconfig, and run a focused
 
 The local scripts rely on your current `main` ref for Terragrunt's
 `--filter-affected` comparison. Update `main` first when you want local output
-to match the GitHub pull request or push diff.
+to match the GitHub pull request or push diff. Deleted-unit detection uses the
+same comparison base; set `TERRAGRUNT_FILTER_BASE_SHA` and
+`TERRAGRUNT_FILTER_HEAD_SHA` when reproducing an exact GitHub run locally.
 
 Set `TERRAGRUNT_PLAN_MARKDOWN=/path/to/terragrunt-plan.md` when running the PR
 plan script locally if you want the same rendered `plan.out` markdown that the

--- a/docs/knowledge-base/operations/continuous-improvement.md
+++ b/docs/knowledge-base/operations/continuous-improvement.md
@@ -90,3 +90,18 @@ policy`.
 - **Next step:** decide whether to keep squash-only merges with GitHub-signed
   mainline commits, allow rebase/merge methods that preserve Claw-signed branch
   commits, or add a bot-supported path for signed squash commits.
+
+- **Status:** fixed
+- **Area:** CI/CD
+- **Evidence:** PR #374 updates `scripts/ci/terragrunt-plan.sh`,
+  `scripts/ci/terragrunt-apply.sh`, and
+  `scripts/ci/terragrunt-filter-base.sh` after PR #371 exposed that
+  current-tree `terragrunt run --all --filter-affected` cannot enter a deleted
+  unit directory.
+- **Risk:** deleting a Terragrunt unit can otherwise leave remote-state-backed
+  cloud or Kubernetes resources orphaned while reviewers assume post-merge apply
+  cleaned them up.
+- **Next step:** keep deleted-unit cleanup in the CI path: generate a temporary
+  empty Terragrunt unit at each deleted path, rely on `IaC/root.hcl` to target
+  the original backend key, list the remote-state resources, and apply the saved
+  destroy plan before applying the current checkout.

--- a/docs/knowledge-base/runbooks/ci-cd.md
+++ b/docs/knowledge-base/runbooks/ci-cd.md
@@ -51,6 +51,15 @@ Source: `docs/ci-cd.md`
   limited to units changed between `main` and `HEAD`. In CI, the helper script
   prepares `main` to mean the PR base branch for plans or the previous push SHA
   for post-merge applies. Manual apply dispatches compare against `HEAD^`.
+- Deleted Terragrunt units are a special case because current-tree
+  `--filter-affected` runs cannot enter a directory that no longer exists.
+  `scripts/ci/terragrunt-plan.sh` and `scripts/ci/terragrunt-apply.sh` detect
+  deleted `IaC/**/terragrunt.hcl` files, create temporary empty Terragrunt
+  units at those deleted paths, and rely on `IaC/root.hcl` so the fake units
+  point at the same remote-state keys as the removed units. PR plans list the
+  state resources and save destroy plans without rendering potentially
+  sensitive values; production apply lists those state resources and applies
+  the saved destroy plans before applying the current checkout.
 - Stack-wide apply phases use Terragrunt's explicit
   `run --all --filter-affected --non-interactive -- apply ...` form so the run
   queue is accepted in Actions and OpenTofu flags such as `-auto-approve` are

--- a/scripts/ci/terragrunt-apply.sh
+++ b/scripts/ci/terragrunt-apply.sh
@@ -4,21 +4,19 @@ set -euo pipefail
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${script_dir}/terragrunt-filter-base.sh"
 
-prepare_terragrunt_filter_base
+cleanup_dirs=()
 
-echo "::group::Argo CD bootstrap apply"
-(
-  cd IaC/bootstrap
-  terragrunt run --all --filter-affected --non-interactive --parallelism 1 -- apply -no-color -auto-approve
-)
-echo "::endgroup::"
+cleanup_temp_dirs() {
+  local temp_dir
 
-echo "::group::AWS SSM parameter declaration apply"
-(
-  cd IaC/live/aws-ssm-parameters
-  terragrunt run --all --filter-affected --non-interactive --parallelism 1 -- apply -no-color -auto-approve
-)
-echo "::endgroup::"
+  for temp_dir in "${cleanup_dirs[@]}"; do
+    if [[ -d "$temp_dir" ]]; then
+      rm -rf "$temp_dir"
+    fi
+  done
+}
+
+trap cleanup_temp_dirs EXIT
 
 azuread_credentials_available() {
   [[ -n "${ARM_CLIENT_ID:-}" && -n "${ARM_CLIENT_SECRET:-}" && -n "${ARM_TENANT_ID:-}" ]]
@@ -38,6 +36,79 @@ azuread_stack_changed() {
 
   ! git diff --quiet "$base_sha" "$head_sha" -- IaC/live/azuread-applications
 }
+
+destroy_deleted_terragrunt_units() {
+  local deleted_units=()
+  local snapshot_dir
+  local unit_dir
+  local snapshot_unit_dir
+  local state_list_file
+
+  while IFS= read -r unit_dir; do
+    deleted_units+=("$unit_dir")
+  done < <(terragrunt_deleted_unit_paths)
+
+  if ((${#deleted_units[@]} == 0)); then
+    echo "No deleted Terragrunt units require destroy handling."
+    return 0
+  fi
+
+  for unit_dir in "${deleted_units[@]}"; do
+    snapshot_dir="$(mktemp -d "${RUNNER_TEMP:-/tmp}/terragrunt-deleted-apply.XXXXXX")"
+    cleanup_dirs+=("$snapshot_dir")
+    terragrunt_create_deleted_unit_destroy_stack "$snapshot_dir" "$unit_dir"
+    snapshot_unit_dir="${snapshot_dir}/${unit_dir}"
+    state_list_file="${snapshot_unit_dir}/state-resources.txt"
+
+    if [[ ! -f "${snapshot_unit_dir}/terragrunt.hcl" ]]; then
+      echo "Deleted Terragrunt unit ${unit_dir} fake stack was not generated." >&2
+      exit 1
+    fi
+
+    echo "::group::Deleted Terragrunt unit state destroy: ${unit_dir}"
+    (
+      cd "$snapshot_unit_dir"
+      terragrunt --log-disable init -no-color
+      if ! terragrunt --log-disable state list >"$state_list_file"; then
+        echo "Unable to list state for deleted Terragrunt unit ${unit_dir}; inspect the backend or credentials before applying." >&2
+        exit 1
+      fi
+      if [[ -s "$state_list_file" ]]; then
+        echo "Resources in deleted Terragrunt unit state:"
+        cat "$state_list_file"
+        terragrunt plan -destroy -refresh=false -out plan.out -no-color >/dev/null
+        terragrunt apply -no-color plan.out
+      else
+        echo "Deleted Terragrunt unit ${unit_dir} has no resources in remote state."
+      fi
+    )
+    echo "::endgroup::"
+  done
+}
+
+prepare_terragrunt_filter_base
+
+if ! azuread_credentials_available && azuread_stack_changed; then
+  echo "AzureAD credentials are required because IaC/live/azuread-applications changed or the apply diff could not be determined." >&2
+  echo "Set AZUREAD_CLIENT_ID, AZUREAD_CLIENT_SECRET, and AZUREAD_TENANT_ID on homelab-production." >&2
+  exit 1
+fi
+
+destroy_deleted_terragrunt_units
+
+echo "::group::Argo CD bootstrap apply"
+(
+  cd IaC/bootstrap
+  terragrunt run --all --filter-affected --non-interactive --parallelism 1 -- apply -no-color -auto-approve
+)
+echo "::endgroup::"
+
+echo "::group::AWS SSM parameter declaration apply"
+(
+  cd IaC/live/aws-ssm-parameters
+  terragrunt run --all --filter-affected --non-interactive --parallelism 1 -- apply -no-color -auto-approve
+)
+echo "::endgroup::"
 
 echo "::group::AzureAD application registration apply"
 if azuread_credentials_available; then

--- a/scripts/ci/terragrunt-filter-base.sh
+++ b/scripts/ci/terragrunt-filter-base.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
 
-prepare_terragrunt_filter_base() {
-  if [[ "${CI:-}" != "true" ]]; then
-    return 0
+terragrunt_filter_head_ref() {
+  local head_ref="${TERRAGRUNT_FILTER_HEAD_SHA:-${APPLY_HEAD_SHA:-${GITHUB_SHA:-HEAD}}}"
+
+  if ! git rev-parse --verify --quiet "${head_ref}^{commit}" >/dev/null; then
+    head_ref="HEAD"
   fi
 
+  printf '%s\n' "$head_ref"
+}
+
+terragrunt_filter_base_ref() {
   local base_ref="${TERRAGRUNT_FILTER_BASE_SHA:-${APPLY_BASE_SHA:-}}"
-  local head_ref="${TERRAGRUNT_FILTER_HEAD_SHA:-${APPLY_HEAD_SHA:-${GITHUB_SHA:-HEAD}}}"
 
   if [[ -z "$base_ref" && -n "${GITHUB_BASE_REF:-}" ]]; then
     base_ref="origin/${GITHUB_BASE_REF}"
@@ -17,7 +22,36 @@ prepare_terragrunt_filter_base() {
   fi
 
   if [[ -z "$base_ref" ]]; then
-    base_ref="origin/main"
+    if git rev-parse --verify --quiet "main^{commit}" >/dev/null; then
+      base_ref="main"
+    else
+      base_ref="origin/main"
+    fi
+  fi
+
+  if [[ -z "$base_ref" || "$base_ref" =~ ^0+$ ]]; then
+    return 1
+  fi
+
+  printf '%s\n' "$base_ref"
+}
+
+prepare_terragrunt_filter_base() {
+  local base_ref
+  local head_ref
+
+  if ! base_ref="$(terragrunt_filter_base_ref)"; then
+    echo "::warning::No usable Terragrunt --filter-affected base ref was available; using the existing main ref."
+    return 0
+  fi
+
+  head_ref="$(terragrunt_filter_head_ref)"
+
+  export TERRAGRUNT_EFFECTIVE_FILTER_BASE_REF="$base_ref"
+  export TERRAGRUNT_EFFECTIVE_FILTER_HEAD_REF="$head_ref"
+
+  if [[ "${CI:-}" != "true" ]]; then
+    return 0
   fi
 
   if [[ -z "$base_ref" || "$base_ref" =~ ^0+$ ]]; then
@@ -35,4 +69,97 @@ prepare_terragrunt_filter_base() {
   fi
 
   git branch --force main "$base_ref"
+}
+
+terragrunt_deleted_unit_paths() {
+  local base_ref="${TERRAGRUNT_EFFECTIVE_FILTER_BASE_REF:-}"
+  local head_ref="${TERRAGRUNT_EFFECTIVE_FILTER_HEAD_REF:-}"
+
+  if [[ -z "$base_ref" ]] && ! base_ref="$(terragrunt_filter_base_ref)"; then
+    return 0
+  fi
+
+  if [[ -z "$head_ref" ]]; then
+    head_ref="$(terragrunt_filter_head_ref)"
+  fi
+
+  if ! git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
+    echo "::warning::Terragrunt deleted-unit base ${base_ref} is unavailable; skipping deleted-unit destroy detection."
+    return 0
+  fi
+
+  if ! git rev-parse --verify --quiet "${head_ref}^{commit}" >/dev/null; then
+    echo "::warning::Terragrunt deleted-unit head ${head_ref} is unavailable; skipping deleted-unit destroy detection."
+    return 0
+  fi
+
+  git diff --name-only --diff-filter=D "$base_ref" "$head_ref" -- 'IaC/**/terragrunt.hcl' \
+    | sed 's#/terragrunt\.hcl$##' \
+    | sort
+}
+
+terragrunt_create_deleted_unit_destroy_stack() {
+  local destination="$1"
+  local unit_dir="$2"
+  local head_ref="${3:-${TERRAGRUNT_EFFECTIVE_FILTER_HEAD_REF:-}}"
+  local fake_unit_dir
+
+  if [[ -z "$head_ref" ]]; then
+    head_ref="$(terragrunt_filter_head_ref)"
+  fi
+
+  if ! git rev-parse --verify --quiet "${head_ref}^{commit}" >/dev/null; then
+    echo "No usable Terragrunt head ref is available for deleted-unit destroy handling." >&2
+    return 1
+  fi
+
+  mkdir -p "$destination"
+  git archive "$head_ref" | tar -x -C "$destination"
+
+  fake_unit_dir="${destination}/${unit_dir}"
+  mkdir -p "$fake_unit_dir"
+
+  cat >"${fake_unit_dir}/terragrunt.hcl" <<'EOF'
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+locals {
+  root_config = read_terragrunt_config(find_in_parent_folders("root.hcl"))
+  aws_region  = local.root_config.locals.aws_region
+}
+
+generate "deleted_unit_destroy_config" {
+  path      = "deleted-unit-destroy.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<TF
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    azuread = {
+      source = "hashicorp/azuread"
+    }
+    helm = {
+      source = "hashicorp/helm"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
+}
+
+provider "aws" {
+  region = "${local.aws_region}"
+}
+
+provider "azuread" {}
+provider "random" {}
+TF
+}
+EOF
 }

--- a/scripts/ci/terragrunt-plan.sh
+++ b/scripts/ci/terragrunt-plan.sh
@@ -6,6 +6,20 @@ source "${script_dir}/terragrunt-filter-base.sh"
 
 plan_markdown="${TERRAGRUNT_PLAN_MARKDOWN:-${RUNNER_TEMP:-/tmp}/terragrunt-plan.md}"
 mkdir -p "$(dirname "$plan_markdown")"
+extra_plan_json_files=()
+cleanup_dirs=()
+
+cleanup_temp_dirs() {
+  local temp_dir
+
+  for temp_dir in "${cleanup_dirs[@]}"; do
+    if [[ -d "$temp_dir" ]]; then
+      rm -rf "$temp_dir"
+    fi
+  done
+}
+
+trap cleanup_temp_dirs EXIT
 
 clear_plan_artifacts() {
   find "$@" \( -name plan.out -o -name plan.json \) -type f -delete
@@ -66,6 +80,10 @@ validate_terraform_plan_policies() {
       -print 2>/dev/null | sort
   )
 
+  if ((${#extra_plan_json_files[@]} > 0)); then
+    plan_json_files+=("${extra_plan_json_files[@]}")
+  fi
+
   if ((${#plan_json_files[@]} > 0)); then
     echo "::group::Terraform plan Conftest policies"
     conftest test --policy policy --output github "${plan_json_files[@]}"
@@ -79,6 +97,81 @@ append_plan_note() {
   {
     printf '> %s\n\n' "$message"
   } >>"$plan_markdown"
+}
+
+append_deleted_unit_note() {
+  local message="$1"
+  shift
+
+  {
+    printf '### Deleted Terragrunt Units\n\n'
+    printf '%s\n\n' "$message"
+    for unit_dir in "$@"; do
+      printf -- '- `%s`\n' "$unit_dir"
+    done
+    printf '\n'
+  } >>"$plan_markdown"
+}
+
+plan_deleted_terragrunt_units() {
+  local unit_dirs=("$@")
+  local snapshot_dir
+  local unit_dir
+  local snapshot_unit_dir
+  local state_list_file
+
+  if ((${#unit_dirs[@]} == 0)); then
+    return 0
+  fi
+
+  append_deleted_unit_note "The current checkout deleted these Terragrunt units. The plan script creates temporary empty Terragrunt units at the deleted paths, reuses \`root.hcl\` so each fake unit points at the original backend key, lists the state resources, and plans their removal without replaying deleted module code." "${unit_dirs[@]}"
+
+  for unit_dir in "${unit_dirs[@]}"; do
+    snapshot_dir="$(mktemp -d "${RUNNER_TEMP:-/tmp}/terragrunt-deleted-plan.XXXXXX")"
+    cleanup_dirs+=("$snapshot_dir")
+    terragrunt_create_deleted_unit_destroy_stack "$snapshot_dir" "$unit_dir"
+    snapshot_unit_dir="${snapshot_dir}/${unit_dir}"
+    state_list_file="${snapshot_unit_dir}/state-resources.txt"
+
+    if [[ ! -f "${snapshot_unit_dir}/terragrunt.hcl" ]]; then
+      echo "Deleted Terragrunt unit ${unit_dir} fake stack was not generated." >&2
+      exit 1
+    fi
+
+    echo "::group::Deleted Terragrunt unit state comparison: ${unit_dir}"
+    (
+      cd "$snapshot_unit_dir"
+      rm -f plan.out plan.json
+      terragrunt --log-disable init -no-color
+      if ! terragrunt --log-disable state list >"$state_list_file"; then
+        echo "Unable to list state for deleted Terragrunt unit ${unit_dir}; inspect the backend or credentials before applying." >&2
+        exit 1
+      fi
+      if [[ -s "$state_list_file" ]]; then
+        terragrunt plan -destroy -refresh=false -lock=false -out plan.out -no-color >/dev/null
+      else
+        echo "Deleted Terragrunt unit ${unit_dir} has no resources in remote state."
+      fi
+    )
+    echo "::endgroup::"
+
+    if [[ -s "$state_list_file" ]]; then
+      {
+        printf '<details>\n'
+        printf '<summary>Deleted Terragrunt unit state: %s</summary>\n\n' "$unit_dir"
+        printf '~~~~text\n'
+        cat "$state_list_file"
+        printf '~~~~\n\n'
+        printf '</details>\n\n'
+      } >>"$plan_markdown"
+
+      if render_plan_json_if_present "$snapshot_unit_dir"; then
+        extra_plan_json_files+=("${snapshot_unit_dir}/plan.json")
+      fi
+    else
+      append_plan_note "Deleted Terragrunt unit \`${unit_dir}\` had no resources in remote state."
+    fi
+  done
 }
 
 prepare_terragrunt_filter_base
@@ -126,6 +219,13 @@ done < <(find IaC/live/argocd-apps -mindepth 2 -maxdepth 2 -name terragrunt.hcl 
 if [[ "$planned_app_count" -eq 0 ]]; then
   append_plan_note "No affected Argo CD Application registration units were planned."
 fi
+
+deleted_plan_units=()
+while IFS= read -r deleted_unit_dir; do
+  deleted_plan_units+=("$deleted_unit_dir")
+done < <(terragrunt_deleted_unit_paths)
+
+plan_deleted_terragrunt_units "${deleted_plan_units[@]}"
 
 validate_terraform_plan_policies
 


### PR DESCRIPTION
## Issue

Terragrunt's normal current-tree `run --all --filter-affected` flow cannot enter a unit directory after that directory has been deleted. If a pull request removes `IaC/**/terragrunt.hcl`, the unit can disappear from the plan/apply queue even though its OpenTofu state and live resources still exist.

PR #371 exposed this workflow gap. PR #372 later reverted the hardening change that removed the Kubernetes secret stack, so this PR no longer depends on that specific deletion. The remaining fix is the reusable CI behavior: future deleted Terragrunt units should have their state-backed resources planned and destroyed intentionally.

## Cause And Effect

The backend key in `IaC/root.hcl` is derived from:

```hcl
"IaC/${lower(local.project_name)}/${path_relative_to_include()}/terraform.tfstate"
```

That means a fake Terragrunt unit created at the same deleted path can target the exact same remote state key as the removed unit. The previous branch approach replayed the old unit from a base snapshot, but that still depended on deleted module code being available. This update uses the state path directly instead.

Without this, deleting a unit can leave orphaned cloud or Kubernetes resources behind while CI reports only the current checkout's surviving units.

## Fix

The shared Terragrunt CI helper now resolves the effective base/head refs, detects deleted `IaC/**/terragrunt.hcl` files, and can generate a temporary empty Terragrunt unit at each deleted path in a temp copy of the current repo. The fake unit includes `IaC/root.hcl`, so `path_relative_to_include()` points at the original backend key, and it supplies common provider requirements/configuration needed to read and destroy state-backed resources.

The PR plan script now creates these fake units, runs `terragrunt state list` to compare the current empty config against resources still present in remote state, saves a destroy plan, and publishes only the resource addresses in the PR summary to avoid rendering potentially sensitive state values.

The production apply script now performs the same state listing and applies the saved destroy plan for each deleted unit before running the normal current-checkout phases: Argo CD bootstrap, SSM parameters, AzureAD apps, Argo CD Application registrations, and Kubernetes secret materialization.

Docs and the Obsidian knowledge base now describe the deleted-unit cleanup path.

## Validation

- `bash -n scripts/ci/terragrunt-filter-base.sh scripts/ci/terragrunt-plan.sh scripts/ci/terragrunt-apply.sh`
- Generated a fake deleted-unit stack locally and verified it creates the expected temporary `terragrunt.hcl` at the deleted path
- `rg -n "<<<<<<<|=======|>>>>>>>" .`
- `git diff --name-only --diff-filter=U`
- `git diff --check origin/main..HEAD`
- `bash scripts/ci/static-checks.sh`

Checkov ran inside the local static check and reported zero failed checks. It emitted offline guideline lookup warnings because the local shell could not resolve `api0.prismacloud.io`; the scan results themselves were clean.


<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `874f785a8dda035d385e5b1a455c82114f572360`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->

