### PR TITLE
fix(n8n): restrict public funnel webhooks

### DIFF
--- a/clusters/homelab/apps/n8n/README.md
+++ b/clusters/homelab/apps/n8n/README.md
@@ -30,13 +30,20 @@ persisted settings file instead of crashlooping on an accidental mismatch.
 - Editor/UI ingress: `istio-system/tailnet-gateway`
 - Public webhook Funnel host: `https://n8n-webhook.tail67beb.ts.net`
 - Public webhook paths: production `/webhook` paths only
+- Private test and waiting webhook paths:
+  `https://n8n.stinkyboi.com/webhook-test/...` and
+  `https://n8n.stinkyboi.com/webhook-waiting/...`
 
 `WEBHOOK_URL` is set to the public Funnel host so n8n advertises externally
-reachable webhook URLs. The editor base URL stays on the tailnet-only
-`n8n.stinkyboi.com` host. The Funnel route is declared as a Tailscale Ingress
-in `istio-system` and forwards only the webhook path prefixes to the Istio
-gateway, which then routes to the n8n service. Do not add the root path, editor
-routes, static assets, or API routes to the Funnel Ingress.
+reachable production webhook URLs. n8n also uses that value when displaying
+test and waiting webhook URLs, so operators testing from the editor should keep
+the generated path but replace the host with the tailnet-only
+`n8n.stinkyboi.com` host for `/webhook-test/...` and `/webhook-waiting/...`.
+The Funnel route is declared as a Tailscale Ingress in `istio-system` and
+forwards only the production `/webhook` path family to the Istio gateway, which
+then routes to the n8n service. Do not add the root path, editor routes, static
+assets, API routes, `/webhook-test`, or `/webhook-waiting` to the Funnel
+Ingress.
 
 The Tailscale tailnet policy must allow the operator proxy tag, currently
 `tag:k8s`, to use Funnel:
