### PR TITLE
ci: add lint PR check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,26 @@
+---
+name: Lint
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+permissions: {}
+jobs:
+  build:
+    name: Lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+      statuses: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          # Super-Linter needs the full git history to find changed files.
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Super-linter
+        uses: super-linter/super-linter@9e863354e3ff62e0727d37183162c4a88873df41  # v8.6.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DISABLE_ERRORS: true
+          VALIDATE_ALL_CODEBASE: false

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -2,6 +2,10 @@
 
 This repository uses GitHub Actions for the review and rollout path:
 
+- `Lint` runs on pull requests and invokes Super-Linter against changed files
+  with advisory status reporting. It is the shared lightweight lint signal for
+  every PR; the repository-specific blocking checks remain in `Terragrunt Plan`
+  and `validate`.
 - `Terragrunt Plan` runs on pull requests. It always runs static checks and
   Checkov first. Trusted same-repository pull requests then connect to the
   tailnet, run a live Terragrunt plan, and run Conftest policies after the plan
@@ -35,6 +39,11 @@ contract for Grafana.
 
 - Workflows use `pull_request` and `push`; they do not use
   `pull_request_target`.
+- The lint workflow is copied from the shared `Stuhlmuller/workflows`
+  Super-Linter PR check and keeps its external actions pinned to full commit
+  SHAs. It sets `DISABLE_ERRORS=true`, so lint findings are surfaced as PR
+  status context without replacing the repository's stricter static and
+  Terragrunt gates.
 - Policy Bot reads this repository's `.policy.yml` and requires every pull
   request commit to have a GitHub-verified signature before normal review
   approval can satisfy the `policy-bot: main` branch protection check. The
@@ -274,10 +283,15 @@ credentials so identity drift is not silently ignored.
 Run the same checks locally through the Nix shell:
 
 ```sh
+nix develop --command pre-commit run --all-files
 nix develop --command bash scripts/ci/static-checks.sh
 nix develop --command bash scripts/ci/terragrunt-plan.sh
 nix develop --command bash scripts/ci/conftest-policies.sh
 ```
+
+The local pre-commit run is the closest repository-owned equivalent to the
+Super-Linter PR check; GitHub Actions remains the source for the exact
+Super-Linter status contexts.
 
 The PR plan script intentionally skips the privileged SSM declaration and
 Kubernetes secret materialization stacks. To review those locally, assume the

--- a/docs/knowledge-base/runbooks/ci-cd.md
+++ b/docs/knowledge-base/runbooks/ci-cd.md
@@ -6,6 +6,9 @@ Source: `docs/ci-cd.md`
 
 ## Pipeline Shape
 
+- `Lint` runs on pull requests with Super-Linter against changed files. It is an
+  advisory shared lint signal; repository-specific blocking checks stay in
+  `Terragrunt Plan` and `validate`.
 - `Terragrunt Plan` runs on pull requests. It always runs static checks and
   Checkov first. Trusted same-repo PRs can join the tailnet, run a live
   Terragrunt plan, validate the rendered Terraform plan JSON with Conftest,
@@ -21,6 +24,10 @@ Source: `docs/ci-cd.md`
 ## Security Model
 
 - Workflows use `pull_request` and `push`, not `pull_request_target`.
+- The lint workflow mirrors the shared `Stuhlmuller/workflows` Super-Linter PR
+  check, keeps external actions pinned to full commit SHAs, and sets
+  `DISABLE_ERRORS=true` so findings are surfaced without replacing the stricter
+  static and Terragrunt gates.
 - Policy Bot reads this repository's `.policy.yml` and requires every PR commit
   to have a GitHub-verified signature before normal review approval can satisfy
   the `policy-bot: main` branch protection check. The review-bot path accepts
@@ -119,11 +126,15 @@ against `127.0.0.53`. Keep CI grants limited to TCP `6443` on the API host.
 ## Local Equivalents
 
 ```sh
+nix develop --command pre-commit run --all-files
 nix develop --command bash scripts/ci/static-checks.sh
 nix develop --command bash scripts/ci/terragrunt-plan.sh
 nix develop --command bash scripts/ci/conftest-policies.sh
 nix develop --command bash scripts/ci/terragrunt-apply.sh
 ```
+
+The pre-commit run is the closest local equivalent to the Super-Linter PR
+check. GitHub Actions remains the source for the exact lint status contexts.
 
 Local runs use the current `main` ref for Terragrunt's affected-unit
 comparison. Refresh `main` before reproducing a GitHub plan or apply diff.


### PR DESCRIPTION
## Summary

This adds the shared Super-Linter pull request check to the homelab repository so every PR gets a lightweight lint status alongside the existing infrastructure checks.

## Issue

The repository already has strong blocking validation through Terragrunt, Conftest, Checkov, Kustomize rendering, and the `validate` workflow, but it did not have the shared `Lint` PR status used by the reusable workflows project. That made homelab PRs less consistent with the rest of the workflow surface and left common lint feedback to local pre-commit or broader static gates.

## Root Cause

The shared workflow library contains `.github/workflows/lint.yml`, but homelab did not have an equivalent local PR workflow. Because that shared lint workflow is a normal `pull_request` workflow rather than a reusable `workflow_call`, homelab needs its own checked-in workflow file instead of a `uses:` caller.

## Fix

- Add `.github/workflows/lint.yml` with the current pinned Super-Linter setup from `Stuhlmuller/workflows`.
- Keep external actions pinned to full commit SHAs so the existing workflow Conftest policy continues to apply.
- Preserve `permissions: {}` at the workflow level and grant only the job permissions Super-Linter needs for checkout and status reporting.
- Document the new lint signal in `docs/ci-cd.md` and the Obsidian knowledge-base mirror under `docs/knowledge-base/runbooks/ci-cd.md`.

The lint workflow keeps `DISABLE_ERRORS=true`, so it surfaces lint findings as PR status context without replacing the stricter repository-specific static and Terragrunt gates.

## Validation

- `yamllint .github/workflows/lint.yml`
- `pre-commit run --files .github/workflows/lint.yml docs/ci-cd.md docs/knowledge-base/runbooks/ci-cd.md`
- `bash scripts/ci/static-checks.sh`
- `bash scripts/ci/conftest-policies.sh`

`nix develop --command bash scripts/ci/static-checks.sh` was unavailable in this shell because `nix` is not installed, so the repo script was run directly with the available local tools. Checkov printed offline guideline-fetch warnings but completed with zero failed checks.


<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `1b419814f8c51315a7127b4f59720e96726288b3`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
