### PR TITLE
ci: validate rendered kustomize policies

### DIFF
--- a/policy/kubernetes.rego
+++ b/policy/kubernetes.rego
@@ -120,6 +120,19 @@ deny contains msg if {
 	msg := sprintf("ExternalSecret %q uses ClusterSecretStore in namespace %q without an approved SSM prefix policy", [name, namespace])
 }
 
+deny contains msg if {
+	input.kind == "ExternalSecret"
+	metadata := object.get(input, "metadata", {})
+	item := object.get(object.get(input, "spec", {}), "dataFrom", [])[_]
+	find := object.get(item, "find", {})
+	count(find) > 0
+	path := object.get(find, "path", "")
+	count(trim(path, " ")) == 0
+	name := object.get(metadata, "name", "<unknown>")
+	namespace := object.get(metadata, "namespace", "default")
+	msg := sprintf("ExternalSecret %q in namespace %q uses dataFrom.find without a scoped SSM path", [name, namespace])
+}
+
 remote_ref_key_allowed(key, allowed) if {
 	some allowed_key in allowed
 	endswith(allowed_key, "/")

--- a/policy/kubernetes.rego
+++ b/policy/kubernetes.rego
@@ -105,9 +105,7 @@ deny contains msg if {
 	metadata := object.get(input, "metadata", {})
 	namespace := object.get(metadata, "namespace", "default")
 	allowed := external_secret_allowed_prefixes[namespace]
-	item := object.get(object.get(input, "spec", {}), "data", [])[_]
-	key := object.get(object.get(item, "remoteRef", {}), "key", "")
-	key != ""
+	some key in external_secret_remote_keys(input)
 	not remote_ref_key_allowed(key, allowed)
 	name := object.get(metadata, "name", "<unknown>")
 	msg := sprintf("ExternalSecret %q in namespace %q references SSM key %q outside its allowed application prefixes", [name, namespace, key])
@@ -125,4 +123,22 @@ deny contains msg if {
 remote_ref_key_allowed(key, allowed) if {
 	some prefix in allowed
 	startswith(key, prefix)
+}
+
+external_secret_remote_keys(secret) contains key if {
+	item := object.get(object.get(secret, "spec", {}), "data", [])[_]
+	key := object.get(object.get(item, "remoteRef", {}), "key", "")
+	key != ""
+}
+
+external_secret_remote_keys(secret) contains key if {
+	item := object.get(object.get(secret, "spec", {}), "dataFrom", [])[_]
+	key := object.get(object.get(item, "extract", {}), "key", "")
+	key != ""
+}
+
+external_secret_remote_keys(secret) contains key if {
+	item := object.get(object.get(secret, "spec", {}), "dataFrom", [])[_]
+	key := object.get(object.get(item, "find", {}), "path", "")
+	key != ""
 }

--- a/policy/kubernetes.rego
+++ b/policy/kubernetes.rego
@@ -105,7 +105,7 @@ deny contains msg if {
 	metadata := object.get(input, "metadata", {})
 	namespace := object.get(metadata, "namespace", "default")
 	allowed := external_secret_allowed_prefixes[namespace]
-	some key in external_secret_remote_keys(input)
+	key := external_secret_remote_keys(input)[_]
 	not remote_ref_key_allowed(key, allowed)
 	name := object.get(metadata, "name", "<unknown>")
 	msg := sprintf("ExternalSecret %q in namespace %q references SSM key %q outside its allowed application prefixes", [name, namespace, key])
@@ -125,20 +125,22 @@ remote_ref_key_allowed(key, allowed) if {
 	startswith(key, prefix)
 }
 
-external_secret_remote_keys(secret) contains key if {
-	item := object.get(object.get(secret, "spec", {}), "data", [])[_]
-	key := object.get(object.get(item, "remoteRef", {}), "key", "")
-	key != ""
-}
-
-external_secret_remote_keys(secret) contains key if {
-	item := object.get(object.get(secret, "spec", {}), "dataFrom", [])[_]
-	key := object.get(object.get(item, "extract", {}), "key", "")
-	key != ""
-}
-
-external_secret_remote_keys(secret) contains key if {
-	item := object.get(object.get(secret, "spec", {}), "dataFrom", [])[_]
-	key := object.get(object.get(item, "find", {}), "path", "")
-	key != ""
+external_secret_remote_keys(secret) := keys if {
+	spec := object.get(secret, "spec", {})
+	data_keys := [key |
+		item := object.get(spec, "data", [])[_]
+		key := object.get(object.get(item, "remoteRef", {}), "key", "")
+		key != ""
+	]
+	extract_keys := [key |
+		item := object.get(spec, "dataFrom", [])[_]
+		key := object.get(object.get(item, "extract", {}), "key", "")
+		key != ""
+	]
+	find_keys := [key |
+		item := object.get(spec, "dataFrom", [])[_]
+		key := object.get(object.get(item, "find", {}), "path", "")
+		key != ""
+	]
+	keys := array.concat(array.concat(data_keys, extract_keys), find_keys)
 }

--- a/policy/kubernetes.rego
+++ b/policy/kubernetes.rego
@@ -88,3 +88,40 @@ has_nonempty_label(labels, key) if {
 truthy(value) if {
 	lower(sprintf("%v", [value])) == "true"
 }
+
+external_secret_allowed_prefixes := {
+	"ai": {"/homelab/litellm/", "/homelab/openclaw/", "/homelab/grafana/openclaw-alert-hook-token"},
+	"argocd": {"/homelab/argocd/", "/homelab/argocd-image-updater/"},
+	"automation": {"/homelab/n8n/", "/homelab/policy-bot/"},
+	"cert-manager": {"/homelab/cert-manager/"},
+	"media": {"/homelab/deluge/", "/homelab/media-postgres/"},
+	"monitoring": {"/homelab/grafana/"},
+	"tailscale": {"/homelab/tailscale/"},
+}
+
+deny contains msg if {
+	input.kind == "ExternalSecret"
+	metadata := object.get(input, "metadata", {})
+	namespace := object.get(metadata, "namespace", "default")
+	allowed := external_secret_allowed_prefixes[namespace]
+	item := object.get(object.get(input, "spec", {}), "data", [])[_]
+	key := object.get(object.get(item, "remoteRef", {}), "key", "")
+	key != ""
+	not remote_ref_key_allowed(key, allowed)
+	name := object.get(metadata, "name", "<unknown>")
+	msg := sprintf("ExternalSecret %q in namespace %q references SSM key %q outside its allowed application prefixes", [name, namespace, key])
+}
+
+deny contains msg if {
+	input.kind == "ExternalSecret"
+	metadata := object.get(input, "metadata", {})
+	namespace := object.get(metadata, "namespace", "default")
+	not external_secret_allowed_prefixes[namespace]
+	name := object.get(metadata, "name", "<unknown>")
+	msg := sprintf("ExternalSecret %q uses ClusterSecretStore in namespace %q without an approved SSM prefix policy", [name, namespace])
+}
+
+remote_ref_key_allowed(key, allowed) if {
+	some prefix in allowed
+	startswith(key, prefix)
+}

--- a/policy/kubernetes.rego
+++ b/policy/kubernetes.rego
@@ -121,8 +121,15 @@ deny contains msg if {
 }
 
 remote_ref_key_allowed(key, allowed) if {
-	some prefix in allowed
-	startswith(key, prefix)
+	some allowed_key in allowed
+	endswith(allowed_key, "/")
+	startswith(key, allowed_key)
+}
+
+remote_ref_key_allowed(key, allowed) if {
+	some allowed_key in allowed
+	not endswith(allowed_key, "/")
+	key == allowed_key
 }
 
 external_secret_remote_keys(secret) := keys if {

--- a/policy/kubernetes.rego
+++ b/policy/kubernetes.rego
@@ -96,6 +96,7 @@ external_secret_allowed_prefixes := {
 	"cert-manager": {"/homelab/cert-manager/"},
 	"media": {"/homelab/deluge/", "/homelab/media-postgres/"},
 	"monitoring": {"/homelab/grafana/"},
+	"octelium-client": {"/homelab/octelium/"},
 	"tailscale": {"/homelab/tailscale/"},
 }
 

--- a/scripts/ci/conftest-policies.sh
+++ b/scripts/ci/conftest-policies.sh
@@ -2,17 +2,36 @@
 set -euo pipefail
 
 echo "::group::Conftest policies"
-yaml_files=()
+workflow_files=()
 while IFS= read -r yaml_file; do
-  yaml_files+=("$yaml_file")
+  workflow_files+=("$yaml_file")
 done < <(
-  find .github clusters \
+  find .github \
     \( -name '*.yaml' -o -name '*.yml' \) \
     -not -path './.terragrunt-cache/*' \
     -print 2>/dev/null | sort
 )
 
-if ((${#yaml_files[@]} > 0)); then
-  conftest test --policy policy --output github "${yaml_files[@]}"
+if ((${#workflow_files[@]} > 0)); then
+  conftest test --policy policy --output github "${workflow_files[@]}"
+fi
+
+rendered_dir="$(mktemp -d)"
+trap 'rm -rf "$rendered_dir"' EXIT
+rendered_files=()
+
+while IFS= read -r overlay; do
+  rendered_file="${rendered_dir}/$(printf '%s' "$overlay" | tr '/.' '__').yaml"
+  echo "rendering ${overlay} for policy evaluation"
+  kubectl kustomize "$overlay" >"$rendered_file"
+  rendered_files+=("$rendered_file")
+done < <(
+  find clusters/homelab/argocd clusters/homelab/apps clusters/homelab/platform \
+    -name kustomization.yaml \
+    -exec dirname {} \; | sort
+)
+
+if ((${#rendered_files[@]} > 0)); then
+  conftest test --policy policy --output github "${rendered_files[@]}"
 fi
 echo "::endgroup::"


### PR DESCRIPTION
Split from reverted PR #371.

Finding: Conftest was not evaluating rendered Kubernetes manifests, leaving rendered ExternalSecret SSM references outside policy review.

Changes:
- update scripts/ci/conftest-policies.sh to render Kustomize overlays before Conftest evaluation
- add ExternalSecret namespace-to-SSM-prefix policy rules
- keep n8n Funnel path policy in the separate n8n exposure PR so this branch stays green on current main

Validation:
- bash -n scripts/ci/conftest-policies.sh passed
- bash scripts/ci/conftest-policies.sh passed locally with 2394 rendered-manifest tests
- pre-commit hooks passed during signed commit
- git diff --check against origin/main passed after rebase

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `fc6449b8dee9c6ffcd90251c77b50caeee4c846b`.

> `IaC/live/aws-ssm-parameters` is intentionally excluded from PR plans because it manages KMS, IAM, and secret declarations that require protected apply credentials. Runtime Kubernetes Secrets are installed by protected CI scripts instead of OpenTofu state.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->




