### PR TITLE
fix: tighten privileged namespace warnings

### DIFF
--- a/clusters/homelab/apps/deluge/namespace.yaml
+++ b/clusters/homelab/apps/deluge/namespace.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/part-of: homelab
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/enforce-version: latest
-    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/audit: restricted
     pod-security.kubernetes.io/audit-version: latest
-    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/warn: restricted
     pod-security.kubernetes.io/warn-version: latest

--- a/clusters/homelab/apps/istio/namespace.yaml
+++ b/clusters/homelab/apps/istio/namespace.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/part-of: homelab
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/enforce-version: latest
-    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/audit: restricted
     pod-security.kubernetes.io/audit-version: latest
-    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/warn: restricted
     pod-security.kubernetes.io/warn-version: latest

--- a/clusters/homelab/apps/tailscale/namespace.yaml
+++ b/clusters/homelab/apps/tailscale/namespace.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/part-of: homelab
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/enforce-version: latest
-    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/audit: restricted
     pod-security.kubernetes.io/audit-version: latest
-    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/warn: restricted
     pod-security.kubernetes.io/warn-version: latest

--- a/docs/knowledge-base/operations/continuous-improvement.md
+++ b/docs/knowledge-base/operations/continuous-improvement.md
@@ -90,3 +90,14 @@ policy`.
 - **Next step:** decide whether to keep squash-only merges with GitHub-signed
   mainline commits, allow rebase/merge methods that preserve Claw-signed branch
   commits, or add a bot-supported path for signed squash commits.
+- **Status:** fixed
+- **Area:** platform service / Pod Security
+- **Evidence:** June 2026 security audit found privileged namespaces using
+  `privileged` for `enforce`, `audit`, and `warn`. This change keeps the
+  required `enforce: privileged` exception for Deluge VPN, Istio ingress, and
+  Tailscale operator proxy workloads, but moves `audit` and `warn` to
+  `restricted` so drift is visible during review and sync.
+- **Risk:** privileged audit/warn labels hide workloads that could run under a
+  tighter profile or accidentally expand the exception blast radius.
+- **Next step:** continue splitting the Deluge VPN privilege exception into a
+  dedicated namespace once the media workloads can stay restricted.


### PR DESCRIPTION
Split from reverted PR #371.

Finding: Namespaces that require privileged enforcement also used privileged audit and warn labels, hiding drift that could run under a tighter profile.

Changes:
- keep enforce: privileged for media, istio-system, and tailscale
- move audit and warn labels to restricted for those namespaces
- record the PSA follow-up in the knowledge base

Validation:
- kubectl kustomize clusters/homelab/apps/deluge rendered successfully
- kubectl kustomize clusters/homelab/apps/istio rendered successfully
- kubectl kustomize clusters/homelab/apps/tailscale rendered successfully
- pre-commit hooks passed during signed commit
- git diff --check against origin/main passed after rebase

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `65f3eec1baacbf631c357ba8b634ac2801af1dae`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
