### PR TITLE
fix: remove redundant octelium certificate SAN

### DIFF
--- a/clusters/homelab/apps/istio/certificate.yaml
+++ b/clusters/homelab/apps/istio/certificate.yaml
@@ -11,7 +11,6 @@ spec:
     rotationPolicy: Always
   dnsNames:
     - "*.stinkyboi.com"
-    - octelium.stinkyboi.com
     - "*.octelium.stinkyboi.com"
   issuerRef:
     group: cert-manager.io

--- a/clusters/homelab/apps/octelium/README.md
+++ b/clusters/homelab/apps/octelium/README.md
@@ -66,9 +66,10 @@ configured Octelium Service from inside the homelab cluster.
 
 Use `octelium.stinkyboi.com` as the Octelium Cluster domain. With this nested
 domain, clients call `octelium-api.octelium.stinkyboi.com`, and the browser
-portal may use `portal.octelium.stinkyboi.com`. The Istio certificate requests
-both `octelium.stinkyboi.com` and `*.octelium.stinkyboi.com`; a one-level
-`*.stinkyboi.com` wildcard does not cover the API hostname.
+portal may use `portal.octelium.stinkyboi.com`. The existing Istio
+`*.stinkyboi.com` certificate covers `octelium.stinkyboi.com`; it also requests
+`*.octelium.stinkyboi.com` because the one-level wildcard does not cover the API
+hostname.
 
 Before DNS or VPN access reaches the Octelium Cluster ingress, bootstrap
 through a local port-forward:
