### PR TITLE
fix: repair octelium argocd rollout

### DIFF
--- a/clusters/homelab/apps/octelium/README.md
+++ b/clusters/homelab/apps/octelium/README.md
@@ -72,15 +72,21 @@ Current desired Enterprise package version:
 0.22.0
 ```
 
+The Octelium Cluster domain is `stinkyboi.com`, so the client talks to
+`octelium-api.stinkyboi.com`, which is covered by the current `*.stinkyboi.com`
+certificate. A nested domain such as `octelium.stinkyboi.com` would make the
+client use `octelium-api.octelium.stinkyboi.com` and would require a matching
+`*.octelium.stinkyboi.com` certificate.
+
 Install or upgrade it with the repo-owned wrapper:
 
 ```sh
 scripts/octelium-enterprise-package.sh \
-  --domain octelium.stinkyboi.com \
+  --domain stinkyboi.com \
   --version 0.22.0
 
 scripts/octelium-enterprise-package.sh \
-  --domain octelium.stinkyboi.com \
+  --domain stinkyboi.com \
   --version 0.22.0 \
   --upgrade
 ```
@@ -112,7 +118,7 @@ kubectl -n octelium-client logs deploy/octelium-client
 From an Octelium client session, query one of the private service names:
 
 ```sh
-octelium connect --domain octelium.stinkyboi.com -p grafana.homelab:18080
+octelium connect --domain stinkyboi.com -p grafana.homelab:18080
 curl http://127.0.0.1:18080/api/health
 ```
 
@@ -120,7 +126,7 @@ Use the smoke-test service when you want to validate the bridge separately from
 app-specific auth:
 
 ```sh
-octelium connect --domain octelium.stinkyboi.com -p homelab-demo.homelab:18081
+octelium connect --domain stinkyboi.com -p homelab-demo.homelab:18081
 curl http://127.0.0.1:18081/version
 ```
 

--- a/clusters/homelab/apps/octelium/demo.yaml
+++ b/clusters/homelab/apps/octelium/demo.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: octelium-demo
   namespace: octelium-client
+  annotations:
+    checkov.io/skip1: CKV2_K8S_6=octelium-demo is covered by networkpolicy.yaml; diff-only scans do not include sibling manifests.
   labels:
     app.kubernetes.io/name: octelium-demo
     app.kubernetes.io/instance: octelium-demo
@@ -27,6 +29,8 @@ spec:
       containers:
         - name: podinfo
           image: ghcr.io/stefanprodan/podinfo:6.9.3@sha256:0c73d438b0fe28c1d52bac0d6aafa04efe2023910378c4b436e234f56b6e9b99
+          command:
+            - /podinfo
           args:
             - --port=9898
           ports:

--- a/clusters/homelab/apps/octelium/values.yaml
+++ b/clusters/homelab/apps/octelium/values.yaml
@@ -38,7 +38,7 @@ resources:
     memory: 256Mi
 
 octelium:
-  domain: octelium.stinkyboi.com
+  domain: stinkyboi.com
   # checkov:skip=CKV_SECRET_6: Kubernetes Secret name, not a secret value.
   authTokenSecret: octelium-client-auth
   # checkov:skip=CKV_SECRET_6: Kubernetes Secret key name, not a secret value.

--- a/docs/knowledge-base/runbooks/octelium.md
+++ b/docs/knowledge-base/runbooks/octelium.md
@@ -37,15 +37,20 @@ state and it does not replace the `octelium-client` connector in this homelab.
 
 Current desired package version: `0.22.0`.
 
+The Octelium Cluster domain is `stinkyboi.com`, which makes the client contact
+`octelium-api.stinkyboi.com`. The current cluster certificate is
+`*.stinkyboi.com`, so `octelium.stinkyboi.com` is too deep as a client domain
+unless a future certificate also covers `*.octelium.stinkyboi.com`.
+
 Install or upgrade with:
 
 ```sh
 scripts/octelium-enterprise-package.sh \
-  --domain octelium.stinkyboi.com \
+  --domain stinkyboi.com \
   --version 0.22.0
 
 scripts/octelium-enterprise-package.sh \
-  --domain octelium.stinkyboi.com \
+  --domain stinkyboi.com \
   --version 0.22.0 \
   --upgrade
 ```
@@ -100,3 +105,13 @@ connector Deployment in `octelium-client`. Stop the connector by returning
 Rollback for the Enterprise package is an Octelium package operation, not an
 Argo CD sync. Update the desired package version in this runbook first, then
 run the wrapper with the intended `--version` and `--upgrade` flags.
+
+## Failure Notes
+
+If Argo CD is `Synced` but `Degraded`, inspect the child pods and events before
+changing the Application. On June 6, 2026 the first rollout degraded because the
+Podinfo demo had only `args: [--port=9898]`, which made containerd try to
+execute the flag as the binary, and because the connector domain was
+`octelium.stinkyboi.com`, which made the client call
+`octelium-api.octelium.stinkyboi.com` with a certificate that only covered
+`*.stinkyboi.com`.

--- a/docs/octelium.md
+++ b/docs/octelium.md
@@ -97,11 +97,17 @@ The upstream Enterprise README requires `octops` `v0.29.0` or later and an
 existing Octelium Cluster. Commercial or production use requires an Enterprise
 license; license material must stay outside git.
 
+The configured Octelium Cluster domain is `stinkyboi.com`, which makes the
+client use `octelium-api.stinkyboi.com`. That hostname is covered by the
+current `*.stinkyboi.com` certificate. Do not set the client domain to
+`octelium.stinkyboi.com` unless the Octelium Cluster presents a certificate for
+`*.octelium.stinkyboi.com`.
+
 Install the pinned package:
 
 ```sh
 scripts/octelium-enterprise-package.sh \