@@ -77,9 +84,10 @@ curl -sS -o /dev/null -w '%{http_code}\n' https://n8n-webhook.tail67beb.ts.net/w
 ```
 
 Expected route behavior: the editor host serves n8n through the tailnet, the
-Funnel host reaches n8n only under the webhook prefixes, and an unknown
-webhook path returns an n8n not-found response until a workflow registers that
-webhook.
+Funnel host reaches n8n only under `/webhook` and `/webhook/*`, private
+`/webhook-test/...` and `/webhook-waiting/...` calls use
+`n8n.stinkyboi.com`, and an unknown webhook path returns an n8n not-found
+response until a workflow registers that webhook.
 
 ## Rollback
 

--- a/clusters/homelab/apps/n8n/README.md
+++ b/clusters/homelab/apps/n8n/README.md
@@ -29,7 +29,7 @@ persisted settings file instead of crashlooping on an accidental mismatch.
 - Editor/UI host: `https://n8n.stinkyboi.com`
 - Editor/UI ingress: `istio-system/tailnet-gateway`
 - Public webhook Funnel host: `https://n8n-webhook.tail67beb.ts.net`
-- Public webhook paths: `/webhook`, `/webhook-test`, and `/webhook-waiting`
+- Public webhook paths: production `/webhook` paths only
 
 `WEBHOOK_URL` is set to the public Funnel host so n8n advertises externally
 reachable webhook URLs. The editor base URL stays on the tailnet-only

--- a/clusters/homelab/apps/n8n/ingress-funnel.yaml
+++ b/clusters/homelab/apps/n8n/ingress-funnel.yaml
@@ -23,17 +23,3 @@ spec:
                 name: istio-ingressgateway
                 port:
                   name: http2
-          - path: /webhook-test
-            pathType: Prefix
-            backend:
-              service:
-                name: istio-ingressgateway
-                port:
-                  name: http2
-          - path: /webhook-waiting
-            pathType: Prefix
-            backend:
-              service:
-                name: istio-ingressgateway
-                port:
-                  name: http2

--- a/clusters/homelab/apps/n8n/virtualservice.yaml
+++ b/clusters/homelab/apps/n8n/virtualservice.yaml
@@ -23,22 +23,6 @@ spec:
             - istio-system/n8n-webhook-funnel
           uri:
             prefix: /webhook/
-        - gateways:
-            - istio-system/n8n-webhook-funnel
-          uri:
-            exact: /webhook-test
-        - gateways:
-            - istio-system/n8n-webhook-funnel
-          uri:
-            prefix: /webhook-test/
-        - gateways:
-            - istio-system/n8n-webhook-funnel
-          uri:
-            exact: /webhook-waiting
-        - gateways:
-            - istio-system/n8n-webhook-funnel
-          uri:
-            prefix: /webhook-waiting/
       route:
         - destination:
             host: n8n.automation.svc.cluster.local

--- a/docs/knowledge-base/runbooks/tailnet-ingress.md
+++ b/docs/knowledge-base/runbooks/tailnet-ingress.md
@@ -23,8 +23,7 @@ does not replace the Tailscale exit node.
   OpenClaw, n8n editor/UI, Policy Bot UI and normal routes, and OctoBot UI are
   tailnet-only.
 - n8n webhooks are a reviewed public Funnel exception:
-  `https://n8n-webhook.tail67beb.ts.net` for `/webhook`, `/webhook-test`, and
-  `/webhook-waiting` only.
+  `https://n8n-webhook.tail67beb.ts.net` for production `/webhook` paths only.
 - Policy Bot GitHub webhook is another reviewed public Funnel exception:
   `https://policy-bot-hook.<tailnet-name>.ts.net/api/github/hook`.
 - Prometheus is intentionally not exposed; Grafana is the metrics UI and Kiali

--- a/docs/knowledge-base/runbooks/tailnet-ingress.md
+++ b/docs/knowledge-base/runbooks/tailnet-ingress.md
@@ -24,6 +24,9 @@ does not replace the Tailscale exit node.
   tailnet-only.
 - n8n webhooks are a reviewed public Funnel exception:
   `https://n8n-webhook.tail67beb.ts.net` for production `/webhook` paths only.
+- n8n test and waiting webhook paths stay private on the tailnet editor host:
+  `https://n8n.stinkyboi.com/webhook-test/...` and
+  `https://n8n.stinkyboi.com/webhook-waiting/...`.
 - Policy Bot GitHub webhook is another reviewed public Funnel exception:
   `https://policy-bot-hook.<tailnet-name>.ts.net/api/github/hook`.
 - Prometheus is intentionally not exposed; Grafana is the metrics UI and Kiali

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -243,7 +243,9 @@ workflow webhook URLs through `https://n8n-webhook.tail67beb.ts.net`. The
 Funnel route is limited to production `/webhook` paths and forwards through
 the Istio ingress gateway so the n8n
 workload AuthorizationPolicy can continue allowing only the gateway service
-account.
+account. Test and waiting webhook paths remain private by using the generated
+path on `https://n8n.stinkyboi.com` instead of exposing `/webhook-test` or
+`/webhook-waiting` through Funnel.
 
 ## Policy Bot
 

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -240,8 +240,8 @@ rollout when existing SQLite contents must be preserved.
 
 n8n keeps the editor and API on `https://n8n.stinkyboi.com`, but advertises
 workflow webhook URLs through `https://n8n-webhook.tail67beb.ts.net`. The
-Funnel route is limited to `/webhook`, `/webhook-test`, and
-`/webhook-waiting`, and forwards through the Istio ingress gateway so the n8n
+Funnel route is limited to production `/webhook` paths and forwards through
+the Istio ingress gateway so the n8n
 workload AuthorizationPolicy can continue allowing only the gateway service
 account.
 

--- a/docs/networking-tailnet-ingress.md
+++ b/docs/networking-tailnet-ingress.md
@@ -35,7 +35,7 @@ that must be added through a separate Terragrunt/OpenTofu entry point.
 | litellm | `https://litellm.stinkyboi.com` | disabled |
 | openclaw | `https://openclaw.stinkyboi.com` | disabled |
 | n8n editor/UI | `https://n8n.stinkyboi.com` | disabled |
-| n8n webhooks | `https://n8n-webhook.tail67beb.ts.net/webhook...` | enabled for `/webhook`, `/webhook-test`, and `/webhook-waiting` only |
+| n8n webhooks | `https://n8n-webhook.tail67beb.ts.net/webhook...` | enabled for production `/webhook` paths only |
 | policy-bot UI and normal routes | `https://policy-bot.stinkyboi.com` | disabled |
 | octobot UI | `https://octobot.stinkyboi.com` | disabled |
 | policy-bot GitHub webhook | `https://policy-bot-hook.<tailnet-name>.ts.net/api/github/hook` | enabled for `/api/github/hook` only |
@@ -153,7 +153,7 @@ reviewed public route is:
 
 ```text
 Owning application: n8n
-Public paths: /webhook, /webhook-test, /webhook-waiting
+Public paths: /webhook and /webhook/*
 Purpose: n8n workflow webhook deliveries from external systems.
 Source system: workflow-specific SaaS integrations and HTTP clients configured in n8n.
 Authentication or signature check: workflow-specific n8n webhook credentials, node-level signing, or path entropy where configured.

--- a/docs/networking-tailnet-ingress.md
+++ b/docs/networking-tailnet-ingress.md
@@ -164,8 +164,14 @@ Data exposed: request bodies and headers sent to active n8n webhook workflows.
 
 The n8n editor, REST API, static assets, and root path stay on
 `https://n8n.stinkyboi.com` through the tailnet-only Istio gateway. The Funnel
-Ingress forwards only webhook path prefixes to the Istio gateway, and the n8n
-VirtualService only routes those prefixes on the public webhook gateway.
+Ingress forwards only the production `/webhook` path family to the Istio
+gateway, and the n8n VirtualService only routes those prefixes on the public
+webhook gateway.
+Test and waiting webhook URLs remain private: because n8n displays the
+configured `WEBHOOK_URL` host for those generated URLs too, operators should
+use the same generated path on `https://n8n.stinkyboi.com` for
+`/webhook-test/...` and `/webhook-waiting/...` while testing from the tailnet.
+Do not add those non-production endpoint families to the public Funnel route.
 
 ## Future Funnel Webhook Exception Template
 

--- a/policy/kubernetes.rego
+++ b/policy/kubernetes.rego
@@ -75,6 +75,40 @@ deny contains msg if {
 	msg := sprintf("Application %q source %d must target the homelab repository default branch main", [name, index])
 }
 
+forbidden_public_funnel_prefixes := {
+	"/webhook-test",
+	"/webhook-test/",
+	"/webhook-waiting",
+	"/webhook-waiting/",
+}
+
+deny contains msg if {
+	input.kind == "Ingress"
+	metadata := object.get(input, "metadata", {})
+	annotations := object.get(metadata, "annotations", {})
+	truthy(object.get(annotations, "homelab.rst.io/public-funnel", "false"))
+	rule := object.get(object.get(input, "spec", {}), "rules", [])[_]
+	http := object.get(rule, "http", {})
+	backend_path := object.get(http, "paths", [])[_]
+	path := object.get(backend_path, "path", "")
+	path in forbidden_public_funnel_prefixes
+	name := object.get(metadata, "name", "<unknown>")
+	msg := sprintf("public Funnel Ingress %q must not expose non-production webhook path %q", [name, path])
+}
+
+deny contains msg if {
+	input.kind == "VirtualService"
+	metadata := object.get(input, "metadata", {})
+	route := object.get(object.get(input, "spec", {}), "http", [])[_]
+	match := object.get(route, "match", [])[_]
+	object.get(match, "gateways", [])[_] == "istio-system/n8n-webhook-funnel"
+	uri := object.get(match, "uri", {})
+	path := object.get(uri, "exact", object.get(uri, "prefix", ""))
+	path in forbidden_public_funnel_prefixes
+	name := object.get(metadata, "name", "<unknown>")
+	msg := sprintf("VirtualService %q must not route non-production webhook path %q through the public n8n funnel", [name, path])
+}
+
 has_nonempty_annotation(annotations, key) if {
 	value := object.get(annotations, key, "")
 	count(trim(value, " ")) > 0

--- a/policy/kubernetes.rego
+++ b/policy/kubernetes.rego
@@ -77,9 +77,17 @@ deny contains msg if {
 
 forbidden_public_funnel_prefixes := {
 	"/webhook-test",
-	"/webhook-test/",
 	"/webhook-waiting",
-	"/webhook-waiting/",
+}
+
+forbidden_public_funnel_path(path) if {
+	some prefix in forbidden_public_funnel_prefixes
+	path == prefix
+}
+
+forbidden_public_funnel_path(path) if {
+	some prefix in forbidden_public_funnel_prefixes
+	startswith(path, sprintf("%s/", [prefix]))
 }
 
 deny contains msg if {
@@ -91,7 +99,7 @@ deny contains msg if {
 	http := object.get(rule, "http", {})
 	backend_path := object.get(http, "paths", [])[_]
 	path := object.get(backend_path, "path", "")
-	path in forbidden_public_funnel_prefixes
+	forbidden_public_funnel_path(path)
 	name := object.get(metadata, "name", "<unknown>")
 	msg := sprintf("public Funnel Ingress %q must not expose non-production webhook path %q", [name, path])
 }
@@ -104,7 +112,7 @@ deny contains msg if {
 	object.get(match, "gateways", [])[_] == "istio-system/n8n-webhook-funnel"
 	uri := object.get(match, "uri", {})
 	path := object.get(uri, "exact", object.get(uri, "prefix", ""))
-	path in forbidden_public_funnel_prefixes
+	forbidden_public_funnel_path(path)
 	name := object.get(metadata, "name", "<unknown>")
 	msg := sprintf("VirtualService %q must not route non-production webhook path %q through the public n8n funnel", [name, path])
 }


### PR DESCRIPTION
Split from reverted PR #371.

Finding: The public n8n Tailscale Funnel exposed test and waiting webhook paths that should stay private to the operator UI path.

Changes:
- remove /webhook-test and /webhook-waiting from the public Funnel Ingress and VirtualService
- document production /webhook paths only in n8n and tailnet-ingress docs
- add n8n-specific Rego policy that forbids those non-production paths on public Funnel routes

Validation:
- kubectl kustomize clusters/homelab/apps/n8n rendered successfully
- conftest test --policy policy --output github /private/tmp/homelab-n8n-render.yaml passed with 114 tests
- pre-commit hooks passed during signed commit
- git diff --check against origin/main passed after rebase

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `acc50388d0a890e5f52b3620d044c2238296a7b0`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
