### PR TITLE
fix: repair OpenClaw hook token bootstrap

### DIFF
--- a/clusters/homelab/apps/openclaw/README.md
+++ b/clusters/homelab/apps/openclaw/README.md
@@ -135,6 +135,11 @@ AuthorizationPolicy allows the
 `cluster.local/ns/monitoring/sa/prometheus-kube-prometheus-alertmanager`
 principal through the ambient default deny.
 
+OpenClaw rejects SecretRef objects for `hooks.token`, so bootstrap writes the
+plain env-template string `"${GRAFANA_ALERT_HOOK_TOKEN}"` instead of using
+`--ref-source env`. This keeps the token out of git while satisfying
+OpenClaw's hook-token policy.
+
 After rotating the hook token, bump both
 `homelab.rst.io/openclaw-alert-hook-ssm-version` on the Prometheus-owned
 ExternalSecret and Alertmanager pod metadata, plus

--- a/clusters/homelab/apps/openclaw/README.md
+++ b/clusters/homelab/apps/openclaw/README.md
@@ -135,10 +135,11 @@ AuthorizationPolicy allows the
 `cluster.local/ns/monitoring/sa/prometheus-kube-prometheus-alertmanager`
 principal through the ambient default deny.
 
-OpenClaw rejects SecretRef objects for `hooks.token`, so bootstrap writes the
-plain env-template string `"${GRAFANA_ALERT_HOOK_TOKEN}"` instead of using
-`--ref-source env`. This keeps the token out of git while satisfying
-OpenClaw's hook-token policy.
+OpenClaw rejects SecretRef objects for `hooks.token`, so bootstrap expands
+`GRAFANA_ALERT_HOOK_TOKEN` from the mounted Secret at pod startup, JSON-encodes
+the actual runtime value, and writes that plain string to the PVC-backed
+OpenClaw config. This keeps the token out of git while satisfying OpenClaw's
+hook-token policy.
 
 After rotating the hook token, bump both
 `homelab.rst.io/openclaw-alert-hook-ssm-version` on the Prometheus-owned

--- a/clusters/homelab/apps/openclaw/values.yaml
+++ b/clusters/homelab/apps/openclaw/values.yaml
@@ -153,9 +153,10 @@ controllers:
               openclaw config set --strict-json \
                 hooks.path \
                 '"/hooks"'
+              HOOK_TOKEN_JSON="$(python3 -c 'import json, os; print(json.dumps(os.environ["GRAFANA_ALERT_HOOK_TOKEN"]))')"
               openclaw config set --strict-json \
                 hooks.token \
-                '"${GRAFANA_ALERT_HOOK_TOKEN}"'
+                "$HOOK_TOKEN_JSON"
               openclaw config set --strict-json \
                 hooks.defaultSessionKey \
                 '"agent:main:hooks:grafana-alerts"'

--- a/clusters/homelab/apps/openclaw/values.yaml
+++ b/clusters/homelab/apps/openclaw/values.yaml
@@ -153,11 +153,9 @@ controllers:
               openclaw config set --strict-json \
                 hooks.path \
                 '"/hooks"'
-              openclaw config set \
+              openclaw config set --strict-json \
                 hooks.token \
-                --ref-provider default \
-                --ref-source env \
-                --ref-id GRAFANA_ALERT_HOOK_TOKEN
+                '"${GRAFANA_ALERT_HOOK_TOKEN}"'
               openclaw config set --strict-json \
                 hooks.defaultSessionKey \
                 '"agent:main:hooks:grafana-alerts"'

--- a/docs/knowledge-base/architecture/secrets-and-identity.md
+++ b/docs/knowledge-base/architecture/secrets-and-identity.md
@@ -57,9 +57,11 @@ roles need identity-based KMS permissions for both keys.
   in-cluster Alertmanager contact point, Alertmanager fans out with file-backed
   credentials, and Grafana provisioning deletes the retired `homelab-discord`
   and `homelab-openclaw-alert-hook` receiver UIDs so persisted Grafana PVC state
-  does not keep retrying removed integrations. OpenClaw reads the same hook
-  token through `openclaw-secrets` as an env-backed SecretRef for
-  `/hooks/agent`.
+  does not keep retrying removed integrations. OpenClaw receives the same hook
+  token through `openclaw-secrets` as `GRAFANA_ALERT_HOOK_TOKEN`; bootstrap
+  writes `hooks.token` as the plain env-template string
+  `"${GRAFANA_ALERT_HOOK_TOKEN}"` because OpenClaw rejects SecretRef objects for
+  that hook-token surface.
 - Tailscale operator OAuth uses the `tailscale-oauth` ExternalSecret and the
   target Secret `operator-oauth`.
 - Octelium client bridge auth uses the `octelium-client-auth` ExternalSecret in

