### PR TITLE
fix(openclaw): map secrets explicitly

### DIFF
--- a/clusters/homelab/apps/openclaw/README.md
+++ b/clusters/homelab/apps/openclaw/README.md
@@ -149,9 +149,9 @@ OpenClaw receives GitHub App identity through AWS SSM-backed ExternalSecrets:
 
 The pod sets `GITHUB_APP_PRIVATE_KEY_PATH` to
 `/var/run/secrets/openclaw/github-app/private-key.pem`. The private key is
-mounted as a file from `openclaw-github-app-private-key` instead of being
-exported through `envFrom`, so the PEM is not copied into the process
-environment.
+mounted as a file from `openclaw-github-app-private-key`, so the PEM is not
+copied into the process environment. Other OpenClaw secret keys are mapped with
+explicit `secretKeyRef` entries rather than a broad `envFrom` import.
 
 After replacing any GitHub App SSM placeholder, bump
 `homelab.rst.io/openclaw-github-app-credentials-ssm-version` in `values.yaml`

--- a/clusters/homelab/apps/openclaw/values.yaml
+++ b/clusters/homelab/apps/openclaw/values.yaml
@@ -34,9 +34,41 @@ controllers:
                 name: openclaw-secrets
                 key: APP_SECRET
           GITHUB_APP_PRIVATE_KEY_PATH: /var/run/secrets/openclaw/github-app/private-key.pem
-        envFrom:
-          - secretRef:
-              name: openclaw-secrets
+          LITELLM_TOKEN:
+            valueFrom:
+              secretKeyRef:
+                name: openclaw-secrets
+                key: LITELLM_TOKEN
+          DISCORD_BOT_TOKEN:
+            valueFrom:
+              secretKeyRef:
+                name: openclaw-secrets
+                key: DISCORD_BOT_TOKEN
+          GRAFANA_USERNAME:
+            valueFrom:
+              secretKeyRef:
+                name: openclaw-secrets
+                key: GRAFANA_USERNAME
+          GRAFANA_PASSWORD:
+            valueFrom:
+              secretKeyRef:
+                name: openclaw-secrets
+                key: GRAFANA_PASSWORD
+          GRAFANA_ALERT_HOOK_TOKEN:
+            valueFrom:
+              secretKeyRef:
+                name: openclaw-secrets
+                key: GRAFANA_ALERT_HOOK_TOKEN
+          GITHUB_APP_ID:
+            valueFrom:
+              secretKeyRef:
+                name: openclaw-secrets
+                key: GITHUB_APP_ID
+          GITHUB_APP_INSTALLATION_ID:
+            valueFrom:
+              secretKeyRef:
+                name: openclaw-secrets
+                key: GITHUB_APP_INSTALLATION_ID
         command:
           - /bin/sh
           - -ec
@@ -182,9 +214,41 @@ controllers:
                 key: APP_SECRET
           GITHUB_APP_PRIVATE_KEY_PATH: /var/run/secrets/openclaw/github-app/private-key.pem
           LITELLM_BASE_URL: http://litellm.ai.svc.cluster.local:4000
-        envFrom:
-          - secretRef:
-              name: openclaw-secrets
+          LITELLM_TOKEN:
+            valueFrom:
+              secretKeyRef:
+                name: openclaw-secrets
+                key: LITELLM_TOKEN
+          DISCORD_BOT_TOKEN:
+            valueFrom:
+              secretKeyRef:
+                name: openclaw-secrets
+                key: DISCORD_BOT_TOKEN
+          GRAFANA_USERNAME:
+            valueFrom:
+              secretKeyRef:
+                name: openclaw-secrets
+                key: GRAFANA_USERNAME
+          GRAFANA_PASSWORD:
+            valueFrom:
+              secretKeyRef:
+                name: openclaw-secrets
+                key: GRAFANA_PASSWORD
+          GRAFANA_ALERT_HOOK_TOKEN:
+            valueFrom:
+              secretKeyRef:
+                name: openclaw-secrets
+                key: GRAFANA_ALERT_HOOK_TOKEN
+          GITHUB_APP_ID:
+            valueFrom:
+              secretKeyRef:
+                name: openclaw-secrets
+                key: GITHUB_APP_ID
+          GITHUB_APP_INSTALLATION_ID:
+            valueFrom:
+              secretKeyRef:
+                name: openclaw-secrets
+                key: GITHUB_APP_INSTALLATION_ID
         resources:
           requests:
             cpu: 1


### PR DESCRIPTION
Split from reverted PR #371.

Finding: OpenClaw init/app containers imported the full openclaw-secrets Secret with envFrom, widening process-environment exposure beyond the keys each container needs.

Changes:
- replace broad envFrom imports with explicit secretKeyRef entries for init and app containers
- keep the GitHub App PEM mounted as a file through GITHUB_APP_PRIVATE_KEY_PATH
- update the OpenClaw README to describe the narrower mapping

Validation:
- kubectl kustomize clusters/homelab/apps/openclaw rendered successfully
- pre-commit hooks passed during signed commit
- git diff --check against origin/main passed after rebase

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `5447770a3a7f474f48d777315e17672d3384f325`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
