### PR TITLE
feat(grafana): alert on stuck Argo CD progressing apps

### DIFF
--- a/clusters/homelab/apps/grafana/README.md
+++ b/clusters/homelab/apps/grafana/README.md
@@ -125,6 +125,7 @@ The first provisioned rules cover:
 - Homelab stateful PVC usage above 85 percent for 15 minutes.
 - Argo CD application metrics missing from Prometheus for 10 minutes.
 - Argo CD Applications not `Healthy` for 10 minutes.
+- Argo CD Applications remaining in `Progressing` for 30 minutes.
 - Argo CD Applications remaining explicitly `OutOfSync` for 30 minutes.
 - GitHub Actions workflow alert rules are deleted from provisioning until the
   GitHub datasource uses authenticated API access.
@@ -137,6 +138,9 @@ The Argo CD application health and sync rules intentionally keep the original
 `argocd_app_info` series labels instead of aggregating them. Grafana sends one
 alert instance per affected application so notifications include the application
 name, namespace, and current Argo CD status for triage.
+The `Progressing` rule is separate from the critical unhealthy rule so normal
+rollouts can complete without noise; it only warns after the application has
+remained in that health state for 30 minutes.
 The notification policy groups on those Argo CD labels as well as the shared
 alert labels so Discord messages keep the affected application dimensions
 visible instead of collapsing them into a folder-level aggregate.
@@ -180,10 +184,9 @@ In Grafana, check that the `Prometheus` datasource is default, the
 `https://api.github.com`, the `Homelab Overview`, `Argo CD Overview`, and
 `GitHub PR Status` dashboards appear under the `Homelab` folder, the imported
 dashboards appear under the `Kubernetes` and `Monitoring` folders, the
-`Entra ID` login path works, and the seven provisioned `homelab-*` alert rules
-are present under Grafana Alerting. Use the Grafana contact point test action
-after the Discord webhook parameter and OpenClaw hook token have been populated
-in SSM.
+`Entra ID` login path works, and the nine provisioned `homelab-*` alert rules
+under Grafana Alerting. Use the Grafana contact point test action after the
+Discord webhook parameter and OpenClaw hook token have been populated in SSM.
 
 ## Rollback
 

--- a/clusters/homelab/apps/grafana/README.md
+++ b/clusters/homelab/apps/grafana/README.md
@@ -185,8 +185,9 @@ In Grafana, check that the `Prometheus` datasource is default, the
 `GitHub PR Status` dashboards appear under the `Homelab` folder, the imported
 dashboards appear under the `Kubernetes` and `Monitoring` folders, the
 `Entra ID` login path works, and the nine provisioned `homelab-*` alert rules
-under Grafana Alerting. Use the Grafana contact point test action after the
-Discord webhook parameter and OpenClaw hook token have been populated in SSM.
+are present under Grafana Alerting. Use the Grafana contact point test action
+after the Discord webhook parameter and OpenClaw hook token have been populated
+in SSM.
 
 ## Rollback
 

--- a/clusters/homelab/apps/grafana/values.yaml
+++ b/clusters/homelab/apps/grafana/values.yaml
@@ -785,6 +785,81 @@ alerting:
             labels:
               severity: critical
               managed_by: grafana-provisioning