--- a/docs/knowledge-base/architecture/secrets-and-identity.md
+++ b/docs/knowledge-base/architecture/secrets-and-identity.md
@@ -59,9 +59,8 @@ roles need identity-based KMS permissions for both keys.
   and `homelab-openclaw-alert-hook` receiver UIDs so persisted Grafana PVC state
   does not keep retrying removed integrations. OpenClaw receives the same hook
   token through `openclaw-secrets` as `GRAFANA_ALERT_HOOK_TOKEN`; bootstrap
-  writes `hooks.token` as the plain env-template string
-  `"${GRAFANA_ALERT_HOOK_TOKEN}"` because OpenClaw rejects SecretRef objects for
-  that hook-token surface.
+  expands and JSON-encodes that runtime value before writing `hooks.token`,
+  because OpenClaw rejects SecretRef objects for that hook-token surface.
 - Tailscale operator OAuth uses the `tailscale-oauth` ExternalSecret and the
   target Secret `operator-oauth`.
 - Octelium client bridge auth uses the `octelium-client-auth` ExternalSecret in

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -166,9 +166,9 @@ keeps the tailnet Control UI origin allow-list in config and stores
 `gateway.auth.token` as an environment-backed SecretRef to
 `OPENCLAW_GATEWAY_TOKEN`, sourced from the generated
 `/homelab/openclaw/app-secret` SSM parameter. When the shared Grafana alert
-hook token is populated, bootstrap stores `hooks.token` as the plain
-env-template string `"${GRAFANA_ALERT_HOOK_TOKEN}"` because OpenClaw rejects
-SecretRef objects for that hook-token surface. When
+hook token is populated, bootstrap expands `GRAFANA_ALERT_HOOK_TOKEN` from the
+mounted Secret, JSON-encodes the runtime value, and stores it as a plain string
+because OpenClaw rejects SecretRef objects for that hook-token surface. When
 `/homelab/openclaw/discord-bot-token` has been replaced in SSM, bootstrap
 installs and enables the official `@openclaw/discord` plugin and writes a
 SecretRef to `DISCORD_BOT_TOKEN`. The plugin npm cache and extension directory

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -166,9 +166,9 @@ keeps the tailnet Control UI origin allow-list in config and stores
 `gateway.auth.token` as an environment-backed SecretRef to
 `OPENCLAW_GATEWAY_TOKEN`, sourced from the generated
 `/homelab/openclaw/app-secret` SSM parameter. When the shared Grafana alert
-hook token is populated, bootstrap stores `hooks.token` as an environment-backed
-SecretRef to `GRAFANA_ALERT_HOOK_TOKEN` instead of copying the secret into PVC
-config. When
+hook token is populated, bootstrap stores `hooks.token` as the plain
+env-template string `"${GRAFANA_ALERT_HOOK_TOKEN}"` because OpenClaw rejects
+SecretRef objects for that hook-token surface. When
 `/homelab/openclaw/discord-bot-token` has been replaced in SSM, bootstrap
 installs and enables the official `@openclaw/discord` plugin and writes a
 SecretRef to `DISCORD_BOT_TOKEN`. The plugin npm cache and extension directory


### PR DESCRIPTION
## Summary
- Fix OpenClaw bootstrap so hooks.token is written as the plain env-template string OpenClaw accepts.
- Document that hooks.token rejects SecretRef objects, while the token still comes from External Secrets as GRAFANA_ALERT_HOOK_TOKEN.
- Update the homelab knowledge base notes for the OpenClaw secret contract.

## Incident Evidence
- Live Argo CD Application openclaw is Synced but Degraded.
- Pod ai/openclaw-5899d96d5c-rg44g is stuck in Init:CrashLoopBackOff.
- bootstrap-config logs fail with: unsupported SecretRef usage was detected at hooks.token.

## Validation
- git diff --check
- kubectl kustomize clusters/homelab/apps/openclaw
- terragrunt hcl fmt --check
- terragrunt hcl validate
- helm template openclaw app-template --repo https://bjw-s-labs.github.io/helm-charts --version 4.4.0 -f clusters/homelab/apps/openclaw/values.yaml

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `45917e8f59fe4035d2882c91ac8adb210aaf8488`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->

