### PR TITLE
fix: narrow aws ssm reader scope

### DIFF
--- a/IaC/modules/aws-ssm-parameters/main.tf
+++ b/IaC/modules/aws-ssm-parameters/main.tf
@@ -163,7 +163,6 @@ data "aws_iam_policy_document" "parameter_reader" {
       "ssm:DescribeParameters",
       "ssm:GetParameter",
       "ssm:GetParameters",
-      "ssm:GetParametersByPath",
     ]
 
     resources = [

--- a/clusters/homelab/apps/external-secrets/cluster-secret-store.yaml
+++ b/clusters/homelab/apps/external-secrets/cluster-secret-store.yaml
@@ -11,7 +11,6 @@ spec:
         - argocd
         - automation
         - cert-manager
-        - finance
         - media
         - monitoring
         - octelium-client

--- a/docs/knowledge-base/runbooks/secrets-aws-ssm.md
+++ b/docs/knowledge-base/runbooks/secrets-aws-ssm.md
@@ -32,8 +32,8 @@ change External Secrets or SSM values to fix the IAM refresh failure.
 
 The `aws-ssm` ClusterSecretStore is constrained to namespaces with
 repo-owned ExternalSecrets: `ai`, `argocd`, `automation`, `cert-manager`,
-`finance`, `media`, `monitoring`, and `tailscale`. Add a namespace to the
-allow-list in the same PR that adds its first ExternalSecret.
+`media`, `monitoring`, `octelium-client`, and `tailscale`. Add a namespace to
+the allow-list in the same PR that adds its first ExternalSecret.
 
 ## App Contracts
 

--- a/docs/secrets-aws-ssm.md
+++ b/docs/secrets-aws-ssm.md
@@ -49,11 +49,8 @@ only use the `us-east-1` state key will still fail during provider refresh with
 
 The `aws-ssm` ClusterSecretStore is constrained to namespaces with
 repository-owned ExternalSecrets: `ai`, `argocd`, `automation`, `cert-manager`,
-`finance`, `media`, `monitoring`, and `tailscale`. Add a namespace to that
-`finance`, `media`, `monitoring`, `octelium-client`, and `tailscale`. Add a
-namespace to that allow-list in the same PR that adds its first ExternalSecret.
-`media`, `monitoring`, and `tailscale`. Add a namespace to that
-allow-list in the same PR that adds its first ExternalSecret.
+`media`, `monitoring`, `octelium-client`, and `tailscale`. Add a namespace to
+that allow-list in the same PR that adds its first ExternalSecret.
 
 ## External Secrets AWS Auth Bootstrap
 


### PR DESCRIPTION
Split from reverted PR #371.

Finding: External Secrets reader access allowed an unused finance namespace and included ssm:GetParametersByPath even though the policy enumerates managed parameter ARNs.

Changes:
- remove finance from the aws-ssm ClusterSecretStore namespace allow-list
- remove ssm:GetParametersByPath from the SSM reader IAM policy
- update SSM docs and KB allow-list wording while preserving octelium-client from current main

Validation:
- pre-commit hooks passed during signed commit
- rebase conflict resolved to preserve octelium-client and remove only finance
- git diff --check against origin/main passed after rebase

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `ac4621c4b203999bbfab4027c6e2fbb04e4534dd`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
