### PR TITLE
fix: ignore Compass discovery ingress health

### DIFF
--- a/clusters/homelab/apps/compass/kustomization.yaml
+++ b/clusters/homelab/apps/compass/kustomization.yaml
@@ -4,3 +4,11 @@ resources:
   - authorizationpolicy.yaml
   - ingress-discovery.yaml
   - virtualservice.yaml
+patches:
+  - target:
+      kind: Ingress
+      labelSelector: compass.adinhodovic.com/enabled=true
+    patch: |-
+      - op: add
+        path: /metadata/annotations/argocd.argoproj.io~1ignore-healthcheck
+        value: "true"

--- a/docs/knowledge-base/workloads/inventory.md
+++ b/docs/knowledge-base/workloads/inventory.md
@@ -63,8 +63,11 @@ namespaces. The source of truth is `docs/runtime-isolation.md` plus the
   Funnel traffic and database source-identity validation still need live
   validation after rollout.
 - `monitoring` restricts Grafana, Prometheus, Alertmanager, and
-  kube-state-metrics by service account. Compass allows only the tailnet
-  gateway, Prometheus scraper, and Octelium connector. The Prometheus operator
+  kube-state-metrics by service account. Compass allows only the tailnet gateway,
+  Prometheus scraper, and Octelium connector. Compass also owns
+  discovery-only `Ingress` resources with an inert `compass-discovery` class;
+  those resources intentionally ignore Argo CD health checks because no
+  controller populates their load balancer status. The Prometheus operator
   remains unselected until its webhook/control-plane paths are modeled.
 - `octelium-client` is ambient-enrolled so the connector has a stable workload
   principal when it calls protected `ai`, `automation`, and `monitoring`

--- a/docs/networking-tailnet-ingress.md
+++ b/docs/networking-tailnet-ingress.md
@@ -93,7 +93,11 @@ Compass also owns discovery-only `Ingress` resources in the `monitoring`
 namespace. Those resources use the inert `compass-discovery` IngressClass and
 carry the same hostnames and Compass metadata for catalog discovery, but they
 do not replace the Istio `VirtualService` resources that route traffic through
-`tailnet-gateway`.
+`tailnet-gateway`. They are annotated with
+`argocd.argoproj.io/ignore-healthcheck: "true"` because no ingress controller
+is expected to populate `status.loadBalancer` for the inert class; the
+tailnet-only `VirtualService` and Compass Deployment remain the operational
+health signals.
 
 ## Homelab VPN Exit Node And LAN Route
 


### PR DESCRIPTION
## Summary

Compass was stuck `Progressing` in Argo CD even though its sync operation had succeeded and the workload was serving normally. Live inspection showed the `compass` Application was `Synced`, its last operation had `phase: Succeeded`, and the `monitoring/compass` Deployment had one ready replica with healthy rollout conditions.

The misleading health state came from the discovery-only `Ingress` objects Compass uses as catalog metadata. Those resources are intentionally assigned to the inert `compass-discovery` IngressClass, so no ingress controller should ever populate `status.loadBalancer`. Argo CD still includes Kubernetes Ingress health in the Application aggregate, which leaves the app in `Progressing` forever even though the real route is the tailnet-only Istio `VirtualService`.

This PR adds a Kustomize patch that annotates only Compass discovery Ingresses with `argocd.argoproj.io/ignore-healthcheck: "true"`. The operational health signals remain the Compass Deployment, Service, ServiceMonitor, AuthorizationPolicy, and tailnet `VirtualService`; the catalog-only Ingress objects stay available for Compass discovery without poisoning Argo CD health.

Docs and the knowledge-base inventory were updated to record why the discovery Ingresses intentionally do not receive load balancer status.

## Validation

- `kubectl get application compass -n argocd -o yaml` showed `status.sync.status: Synced`, the latest sync `phase: Succeeded`, and app health stuck at `Progressing`.
- `kubectl get pods -n monitoring -l app.kubernetes.io/name=compass -o wide` showed the Compass pod `1/1 Running`.
- `kubectl get deployment compass -n monitoring -o yaml` showed `availableReplicas: 1`, `readyReplicas: 1`, and successful rollout conditions.
- `kubectl get ingress -n monitoring -o wide` showed all `compass-discovery-*` Ingresses with empty `ADDRESS`, as expected for the inert class.
- `kubectl get ingress compass-discovery-argocd -n monitoring -o yaml` confirmed `status.loadBalancer: {}`.
- `kubectl kustomize clusters/homelab/apps/compass` rendered the new health-ignore annotation onto the discovery Ingresses.
- `kubectl diff -k clusters/homelab/apps/compass` showed only the new annotation on the 13 discovery Ingresses.
- `bash scripts/ci/static-checks.sh` passed. `nix run .#validate` could not be run because `nix` is not installed in this local shell.
- `bash scripts/ci/conftest-policies.sh` passed with 2620 tests.


<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `b8ef2de27055bd6a11599408fc91f151c7ce662d`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->






