### PR TITLE
fix: allow policy-bot author approvals

### DIFF
--- a/.policy.yml
+++ b/.policy.yml
@@ -21,9 +21,11 @@ approval_rules:
   - name: rstuhlmuller thumbs-up comment approved
     description: >-
       Count only an explicit thumbs-up comment from rstuhlmuller; this approval
-      path is valid for PRs opened by rodman and PR body text does not satisfy
-      this rule.
+      path is valid when rstuhlmuller opened or contributed to the PR, including
+      PRs opened by rodman, and PR body text does not satisfy this rule.
     options:
+      allow_author: true
+      allow_contributor: true
       methods:
         comments: []
         comment_patterns:
@@ -36,6 +38,9 @@ approval_rules:
       users:
         - "rstuhlmuller"
   - name: organization member approved
+    options:
+      allow_author: true
+      allow_contributor: true
     requires:
       count: 1
       organizations:

--- a/clusters/homelab/apps/policy-bot/README.md
+++ b/clusters/homelab/apps/policy-bot/README.md
@@ -14,8 +14,10 @@ Policy Bot looks for a repository-local `.policy.yml` first and falls back to
 `policy.yml` in the shared `.github` repository. The homelab policy requires
 GitHub-verified commit signatures in addition to the normal review approval
 rules. The explicit comment path accepts a `👍` comment from `rstuhlmuller`,
-including PRs opened by `rodman`; PR body text and other users' comments do not
-count for that rule.
+including PRs opened by `rodman` and PRs where `rstuhlmuller` authored or
+committed changes; PR body text and other users' comments do not count for that
+rule. The organization-member approval rule also allows author and contributor
+approvals so matching Stuhlmuller approvals are not ignored as disqualified.
 
 ## Routes
 

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -39,8 +39,10 @@ contract for Grafana.
   request commit to have a GitHub-verified signature before normal review
   approval can satisfy the `policy-bot: main` branch protection check. The
   explicit comment path accepts only a `👍` comment from `rstuhlmuller`,
-  including PRs opened by `rodman`; it does not read PR body text or other
-  users' comments.
+  including PRs opened by `rodman` and PRs where `rstuhlmuller` authored or
+  committed changes; it does not read PR body text or other users' comments.
+  The organization-member approval rule also opts into author and contributor
+  approvals so matching Stuhlmuller approvals are not ignored as disqualified.
 - External GitHub Actions are pinned to full commit SHAs and checked by
   Conftest.
 - The Terragrunt plan and apply workflows restore and save a GitHub Actions

--- a/docs/knowledge-base/runbooks/ci-cd.md
+++ b/docs/knowledge-base/runbooks/ci-cd.md
@@ -25,7 +25,10 @@ Source: `docs/ci-cd.md`
   to have a GitHub-verified signature before normal review approval can satisfy
   the `policy-bot: main` branch protection check. The explicit comment path
   accepts only a `👍` comment from `rstuhlmuller`, including PRs opened by
-  `rodman`; it does not read PR body text or other users' comments.
+  `rodman` and PRs where `rstuhlmuller` authored or committed changes; it does
+  not read PR body text or other users' comments. The organization-member rule
+  also opts into author and contributor approvals so matching Stuhlmuller
+  approvals are not ignored as disqualified.
 - External actions are pinned to full commit SHAs and checked by Conftest.
 - Terragrunt plan and apply jobs restore and save a GitHub Actions cache for the
   Nix store after installing Nix. The cache key is derived from the runner OS,

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -281,7 +281,10 @@ back to shared `.github/policy.yml`. Homelab's local policy keeps the shared
 review approval choices and adds a Policy Bot condition requiring every PR
 commit to have a GitHub-verified signature. The explicit comment approval path
 counts only a `👍` comment from `rstuhlmuller`, including PRs opened by
-`rodman`, and does not count PR body text or other users' comments.
+`rodman` and PRs where `rstuhlmuller` authored or committed changes, and does
+not count PR body text or other users' comments. The organization-member rule
+also opts into author and contributor approvals so matching Stuhlmuller
+approvals are not ignored as disqualified.
 
 ## Prometheus
 


### PR DESCRIPTION
## Summary

This follow-up updates the homelab repository-local Policy Bot approval rules
so author and contributor approvals are counted when they otherwise match the
configured approval source.

## Issue

Policy Bot can report `Ignored 1 approval from disqualified users` when an
approval comes from the pull request author or from someone who contributed to
the pull request. That blocked the intended approval path for `rstuhlmuller`
even when the approval signal itself matched the policy.

## Root Cause

Policy Bot defaults `allow_author` and `allow_contributor` to `false` at the
approval-rule level. The earlier homelab policy change moved the explicit
thumbs-up approval path to `rstuhlmuller`, but the rule still inherited the
default author/contributor disqualification behavior from Policy Bot. The
normal organization-member approval rule had the same default.

## Fix

The `rstuhlmuller thumbs-up comment approved` rule now sets both
`allow_author: true` and `allow_contributor: true`, so a matching `👍` comment
from `rstuhlmuller` counts even when `rstuhlmuller` opened the PR or contributed
commits.

The `organization member approved` rule now also sets both options to `true`,
so matching Stuhlmuller organization approvals are not discarded solely because
the approver authored or contributed to the PR.

The Policy Bot workload README, CI/CD runbook, and knowledge-base notes were
updated to document the author/contributor behavior.

## Validation

- `git diff --check`
  passed.
- `curl -sS --fail-with-body https://policy-bot.stinkyboi.com/api/validate -T .policy.yml`
  returned `{"message":"Policy file is valid","version":"1.41.1"}`.
- Pre-commit hooks during commit passed: trailing whitespace, end-of-file,
  large-file check, YAML, OpenTofu fmt, Terragrunt HCL fmt, codespell, Checkov
  diff, Checkov secrets, and zizmor.
- `git log -1 --show-signature --format=fuller`
  reported a good signature for `Rodman Stuhlmuller <rodman@stuhlmuller.net>`.


<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `d60d8be5ee4fe47a1d417baef2d2e7b53e8f6d9e`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
