### PR TITLE
docs: require codex thumbs-up comment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,11 @@ are missing, say that clearly in the PR or final response and use the next best
 specific validation available, such as `talosctl validate`, `kubectl diff`,
 `helm template`, or `kustomize build`.
 
+## Review guidelines
+
+- When acting as the Codex review bot on a pull request, add a top-level PR
+  comment containing exactly `👍`.
+
 ## Documentation standards
 
 - Write for a reader who is technical but may be new to Talos, Kubernetes, or

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,8 @@ specific validation available, such as `talosctl validate`, `kubectl diff`,
 - When acting as the Codex review bot on a pull request, add a top-level PR
   comment containing exactly `👍` only after the pull request is approved and
   no P0 or P1 review alerts exist.
+- This top-level comment is required in addition to any thumbs-up reaction the
+  bot adds to the PR description, review summary, or another PR object.
 - If the pull request is not approved, or any P0 or P1 review alert exists, do
   not add the thumbs-up comment.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,7 +133,10 @@ specific validation available, such as `talosctl validate`, `kubectl diff`,
 ## Review guidelines
 
 - When acting as the Codex review bot on a pull request, add a top-level PR
-  comment containing exactly `👍`.
+  comment containing exactly `👍` only after the pull request is approved and
+  no P0 or P1 review alerts exist.
+- If the pull request is not approved, or any P0 or P1 review alert exists, do
+  not add the thumbs-up comment.
 
 ## Documentation standards
 


### PR DESCRIPTION
## Issue

The repository agent instructions did not include a dedicated, conditional
review-bot behavior for Codex PR reviews. That left the expected PR-level
acknowledgement ambiguous when the bot is asked to review changes.

## Cause and user impact

Without an explicit review guideline, future Codex review bot runs could provide
normal review prose, no acknowledgement, or only a thumbs-up reaction on the PR
description. That makes the bot signal less useful when downstream policy or
humans expect a top-level PR comment.

## Root cause

`AGENTS.md` had sections for repository workflow, documentation standards,
infrastructure conventions, and Kubernetes/Talos conventions, but no `Review
guidelines` section for Codex review bot output. The first version of this PR
made the thumbs-up unconditional, which was too broad.

## Fix

Added a `## Review guidelines` section to `AGENTS.md` instructing the Codex
review bot to add a top-level PR comment containing exactly `👍` only after the
pull request is approved and no P0 or P1 review alerts exist. The section also
explicitly says that this comment is required in addition to any thumbs-up
reaction on the PR description, review summary, or another PR object, and not to
add the thumbs-up comment when approval is missing or a P0/P1 alert exists.

## Validation

- Commit hooks passed on all commits: trailing whitespace, end-of-file fixer,
  large-file check, codespell, Checkov Diff, Checkov Secrets; non-applicable
  YAML/HCL/zizmor hooks were skipped.
- Verified signed commits with `git verify-commit HEAD`.
- Ran focused Markdown whitespace checks with
  `git diff --check HEAD~1 HEAD -- AGENTS.md`.
- Full infrastructure validation was not run because this is a docs-only
  instruction change and the infrastructure graph is untouched.
