### PR TITLE
docs: record security audit follow-ups

### DIFF
--- a/docs/knowledge-base/operations/continuous-improvement.md
+++ b/docs/knowledge-base/operations/continuous-improvement.md
@@ -90,6 +90,31 @@ policy`.
 - **Next step:** decide whether to keep squash-only merges with GitHub-signed
   mainline commits, allow rebase/merge methods that preserve Claw-signed branch
   commits, or add a bot-supported path for signed squash commits.
+- **Status:** open
+- **Area:** secrets / CI/CD
+- **Evidence:** June 2026 security audit found
+  `IaC/live/kubernetes-secrets/external-secrets-aws-ssm-auth/terragrunt.hcl`
+  still sources `../../../modules/kubernetes-secret-from-ssm`, whose module
+  reads decrypted SSM values into a Kubernetes Secret resource and OpenTofu
+  state.
+- **Risk:** decrypted External Secrets AWS provider credentials could otherwise
+  be exposed to anyone or anything with access to OpenTofu state, plan caches, or
+  CI artifacts.
+- **Next step:** keep this finding open until repo-owned remediation replaces
+  the state-writing stack, removes any older state object that contained the
+  Kubernetes Secret data, and rotates the External Secrets IAM access key.
+- **Status:** open
+- **Area:** platform service / GitOps
+- **Evidence:** June 2026 security audit found remaining structural hardening
+  work: the shared Argo CD AppProject can still deploy cluster-scoped RBAC,
+  Kiali remains anonymous/view-only on the tailnet, several app-template
+  workloads need explicit restricted container security contexts, and remote
+  Terragrunt catalog modules are still referenced by the mutable `0.4.0` tag.
+- **Risk:** these are reviewability, reconnaissance, and lateral-movement risks
+  that are larger than a single safe patch.
+- **Next step:** split AppProjects, add Kiali identity controls, harden
+  compatible app-template values, and pin or vendor remote modules once the
+  immutable commit for `terragrunt-catalog` tag `0.4.0` can be verified.
 - **Status:** fixed
 - **Area:** platform service / Pod Security
 - **Evidence:** June 2026 security audit found privileged namespaces using


### PR DESCRIPTION
Split from reverted PR #371.

Finding: The audit also produced durable follow-up work that should stay in the knowledge base even when the remediations are reviewed as separate PRs.

Changes:
- record the External Secrets state cleanup and key-rotation follow-up
- record remaining structural hardening items for AppProject scoping, Kiali identity, workload security contexts, and immutable Terragrunt module references

Validation:
- pre-commit hooks passed during signed commit
- git diff --check against origin/main passed after rebase

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `d792de793f5b13f70cf106d33b0340c0c1c1747e`.

> `IaC/live/aws-ssm-parameters` is intentionally excluded from PR plans because it manages KMS, IAM, and secret declarations that require protected apply credentials. Runtime Kubernetes Secrets are installed by protected CI scripts instead of OpenTofu state.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->





