### PR TITLE
fix(prowlarr): harden auth recovery script

### DIFF
--- a/scripts/prowlarr-recover-auth.sh
+++ b/scripts/prowlarr-recover-auth.sh
@@ -101,7 +101,7 @@ fi
 s6-svc "$action" "$svc_dir"'
 
 remote_process_absent_script='set -eu
-process_pattern="$1"
+process_pattern="${PROCESS_PATTERN:?PROCESS_PATTERN is required}"
 for _ in $(seq 1 60); do
   if command -v pgrep >/dev/null 2>&1; then
     if ! pgrep -f -- "$process_pattern" >/dev/null; then
@@ -116,7 +116,7 @@ echo "Timed out waiting for process to stop: ${process_pattern}" >&2
 exit 1'
 
 remote_process_present_script='set -eu
-process_pattern="$1"
+process_pattern="${PROCESS_PATTERN:?PROCESS_PATTERN is required}"
 for _ in $(seq 1 60); do
   if command -v pgrep >/dev/null 2>&1; then
     if pgrep -f -- "$process_pattern" >/dev/null; then
@@ -136,11 +136,11 @@ start_service() {
 
 stop_service() {
   kubectl -n "$namespace" exec "$pod" -- /bin/sh -ec "$remote_service_script" sh "$service_name" -d
-  kubectl -n "$namespace" exec "$pod" -- /bin/sh -ec "$remote_process_absent_script" sh "$process_pattern"
+  kubectl -n "$namespace" exec "$pod" -- env PROCESS_PATTERN="$process_pattern" /bin/sh -ec "$remote_process_absent_script"
 }
 
 wait_for_start() {
-  kubectl -n "$namespace" exec "$pod" -- /bin/sh -ec "$remote_process_present_script" sh "$process_pattern"
+  kubectl -n "$namespace" exec "$pod" -- env PROCESS_PATTERN="$process_pattern" /bin/sh -ec "$remote_process_present_script"
 }
 
 echo "Checking live Prowlarr resources..."

--- a/scripts/prowlarr-recover-auth.sh
+++ b/scripts/prowlarr-recover-auth.sh
@@ -7,9 +7,30 @@ config_path="/config/config.xml"
 process_pattern="${PROCESS_PATTERN:-/app/prowlarr/bin/Prowlarr}"
 service_name="${SERVICE_NAME:-svc-prowlarr}"
 
+validate_kubernetes_name() {
+  local label="$1"
+  local value="$2"
+
+  if [[ ! "$value" =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ ]]; then
+    echo "${label} must be a Kubernetes DNS label; got: ${value}" >&2
+    exit 2
+  fi
+}
+
+validate_process_pattern() {
+  if [[ ! "$process_pattern" =~ ^[A-Za-z0-9_./:-]+$ ]]; then
+    echo "PROCESS_PATTERN contains unsupported characters; use only letters, numbers, '_', '.', '/', ':', and '-'." >&2
+    exit 2
+  fi
+}
+
 usage() {
   cat <<'USAGE'
 Usage: scripts/prowlarr-recover-auth.sh [--yes]
+
+BREAK-GLASS RECOVERY: this is not a normal GitOps reconciliation path.
+Use it only to recover Prowlarr authentication, then verify the repo-owned
+configuration still represents the desired steady state.
 
 Recovers a locked-out LinuxServer Prowlarr deployment by following the Servarr
 procedure in-place inside the running pod:
@@ -43,6 +64,11 @@ case "${1:-}" in
     ;;
 esac
 
+validate_kubernetes_name NAMESPACE "$namespace"
+validate_kubernetes_name DEPLOYMENT "$deployment"
+validate_kubernetes_name SERVICE_NAME "$service_name"
+validate_process_pattern
+
 if ! command -v kubectl >/dev/null 2>&1; then
   echo "kubectl is required but was not found in PATH" >&2
   exit 1
@@ -50,6 +76,10 @@ fi
 
 if [[ "$confirm" != "true" ]]; then
   cat <<EOF
+BREAK-GLASS RECOVERY: this is not a normal GitOps reconciliation path.
+Use it only to recover Prowlarr authentication, then verify the repo-owned
+configuration still represents the desired steady state.
+
 This will temporarily change runtime state inside the live Prowlarr pod:
   - stop the ${service_name} s6 service in deployment/${deployment}
   - edit ${config_path} on the mounted /config PVC after writing a backup
@@ -59,6 +89,59 @@ Re-run with --yes to continue.
 EOF
   exit 1
 fi
+
+remote_service_script='set -eu
+service_name="$1"
+action="$2"
+svc_dir="$(find /run -path "*/servicedirs/${service_name}" -type d 2>/dev/null | grep "/run/s6-rc:" | head -n 1 || true)"
+if [ -z "$svc_dir" ]; then
+  echo "Could not find s6 service directory for ${service_name}" >&2
+  exit 1
+fi
+s6-svc "$action" "$svc_dir"'
+
+remote_process_absent_script='set -eu
+process_pattern="$1"
+for _ in $(seq 1 60); do
+  if command -v pgrep >/dev/null 2>&1; then
+    if ! pgrep -f -- "$process_pattern" >/dev/null; then
+      exit 0
+    fi
+  elif ! ps -ef | grep -F -- "$process_pattern" | grep -v grep >/dev/null; then
+    exit 0
+  fi
+  sleep 1
+done
+echo "Timed out waiting for process to stop: ${process_pattern}" >&2
+exit 1'
+
+remote_process_present_script='set -eu
+process_pattern="$1"
+for _ in $(seq 1 60); do
+  if command -v pgrep >/dev/null 2>&1; then
+    if pgrep -f -- "$process_pattern" >/dev/null; then
+      exit 0
+    fi
+  elif ps -ef | grep -F -- "$process_pattern" | grep -v grep >/dev/null; then
+    exit 0
+  fi
+  sleep 1
+done
+echo "Timed out waiting for process to start: ${process_pattern}" >&2
+exit 1'
+
+start_service() {
+  kubectl -n "$namespace" exec "$pod" -- /bin/sh -ec "$remote_service_script" sh "$service_name" -u
+}
+
+stop_service() {
+  kubectl -n "$namespace" exec "$pod" -- /bin/sh -ec "$remote_service_script" sh "$service_name" -d
+  kubectl -n "$namespace" exec "$pod" -- /bin/sh -ec "$remote_process_absent_script" sh "$process_pattern"
+}
+
+wait_for_start() {
+  kubectl -n "$namespace" exec "$pod" -- /bin/sh -ec "$remote_process_present_script" sh "$process_pattern"
+}
 
 echo "Checking live Prowlarr resources..."
 kubectl -n "$namespace" get deployment "$deployment" >/dev/null
@@ -74,18 +157,6 @@ if [[ -z "$pod" ]]; then
   exit 1
 fi
 
-start_service() {
-  kubectl -n "$namespace" exec "$pod" -- /bin/sh -ec "
-    set -eu
-    svc_dir=\"\$(find /run -path '*/servicedirs/${service_name}' -type d 2>/dev/null | grep '/run/s6-rc:' | head -n 1 || true)\"
-    if [ -z \"\$svc_dir\" ]; then
-      echo \"Could not find s6 service directory for ${service_name}\" >&2
-      exit 1
-    fi
-    s6-svc -u \"\$svc_dir\"
-  "
-}
-
 restore_on_exit="false"
 cleanup() {
   if [[ "${restore_on_exit}" == "true" ]]; then
@@ -95,24 +166,7 @@ cleanup() {
 trap cleanup EXIT
 
 echo "Stopping ${service_name} inside pod/${pod}..."
-kubectl -n "$namespace" exec "$pod" -- /bin/sh -ec "
-  set -eu
-  svc_dir=\"\$(find /run -path '*/servicedirs/${service_name}' -type d 2>/dev/null | grep '/run/s6-rc:' | head -n 1 || true)\"
-  if [ -z \"\$svc_dir\" ]; then
-    echo \"Could not find s6 service directory for ${service_name}\" >&2
-    exit 1
-  fi
-  s6-svc -d \"\$svc_dir\"
-  for _ in \$(seq 1 60); do
-    if ! ps -ef | grep '${process_pattern}' | grep -v grep >/dev/null; then
-      exit 0
-    fi
-    sleep 1
-  done
-  s6-svstat \"\$svc_dir\" || true
-  echo \"Timed out waiting for ${service_name} to stop\" >&2
-  exit 1
-"
+stop_service
 restore_on_exit="true"
 
 echo "Backing up config.xml and removing AuthenticationMethod..."
@@ -147,25 +201,15 @@ echo "Starting ${service_name}..."
 start_service
 
 echo "Waiting for Prowlarr to start..."
-kubectl -n "$namespace" exec "$pod" -- /bin/sh -ec "
-  set -eu
-  for _ in \$(seq 1 60); do
-    if ps -ef | grep '${process_pattern}' | grep -v grep >/dev/null; then
-      exit 0
-    fi
-    sleep 1
-  done
-  echo \"Timed out waiting for Prowlarr process to start\" >&2
-  exit 1
-"
+wait_for_start
 restore_on_exit="false"
 trap - EXIT
 
 echo "Checking that AuthenticationMethod is unset or None after startup..."
 auth_method="$(
-  kubectl -n "$namespace" exec "$pod" -- /bin/sh -ec \
-    "sed -n 's/.*<AuthenticationMethod>\\(.*\\)<\\/AuthenticationMethod>.*/\\1/p' '${config_path}' | head -n 1" \
-    2>/dev/null
+  kubectl -n "$namespace" exec "$pod" -- /bin/sh -ec '
+    sed -n "s/.*<AuthenticationMethod>\(.*\)<\/AuthenticationMethod>.*/\1/p" /config/config.xml | head -n 1
+  ' 2>/dev/null
 )"
 case "$auth_method" in
   ""|None)
@@ -176,4 +220,11 @@ case "$auth_method" in
     ;;
 esac
 
-echo "Prowlarr auth recovery is ready. Open https://prowlarr.stinkyboi.com and set a new password."
+cat <<'EOF'
+Prowlarr auth recovery is ready. Open https://prowlarr.stinkyboi.com and set a new password.
+
+Post-recovery checklist:
+  - Confirm the repo-owned Prowlarr manifests still describe the desired steady state.
+  - Record any durable configuration change in git instead of leaving it only on the PVC.
+  - Keep the timestamped /config/config.xml.auth-recovery.* backup until the new login is verified.
+EOF


### PR DESCRIPTION
Split from reverted PR #371.

Finding: The Prowlarr break-glass auth recovery script accepted broad overrides and interpolated values into remote shell snippets in ways that were easy to misuse.

Changes:
- validate Kubernetes name overrides and process-pattern input
- pass remote shell values positionally instead of interpolating them into script bodies
- add break-glass warnings and a post-recovery checklist

Validation:
- bash -n scripts/prowlarr-recover-auth.sh passed
- pre-commit hooks passed during signed commit
- git diff --check against origin/main passed after rebase

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `b0c4761dca596ab76eb1f8a4f5a2852acd1ab9bc`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