@@ -112,8 +113,8 @@ Current desired Enterprise package version:
 ```
 
 The Octelium Cluster domain is `octelium.stinkyboi.com`, so the client talks to
-`octelium-api.octelium.stinkyboi.com`. Keep certificates valid for both
-`octelium.stinkyboi.com` and `*.octelium.stinkyboi.com`.
+`octelium-api.octelium.stinkyboi.com`. Keep certificates valid for the existing
+`*.stinkyboi.com` wildcard plus `*.octelium.stinkyboi.com`.
 
 Install or upgrade it with the repo-owned wrapper:
 

--- a/docs/knowledge-base/runbooks/octelium.md
+++ b/docs/knowledge-base/runbooks/octelium.md
@@ -40,8 +40,9 @@ Current desired package version: `0.22.0`.
 
 The Octelium Cluster domain is `octelium.stinkyboi.com`, which makes the client
 contact `octelium-api.octelium.stinkyboi.com`. The Istio wildcard certificate
-requests both `octelium.stinkyboi.com` and `*.octelium.stinkyboi.com`; the
-one-level `*.stinkyboi.com` wildcard alone is not enough for the API hostname.
+uses `*.stinkyboi.com` for the Cluster domain and also requests
+`*.octelium.stinkyboi.com`; the one-level wildcard alone is not enough for the
+API hostname.
 
 Install or upgrade with:
 

--- a/docs/knowledge-base/runbooks/tailnet-ingress.md
+++ b/docs/knowledge-base/runbooks/tailnet-ingress.md
@@ -41,9 +41,9 @@ and does not replace the Tailscale exit node.
 Istio terminates HTTPS with `stinkyboi-com-tls` in `istio-system`.
 cert-manager requests the wildcard certificate through
 `letsencrypt-cloudflare`, backed by the `cloudflare-api-token` Secret from
-External Secrets. The certificate also includes `octelium.stinkyboi.com` and
-`*.octelium.stinkyboi.com` for the nested Octelium Cluster domain and bootstrap
-API/portal names.
+External Secrets. The certificate also includes `*.octelium.stinkyboi.com` for
+the nested Octelium API/portal bootstrap names; the existing `*.stinkyboi.com`
+SAN already covers the `octelium.stinkyboi.com` Cluster domain.
 
 ## Homelab Exit Node
 

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -131,7 +131,8 @@ desired version `0.22.0`; install or upgrade it against the external Octelium
 Cluster with `scripts/octelium-enterprise-package.sh`. The Octelium Cluster
 domain is `octelium.stinkyboi.com`, so clients contact
 `octelium-api.octelium.stinkyboi.com`; certificate and bootstrap routing must
-cover both the apex Octelium host and `*.octelium.stinkyboi.com`.
+keep the Cluster domain covered by `*.stinkyboi.com` and the API/portal names
+covered by `*.octelium.stinkyboi.com`.
 
 ## OctoBot
 

--- a/docs/networking-tailnet-ingress.md
+++ b/docs/networking-tailnet-ingress.md
@@ -46,10 +46,11 @@ Istio terminates HTTPS with the `stinkyboi-com-tls` certificate in
 `letsencrypt-cloudflare` ClusterIssuer, which uses DNS-01 challenges for
 `stinkyboi.com` and reads its Cloudflare token from the External Secrets-managed
 `cloudflare-api-token` Secret in the `cert-manager` namespace. The certificate
-also includes `octelium.stinkyboi.com` and `*.octelium.stinkyboi.com` for the
-nested Octelium Cluster domain and API/portal bootstrap names. The
-`homelab-selfsigned` issuer remains available only as a local fallback and is
-not referenced by the ingress wildcard certificate.
+also includes `*.octelium.stinkyboi.com` for the nested Octelium API/portal
+bootstrap names; the existing `*.stinkyboi.com` SAN already covers the
+`octelium.stinkyboi.com` Cluster domain. The `homelab-selfsigned` issuer
+remains available only as a local fallback and is not referenced by the ingress
+wildcard certificate.
 
 Validation on 2026-05-24 found no enabled first-rollout Funnel routes. Policy
 Bot later added a reviewed Funnel exception for GitHub webhook delivery, and

--- a/docs/octelium.md
+++ b/docs/octelium.md
@@ -91,9 +91,10 @@ aws ssm put-parameter \
 The Octelium Cluster domain for this homelab is `octelium.stinkyboi.com`.
 With that domain, Octelium clients contact
 `octelium-api.octelium.stinkyboi.com`, and browser access may also use
-`portal.octelium.stinkyboi.com`. The Istio wildcard certificate now requests
-both `octelium.stinkyboi.com` and `*.octelium.stinkyboi.com` so the nested API
-and portal names can present a valid certificate.
+`portal.octelium.stinkyboi.com`. The existing Istio `*.stinkyboi.com`
+certificate covers `octelium.stinkyboi.com`; it also requests
+`*.octelium.stinkyboi.com` so the nested API and portal names can present a
+valid certificate.
 
 Until DNS or another private route reaches the Octelium Cluster ingress, use a
 local port-forward as the bootstrap path:
@@ -151,9 +152,10 @@ existing Octelium Cluster. Commercial or production use requires an Enterprise
 license; license material must stay outside git.
 
 The configured Octelium Cluster domain is `octelium.stinkyboi.com`, which makes
-the client use `octelium-api.octelium.stinkyboi.com`. The certificate must
-cover both `octelium.stinkyboi.com` and `*.octelium.stinkyboi.com`; the existing
-one-level `*.stinkyboi.com` wildcard is not enough for the API hostname.
+the client use `octelium-api.octelium.stinkyboi.com`. The existing
+`*.stinkyboi.com` wildcard covers the Cluster domain, and the certificate must
+also cover `*.octelium.stinkyboi.com`; the one-level wildcard is not enough for
+the API hostname.
 
 Install the pinned package:
 


### PR DESCRIPTION
## Summary
- remove the redundant exact octelium.stinkyboi.com SAN from the Istio wildcard certificate
- keep *.octelium.stinkyboi.com so portal/API nested names can get valid TLS
- update Octelium and tailnet ingress docs to explain the wildcard coverage split

## Validation
- kubectl kustomize clusters/homelab/apps/istio
- kubectl kustomize clusters/homelab/apps/octelium
- git diff --check
- bash scripts/ci/secret-scan.sh

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `2f5ecd002f662ad8e4a27fb97d3894303dedb27b`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