+          - uid: homelab-argocd-app-progressing-stuck
+            title: Argo CD application stuck progressing
+            condition: C
+            data:
+              - refId: A
+                datasourceUid: prometheus
+                relativeTimeRange:
+                  from: 600
+                  to: 0
+                model:
+                  datasource:
+                    type: prometheus
+                    uid: prometheus
+                  editorMode: code
+                  expr: argocd_app_info{health_status="Progressing"}
+                  instant: true
+                  intervalMs: 1000
+                  legendFormat: Progressing application
+                  maxDataPoints: 43200
+                  range: false
+                  refId: A
+              - refId: B
+                datasourceUid: __expr__
+                relativeTimeRange:
+                  from: 0
+                  to: 0
+                model:
+                  datasource:
+                    type: __expr__
+                    uid: __expr__
+                  expression: A
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  reducer: last
+                  refId: B
+                  type: reduce
+              - refId: C
+                datasourceUid: __expr__
+                relativeTimeRange:
+                  from: 0
+                  to: 0
+                model:
+                  conditions:
+                    - evaluator:
+                        params:
+                          - 0
+                        type: gt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                          - C
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                  datasource:
+                    type: __expr__
+                    uid: __expr__
+                  expression: B
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  refId: C
+                  type: threshold
+            dashboardUid: argocd-overview
+            panelId: 4
+            noDataState: OK
+            execErrState: Alerting
+            for: 30m
+            annotations:
+              summary: One or more Argo CD Applications have remained Progressing for at least 30 minutes.
+              runbook_url: https://github.com/Stuhlmuller/homelab/blob/main/docs/validation-runbook.md
+            labels:
+              severity: warning
+              managed_by: grafana-provisioning
           - uid: homelab-argocd-app-out-of-sync
             title: Argo CD application out of sync
             condition: C

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -75,6 +75,9 @@ The GitHub dashboard uses unauthenticated public REST API reads against
 `Stuhlmuller/homelab`. GitHub Actions failure and timeout alerts are deleted
 from provisioning until Grafana has a token-backed GitHub API secret contract;
 shared public API rate limits have produced noisy datasource-error pages.
+Argo CD app alerting uses `argocd_app_info`: degraded, missing, and unknown
+health states are critical, while apps that stay `Progressing` for 30 minutes
+warn separately so ordinary rollouts do not page as unhealthy.
 The Infinity plugin is pinned with the Grafana release ZIP syntax in
 `clusters/homelab/apps/grafana/values.yaml`; do not use `plugin@version` because
 Grafana treats it as the plugin ID and fails startup with a plugin-catalog 404.


### PR DESCRIPTION
## Summary

Adds a Grafana-managed warning alert for Argo CD Applications that stay in the `Progressing` health state for at least 30 minutes.

## Issue

Argo CD Applications that are stuck progressing can sit between the existing critical unhealthy rule and the out-of-sync rule. Short `Progressing` periods are expected during normal syncs, but a long-running `Progressing` state usually means a rollout, hook, dependency, or child resource is not converging.

The practical effect is that operators may miss stalled GitOps rollouts until they become degraded, trigger a different Kubernetes alert, or are noticed manually in the Argo CD UI.

## Root Cause

The existing Grafana alert rules covered missing Argo CD metrics, critical non-healthy states such as `Degraded`, `Missing`, and `Unknown`, plus explicit `OutOfSync` applications. They did not model `health_status="Progressing"` as a separate delayed warning state.

## Fix

This change adds `homelab-argocd-app-progressing-stuck`, a Grafana-provisioned rule backed by the existing Prometheus datasource and `argocd_app_info` metric. It preserves the original Argo CD metric labels so alert notifications include the affected application dimensions.

The rule is warning severity and waits 30 minutes before firing. That keeps ordinary syncs quiet while still surfacing applications that remain in `Progressing` long enough to deserve triage.

The Grafana alerting provisioning annotation is bumped so Argo CD rolls Grafana and the file provisioning path reloads the new rule. The Grafana README and knowledge-base application note now document the new alert behavior.

## Validation

- `kubectl kustomize clusters/homelab/apps/grafana`
- `helm template grafana grafana --repo https://grafana.github.io/helm-charts --version 10.5.15 --namespace monitoring --values clusters/homelab/apps/grafana/values.yaml`
- `git diff --check`
- `git diff --cached --check`
- Commit hooks: trailing whitespace, end-of-file fixer, large-file check, YAML check, codespell, Checkov diff, Checkov secrets, and skipped non-applicable OpenTofu/Terragrunt/zizmor checks
- Rendered Helm output was checked for `homelab-argocd-app-progressing-stuck` and `argocd_app_info{health_status="Progressing"}`


<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `d24960c887832bbd15d2ac7d5ec05228f3ff93fd`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->