-  --domain octelium.stinkyboi.com \
+  --domain stinkyboi.com \
   --version 0.22.0
 ```
 
@@ -110,7 +116,7 @@ updated to the intended package version:
 
 ```sh
 scripts/octelium-enterprise-package.sh \
-  --domain octelium.stinkyboi.com \
+  --domain stinkyboi.com \
   --version 0.22.0 \
   --upgrade
 ```
@@ -166,7 +172,7 @@ curl http://127.0.0.1:8080/version
 Check a service through Octelium from a client machine:
 
 ```sh
-octelium connect --domain octelium.stinkyboi.com -p grafana.homelab:18080
+octelium connect --domain stinkyboi.com -p grafana.homelab:18080
 curl http://127.0.0.1:18080/api/health
 ```
 

--- a/scripts/octelium-enterprise-package.sh
+++ b/scripts/octelium-enterprise-package.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DEFAULT_DOMAIN="octelium.stinkyboi.com"
+DEFAULT_DOMAIN="stinkyboi.com"
 DEFAULT_VERSION="0.22.0"
 PACKAGE="octeliumee"
 
@@ -13,7 +13,7 @@ Install or upgrade the Octelium Enterprise package in an already running
 Octelium Cluster.
 
 Options:
-  --domain DOMAIN       Octelium Cluster domain. Default: octelium.stinkyboi.com
+  --domain DOMAIN       Octelium Cluster domain. Default: stinkyboi.com
   --version VERSION     Package version to install. Default: 0.22.0
                         Use "latest" to omit --version.
   --upgrade             Upgrade an existing enterprise package installation.


### PR DESCRIPTION
## Issue

The live `octelium` Argo CD Application was `Synced` but `Degraded` after the Enterprise/client bridge rollout. Read-only inspection showed both pods in `octelium-client` were crash-looping.

## Live Evidence

`kubectl -n argocd get application octelium -o yaml` showed the Application had synced successfully to `main` but health transitioned from `Progressing` to `Degraded`.

`kubectl -n octelium-client get all,externalsecret,secret -o wide` showed:

- `pod/octelium-client-75ff464bb4-f7w2z` in `CrashLoopBackOff`
- `pod/octelium-demo-69d6bf9dc8-h5wm7` in `CrashLoopBackOff`
- `externalsecret/octelium-client-auth` was `SecretSynced=True`, so the first failure was not External Secrets.

The namespace events showed the demo container failed with:

```text
exec: "--port=9898": executable file not found in $PATH
```

The Octelium client logs showed:

```text
tls: failed to verify certificate: x509: certificate is valid for *.stinkyboi.com, not octelium-api.octelium.stinkyboi.com
```

Verbose HTTPS probes confirmed that `octelium-api.stinkyboi.com` verifies against the current `*.stinkyboi.com` certificate, while `octelium-api.octelium.stinkyboi.com` does not.

## Root Cause

The Podinfo demo manifest only set `args: [--port=9898]`. That image needs an explicit command, otherwise containerd tries to execute the first argument as the binary.

The Octelium client domain was set to `octelium.stinkyboi.com`. Octelium derives the API endpoint as `octelium-api.<domain>`, so that setting made the client call `octelium-api.octelium.stinkyboi.com`. The current certificate only covers one label under `stinkyboi.com`.

## Fix

- Add `command: /podinfo` to the demo Deployment.
- Change the Octelium Cluster domain to `stinkyboi.com`, making the client call `octelium-api.stinkyboi.com`.
- Update the Enterprise package wrapper default and docs to use `stinkyboi.com`.
- Add a knowledge-base failure note for the exact Argo `Synced` but `Degraded` symptoms.
- Add a diff-only Checkov skip annotation to the demo Deployment pointing at the sibling NetworkPolicy that covers it.

## Validation

- `kubectl kustomize clusters/homelab/apps/octelium`
- `helm template octelium-client oci://ghcr.io/octelium/helm-charts/octelium --version 0.3.0 --namespace octelium-client -f clusters/homelab/apps/octelium/values.yaml`
- `bash -n scripts/octelium-enterprise-package.sh`
- `scripts/octelium-enterprise-package.sh --help`
- `git diff --check`
- `bash scripts/ci/static-checks.sh`
- commit hooks, including Checkov Diff and Checkov Secrets

`nix run .#validate` was not available in this shell because `nix` is not installed. `bash scripts/ci/static-checks.sh` passed; Checkov still emitted offline guideline lookup warnings for `api0.prismacloud.io`, but local Terraform, Kubernetes, and secrets scans reported zero failures.


<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `ab15cda5597d20669e45947bfa9ce2009601b1f1`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
