### PR TITLE
feat: gate octelium app access cutover

### DIFF
--- a/IaC/live/argocd-apps/compass/terragrunt.hcl
+++ b/IaC/live/argocd-apps/compass/terragrunt.hcl
@@ -85,7 +85,7 @@ inputs = {
   info = [
     {
       name  = "ingress"
-      value = "https://compass.stinkyboi.com via tailnet-only Istio gateway"
+      value = "Octelium target compass.homelab; tailnet stinkyboi.com route remains fallback until octelium e2e passes"
     },
     {
       name  = "state"

--- a/IaC/live/argocd-apps/kiali/terragrunt.hcl
+++ b/IaC/live/argocd-apps/kiali/terragrunt.hcl
@@ -89,7 +89,7 @@ inputs = {
     },
     {
       name  = "auth"
-      value = "anonymous read-only; tailnet gateway allowlisted"
+      value = "anonymous read-only; Octelium connector and fallback tailnet gateway allowlisted"
     }
   ]
 }

--- a/IaC/live/argocd-apps/octelium/terragrunt.hcl
+++ b/IaC/live/argocd-apps/octelium/terragrunt.hcl
@@ -83,7 +83,7 @@ inputs = {
   info = [
     {
       name  = "mode"
-      value = "Octelium client connector for private homelab services; Tailscale remains installed"
+      value = "Octelium client connector target for homelab app access; Tailscale app routes remain fallback until e2e passes"
     },
     {
       name  = "services"

--- a/IaC/live/argocd-apps/octobot/terragrunt.hcl
+++ b/IaC/live/argocd-apps/octobot/terragrunt.hcl
@@ -85,7 +85,7 @@ inputs = {
   info = [
     {
       name  = "rollout"
-      value = "OctoBot UI is tailnet-only; no exchange credentials, real-trading strategy, or autostart configuration are committed"
+      value = "OctoBot UI targets octobot.homelab via Octelium; tailnet route remains fallback until octelium e2e passes; no exchange credentials, real-trading strategy, or autostart configuration are committed"
     }
   ]
 }

--- a/IaC/live/argocd-apps/policy-bot/terragrunt.hcl
+++ b/IaC/live/argocd-apps/policy-bot/terragrunt.hcl
@@ -68,7 +68,7 @@ inputs = {
   info = [
     {
       name  = "public-webhook"
-      value = "Only /api/github/hook is exposed through Tailscale Funnel; all other Policy Bot routes remain tailnet-only on policy-bot.stinkyboi.com"
+      value = "Policy Bot UI targets policy-bot.homelab via Octelium; only /api/github/hook remains a Tailscale Funnel exception until separately replaced"
     }
   ]
 }

--- a/clusters/homelab/apps/README.md
+++ b/clusters/homelab/apps/README.md
@@ -7,8 +7,8 @@ Typical files:
 
 - `values.yaml`: Helm values or app-template values with non-secret defaults.
 - `externalsecret.yaml`: AWS SSM Parameter Store references only.
-- `virtualservice.yaml`: Istio tailnet-only route for internal access when
-  direct operator ingress is intentionally allowed.
+- `virtualservice.yaml`: Istio fallback route for app UI access while the
+  Octelium cutover gate is still failing.
 - `kustomization.yaml`: Raw resources included by Argo CD alongside Helm
   sources.
 - `README.md`: Storage, backup, restore, rollback, and app-specific notes.
@@ -21,10 +21,12 @@ Repo-declared workload images that should move automatically must also be listed
 in `clusters/homelab/apps/argocd-image-updater/imageupdater.yaml`; Image Updater
 opens pull requests for those values instead of relying on live-only overrides.
 
-Most first-rollout routes are tailnet-only. Public Tailscale Funnel routes must
-stay limited to reviewed webhook exceptions such as n8n's webhook prefixes and
-Policy Bot's `/api/github/hook` route, and every exception must be documented
-in `docs/networking-tailnet-ingress.md`.
+Human app access targets the Octelium `.homelab` service catalog in
+`docs/examples/octelium/homelab-services.yaml`. Existing tailnet app routes stay
+as fallback only until `scripts/octelium-e2e-check.sh` passes. Public Tailscale
+Funnel routes must stay limited to reviewed webhook exceptions such as n8n's
+webhook prefixes and Policy Bot's `/api/github/hook` route, and every exception
+must be documented in `docs/networking-tailnet-ingress.md`.
 
 Do not add a route just because an upstream chart exposes a web UI. Prefer the
 least direct reviewed access path. For example, Grafana is the operator-facing

--- a/clusters/homelab/apps/compass/ingress-discovery.yaml
+++ b/clusters/homelab/apps/compass/ingress-discovery.yaml
@@ -24,7 +24,7 @@ metadata:
 spec:
   ingressClassName: compass-discovery
   rules:
-    - host: argocd.stinkyboi.com
+    - host: argocd.homelab
       http:
         paths:
           - path: /
@@ -51,7 +51,7 @@ metadata:
 spec:
   ingressClassName: compass-discovery
   rules:
-    - host: compass.stinkyboi.com
+    - host: compass.homelab
       http:
         paths:
           - path: /
@@ -71,14 +71,14 @@ metadata:
     compass.adinhodovic.com/enabled: "true"
   annotations:
     compass.adinhodovic.com/name: Deluge
-    compass.adinhodovic.com/description: Tailnet-only torrent client behind the media VPN path.
+    compass.adinhodovic.com/description: Torrent client reached through the Octelium app access plane.
     compass.adinhodovic.com/icon: selfhst:deluge
     compass.adinhodovic.com/primary-tag: kubernetes
     compass.adinhodovic.com/tags: media
 spec:
   ingressClassName: compass-discovery
   rules:
-    - host: deluge.stinkyboi.com
+    - host: deluge.homelab
       http:
         paths:
           - path: /
@@ -105,7 +105,7 @@ metadata:
 spec:
   ingressClassName: compass-discovery
   rules:
-    - host: grafana.stinkyboi.com
+    - host: grafana.homelab
       http:
         paths:
           - path: /
@@ -132,7 +132,7 @@ metadata:
 spec:
   ingressClassName: compass-discovery
   rules:
-    - host: kiali.stinkyboi.com
+    - host: kiali.homelab
       http:
         paths:
           - path: /
@@ -159,7 +159,7 @@ metadata:
 spec:
   ingressClassName: compass-discovery
   rules:
-    - host: litellm.stinkyboi.com
+    - host: litellm.homelab
       http:
         paths:
           - path: /
@@ -186,7 +186,7 @@ metadata:
 spec:
   ingressClassName: compass-discovery
   rules:
-    - host: n8n.stinkyboi.com
+    - host: n8n.homelab
       http:
         paths:
           - path: /
@@ -213,7 +213,7 @@ metadata:
 spec:
   ingressClassName: compass-discovery
   rules:
-    - host: octobot.stinkyboi.com
+    - host: octobot.homelab
       http:
         paths:
           - path: /
@@ -240,7 +240,7 @@ metadata:
 spec:
   ingressClassName: compass-discovery
   rules:
-    - host: openclaw.stinkyboi.com
+    - host: openclaw.homelab
       http:
         paths:
           - path: /
@@ -267,7 +267,7 @@ metadata:
 spec:
   ingressClassName: compass-discovery
   rules:
-    - host: policy-bot.stinkyboi.com
+    - host: policy-bot.homelab
       http:
         paths:
           - path: /
@@ -294,7 +294,7 @@ metadata:
 spec:
   ingressClassName: compass-discovery
   rules:
-    - host: prowlarr.stinkyboi.com
+    - host: prowlarr.homelab
       http:
         paths:
           - path: /
@@ -321,7 +321,7 @@ metadata:
 spec:
   ingressClassName: compass-discovery
   rules:
-    - host: radarr.stinkyboi.com
+    - host: radarr.homelab
       http:
         paths:
           - path: /
@@ -348,7 +348,7 @@ metadata:
 spec:
   ingressClassName: compass-discovery
   rules:
-    - host: sonarr.stinkyboi.com
+    - host: sonarr.homelab
       http:
         paths:
           - path: /

--- a/clusters/homelab/apps/compass/values.yaml
+++ b/clusters/homelab/apps/compass/values.yaml
@@ -12,13 +12,13 @@ config: |
 
   header_links:
     - label: Grafana
-      url: https://grafana.stinkyboi.com
+      url: http://grafana.homelab
       icon: selfhst:grafana
     - label: Argo CD
-      url: https://argocd.stinkyboi.com
+      url: http://argocd.homelab
       icon: selfhst:argo-cd
     - label: Kiali
-      url: https://kiali.stinkyboi.com
+      url: http://kiali.homelab
       icon: selfhst:kiali
 
   services:

--- a/clusters/homelab/apps/kiali/README.md
+++ b/clusters/homelab/apps/kiali/README.md
@@ -14,17 +14,20 @@ plane while using the monitoring namespace's existing observability boundary.
 Kiali is exposed at:
 
 ```text
-https://kiali.stinkyboi.com
+kiali.homelab
 ```
 
-The route uses the shared `istio-system/tailnet-gateway` and is annotated with
+The Octelium service is the target human access path. The existing
+`https://kiali.stinkyboi.com` route through the shared
+`istio-system/tailnet-gateway` remains fallback until
+`scripts/octelium-e2e-check.sh` passes and is annotated with
 `homelab.rst.io/public-funnel: "false"`. Do not add a public Funnel route for
 Kiali.
 
 Kiali uses `auth.strategy: anonymous` and `deployment.view_only_mode: true`,
-with an Istio `AuthorizationPolicy` that only allows the tailnet gateway and
-Prometheus to reach the Kiali workload. This keeps the UI immediately usable
-from the tailnet without granting write operations through Kiali. If this
+with an Istio `AuthorizationPolicy` that allows Octelium, the fallback tailnet
+gateway, and Prometheus to reach the Kiali workload. This keeps the UI
+immediately usable without granting write operations through Kiali. If this
 becomes a broader operator surface, replace anonymous access with OIDC-backed
 authentication in a separate change.
 
@@ -33,13 +36,14 @@ authentication in a separate change.
 Kiali depends on:
 
 - Istio for mesh resources and status.
-- Tailscale and the shared tailnet gateway for private HTTPS access.
+- Octelium for target app access, with Tailscale as fallback until the cutover
+  gate passes.
 - Prometheus for graph and health metrics.
 - Grafana for dashboard links.
 
 The monitoring AuthorizationPolicies allow the Kiali service account to query
-Prometheus and Grafana, and allow Prometheus plus the tailnet gateway to reach
-Kiali. Kiali has no persistent storage requirement.
+Prometheus and Grafana, and allow Prometheus plus Octelium and the fallback
+tailnet gateway to reach Kiali. Kiali has no persistent storage requirement.
 
 ## Validation
 
@@ -52,9 +56,10 @@ kubectl -n monitoring get deploy,svc kiali
 curl -I https://kiali.stinkyboi.com
 ```
 
-Expected result: the Argo CD Application is `Synced` and `Healthy`, the Kiali
-custom resource reports a successful reconciliation, the Deployment and Service
-exist in `monitoring`, and the tailnet HTTPS route returns a Kiali response.
+Expected result before the Octelium cutover gate passes: the Argo CD
+Application is `Synced` and `Healthy`, the Kiali custom resource reports a
+successful reconciliation, the Deployment and Service exist in `monitoring`,
+and the fallback tailnet HTTPS route returns a Kiali response.
 
 Rollback by reverting the `kiali` Application registration and this desired
 state path, then syncing Argo CD. Let the Kiali CR delete cleanly before

--- a/clusters/homelab/apps/n8n/README.md
+++ b/clusters/homelab/apps/n8n/README.md
@@ -1,7 +1,9 @@
 # n8n Desired State
 
-n8n runs as a self-hosted automation service behind the tailnet-only Istio
-gateway at `https://n8n.stinkyboi.com`.
+n8n runs as a self-hosted automation service. Human editor/UI access targets
+Octelium as `n8n.homelab`; the existing tailnet Istio route at
+`https://n8n.stinkyboi.com` remains fallback until
+`scripts/octelium-e2e-check.sh` passes.
 
 n8n uses the dedicated `n8n-postgres` support app for workflows, credential
 metadata, user records, and execution history. It still persists
@@ -26,17 +28,19 @@ persisted settings file instead of crashlooping on an accidental mismatch.
 
 ## Access Contract
 
-- Editor/UI host: `https://n8n.stinkyboi.com`
-- Editor/UI ingress: `istio-system/tailnet-gateway`
+- Editor/UI target: `n8n.homelab` through Octelium after cutover
+- Editor/UI fallback: `https://n8n.stinkyboi.com` through
+  `istio-system/tailnet-gateway` until the Octelium gate passes
 - Public webhook Funnel host: `https://n8n-webhook.tail67beb.ts.net`
 - Public webhook paths: `/webhook`, `/webhook-test`, and `/webhook-waiting`
 
 `WEBHOOK_URL` is set to the public Funnel host so n8n advertises externally
-reachable webhook URLs. The editor base URL stays on the tailnet-only
-`n8n.stinkyboi.com` host. The Funnel route is declared as a Tailscale Ingress
-in `istio-system` and forwards only the webhook path prefixes to the Istio
-gateway, which then routes to the n8n service. Do not add the root path, editor
-routes, static assets, or API routes to the Funnel Ingress.
+reachable webhook URLs. The editor base URL stays on the fallback
+`n8n.stinkyboi.com` host until the Octelium e2e gate passes and the app base
+URL can move to the Octelium service name. The Funnel route is declared as a
+Tailscale Ingress in `istio-system` and forwards only the webhook path prefixes
+to the Istio gateway, which then routes to the n8n service. Do not add the root
+path, editor routes, static assets, or API routes to the Funnel Ingress.
 
 The Tailscale tailnet policy must allow the operator proxy tag, currently
 `tag:k8s`, to use Funnel:
@@ -76,10 +80,10 @@ curl -I https://n8n.stinkyboi.com/
 curl -sS -o /dev/null -w '%{http_code}\n' https://n8n-webhook.tail67beb.ts.net/webhook/__missing__
 ```
 
-Expected route behavior: the editor host serves n8n through the tailnet, the
-Funnel host reaches n8n only under the webhook prefixes, and an unknown
-webhook path returns an n8n not-found response until a workflow registers that
-webhook.
+Expected route behavior before the Octelium cutover gate passes: the fallback
+editor host serves n8n through the tailnet, the Funnel host reaches n8n only
+under the webhook prefixes, and an unknown webhook path returns an n8n
+not-found response until a workflow registers that webhook.
 
 ## Rollback
 

--- a/clusters/homelab/apps/octelium/README.md
+++ b/clusters/homelab/apps/octelium/README.md
@@ -1,8 +1,10 @@
 # Octelium Client Desired State
 
-This app prepares a repo-owned Octelium client connector in the homelab while
-leaving Tailscale in place as the current tailnet ingress and exit-node layer.
-Octelium is a parallel private access path for the existing homelab services.
+This app prepares a repo-owned Octelium client connector in the homelab.
+Octelium is the replacement target for human app access. Tailscale remains the
+temporary fallback for app routes until `scripts/octelium-e2e-check.sh` proves
+the Octelium Cluster, service catalog, workload credential, connector, and
+client tunnel are all working.
 
 The deployed Kubernetes pieces are:
 
@@ -27,13 +29,12 @@ The Octelium resource catalog for the external Octelium Cluster is
 - WEB Services for Argo CD, Compass, Deluge, Grafana, Kiali, LiteLLM, n8n,
   OctoBot, OpenClaw, Policy Bot, Prowlarr, Radarr, Sonarr, and the demo.
 
-`values.yaml` keeps the connector at `replicaCount: 0` until the external
-Octelium Cluster API, Enterprise package, service catalog, and workload
-credential are verified. The prepared `--scope` entries keep the workload
-credential constrained to the same service names when the connector is
-activated.
+`values.yaml` keeps the connector at `replicaCount: 0` until the Octelium
+Cluster API, service catalog, and workload credential are verified. The
+prepared `--scope` entries keep the workload credential constrained to the same
+service names when the connector is activated.
 
-## Activation
+## Activation And Cutover
 
 Apply the external Octelium resources to the Octelium Cluster:
 
@@ -58,9 +59,17 @@ aws ssm put-parameter \
   --value '<authentication-token>'
 ```
 
-After the external Octelium API is verified, change `replicaCount` to `1` in a
-follow-up PR and let Argo CD sync `octelium`. The connector then serves each
-configured Octelium Service from inside the homelab cluster.
+After the Octelium API is verified, change `replicaCount` to `1` in a follow-up
+PR and let Argo CD sync `octelium`. The connector then serves each configured
+Octelium Service from inside the homelab cluster.
+
+Then run:
+
+```sh
+scripts/octelium-e2e-check.sh
+```
+
+Only remove the old Tailscale-backed app UI routes after this e2e gate passes.
 
 ## Bootstrap UI Access
 
@@ -143,6 +152,7 @@ helm template octelium-client oci://ghcr.io/octelium/helm-charts/octelium \
   --namespace octelium-client \
   -f clusters/homelab/apps/octelium/values.yaml
 scripts/octelium-enterprise-package.sh --help
+scripts/octelium-e2e-check.sh --help
 ```
 
 After activation with `replicaCount: 1`:
@@ -151,6 +161,7 @@ After activation with `replicaCount: 1`:
 kubectl -n octelium-client get externalsecret,secret octelium-client-auth
 kubectl -n octelium-client get deploy,pod -l app.kubernetes.io/instance=octelium-client
 kubectl -n octelium-client logs deploy/octelium-client
+scripts/octelium-e2e-check.sh
 ```
 
 From an Octelium client session, query one of the private service names:

--- a/clusters/homelab/apps/octelium/README.md
+++ b/clusters/homelab/apps/octelium/README.md
@@ -69,6 +69,15 @@ Then run:
 scripts/octelium-e2e-check.sh
 ```
 
+Use separate contexts when the Octelium control plane is not the homelab
+cluster:
+
+```sh
+scripts/octelium-e2e-check.sh \
+  --octelium-context <octelium-cluster-context> \
+  --homelab-context <homelab-context>
+```
+
 Only remove the old Tailscale-backed app UI routes after this e2e gate passes.
 
 ## Bootstrap UI Access
@@ -161,7 +170,9 @@ After activation with `replicaCount: 1`:
 kubectl -n octelium-client get externalsecret,secret octelium-client-auth
 kubectl -n octelium-client get deploy,pod -l app.kubernetes.io/instance=octelium-client
 kubectl -n octelium-client logs deploy/octelium-client
-scripts/octelium-e2e-check.sh
+scripts/octelium-e2e-check.sh \
+  --octelium-context <octelium-cluster-context> \
+  --homelab-context <homelab-context>
 ```
 
 From an Octelium client session, query one of the private service names:

--- a/clusters/homelab/apps/octobot/README.md
+++ b/clusters/homelab/apps/octobot/README.md
@@ -1,8 +1,10 @@
 # OctoBot
 
 OctoBot runs as the finance namespace trading bot with a real web UI. The app
-uses the upstream `drakkarsoftware/octobot` Docker image and exposes only the
-tailnet-only Istio route at `https://octobot.stinkyboi.com`.
+uses the upstream `drakkarsoftware/octobot` Docker image. Human UI access
+targets Octelium as `octobot.homelab`; the existing tailnet Istio route at
+`https://octobot.stinkyboi.com` remains fallback until
+`scripts/octelium-e2e-check.sh` passes.
 
 This repository intentionally does not commit exchange API keys, trading
 profiles, Telegram tokens, or live-trading startup configuration. Use the web
@@ -16,7 +18,9 @@ to trading only with withdrawals disabled before enabling live execution.
 - Web UI port: `5001`
 - Persistent state: `octobot-user`, `octobot-tentacles`, and `octobot-logs`
   PVCs on `nfs-default`
-- Route: `https://octobot.stinkyboi.com`; no public Funnel route
+- Route target: `octobot.homelab` through Octelium; fallback
+  `https://octobot.stinkyboi.com` until the cutover gate passes; no public
+  Funnel route
 - Secret source: none committed; OctoBot setup and exchange credentials are
   stored by the application on its persistent volumes
 
@@ -38,7 +42,8 @@ helm template octobot app-template \
   --values clusters/homelab/apps/octobot/values.yaml
 ```
 
-After Argo CD applies the Application, verify the workload and tailnet route:
+After Argo CD applies the Application, verify the workload and current fallback
+route:
 
 ```sh
 kubectl -n argocd get application octobot
@@ -46,9 +51,9 @@ kubectl -n finance get deploy,pod,pvc,svc -l app.kubernetes.io/instance=octobot
 curl -I https://octobot.stinkyboi.com
 ```
 
-Expected result: one OctoBot pod is ready, the UI service listens on port
-`5001`, the three NFS-backed PVCs are bound, and the FQDN is reachable only from
-the tailnet.
+Expected result before the Octelium cutover gate passes: one OctoBot pod is
+ready, the UI service listens on port `5001`, the three NFS-backed PVCs are
+bound, and the fallback FQDN is reachable only from the tailnet.
 
 ## Operations
 

--- a/clusters/homelab/apps/openclaw/README.md
+++ b/clusters/homelab/apps/openclaw/README.md
@@ -1,8 +1,9 @@
 # OpenClaw
 
-OpenClaw runs behind the tailnet-only Istio gateway at
-`https://openclaw.stinkyboi.com`. Runtime config and agent state persist on the
-`openclaw` PVC under `/data/openclaw`.
+OpenClaw targets Octelium app access as `openclaw.homelab`. The existing
+tailnet Istio route at `https://openclaw.stinkyboi.com` remains fallback until
+`scripts/octelium-e2e-check.sh` passes. Runtime config and agent state persist
+on the `openclaw` PVC under `/data/openclaw`.
 
 ## Resource Profile
 
@@ -56,11 +57,12 @@ kubectl -n ai exec deploy/openclaw -c app -- openclaw gateway health
 kubectl -n ai exec deploy/openclaw -c app -- openclaw devices list --json
 ```
 
-If the gateway is healthy, refresh the browser's site data for
-`https://openclaw.stinkyboi.com` and reconnect through the current shared
-gateway-auth flow. To reissue a server-side token for a paired Control UI
-device, identify the `clientId: openclaw-control-ui` record and rotate its
-operator token:
+If the gateway is healthy, refresh the browser's site data for the host in use:
+`openclaw.homelab` through Octelium after cutover or the fallback
+`https://openclaw.stinkyboi.com` route before the gate passes. Reconnect through
+the current shared gateway-auth flow. To reissue a server-side token for a
+paired Control UI device, identify the `clientId: openclaw-control-ui` record
+and rotate its operator token:
 
 ```sh
 kubectl -n ai exec deploy/openclaw -c app -- \

--- a/clusters/homelab/apps/openclaw/values.yaml
+++ b/clusters/homelab/apps/openclaw/values.yaml
@@ -142,7 +142,7 @@ controllers:
 
             openclaw config set --strict-json \
               gateway.controlUi.allowedOrigins \
-              '["https://openclaw.stinkyboi.com"]'
+              '["https://openclaw.stinkyboi.com","http://openclaw.homelab","https://openclaw.homelab"]'
 
             if [ -z "${GRAFANA_ALERT_HOOK_TOKEN:-}" ] || [ "$GRAFANA_ALERT_HOOK_TOKEN" = "REPLACE_ME" ]; then
               echo "GRAFANA_ALERT_HOOK_TOKEN is not populated; skipping hooks bootstrap"

--- a/clusters/homelab/apps/radarr/README.md
+++ b/clusters/homelab/apps/radarr/README.md
@@ -38,15 +38,16 @@ The Radarr app container also sets `RADARR__AUTH__METHOD=External` and
 variables override persisted `config.xml` entries at startup and keep the
 running process aligned if the PVC copy drifts back to Forms authentication or
 password-required mode.
-Radarr is exposed only through the tailnet Istio route with Funnel disabled, so
-the tailnet gateway is the external access boundary and Radarr's own password
-prompt is intentionally disabled.
+Radarr targets Octelium as the external access boundary, with the tailnet Istio
+route retained as fallback until `scripts/octelium-e2e-check.sh` passes. Funnel
+stays disabled, and Radarr's own password prompt is intentionally disabled.
 
 This avoids recurring lockouts when the internal Radarr username/password state
 drifts or is reset during config/database migrations. If Radarr is ever exposed
-outside the tailnet, restore Forms authentication or add a dedicated forward
-auth layer before rollout. Upstream documents `External` as the config-file-only
-mode for deployments protected by external authentication:
+outside Octelium or another reviewed private access layer, restore Forms
+authentication or add a dedicated forward auth layer before rollout. Upstream
+documents `External` as the config-file-only mode for deployments protected by
+external authentication:
 <https://wiki.servarr.com/radarr/faq#authentication-method>.
 
 ## Media Storage

--- a/docs/knowledge-base/architecture/secrets-and-identity.md
+++ b/docs/knowledge-base/architecture/secrets-and-identity.md
@@ -65,8 +65,8 @@ roles need identity-based KMS permissions for both keys.
   target Secret `operator-oauth`.
 - Octelium client bridge auth uses the `octelium-client-auth` ExternalSecret in
   `octelium-client`, sourced from `/homelab/octelium/client-auth-token`. The
-  token belongs to the external Octelium workload User
-  `homelab-octelium-client` and is created outside git with `octeliumctl`.
+  token belongs to the Octelium workload User `homelab-octelium-client` and is
+  created outside git with `octeliumctl`.
   Octelium Enterprise license material, if required for commercial or
   production use, also stays outside git; add only a safe SSM or
   ExternalSecret contract in a future change if the package needs one.

--- a/docs/knowledge-base/operations/validation-gates.md
+++ b/docs/knowledge-base/operations/validation-gates.md
@@ -53,6 +53,9 @@ must pass:
 scripts/octelium-e2e-check.sh
 ```
 
+Pass `--octelium-context` and `--homelab-context` when the Octelium control
+plane and homelab connector live in different Kubernetes clusters.
+
 The gate checks the Octelium control plane, synced workload credential, ready
 connector replica, non-Istio Cluster/API/portal responses, the complete homelab
 WEB Service catalog, and a tunnel to `homelab-demo.homelab`.

--- a/docs/knowledge-base/operations/validation-gates.md
+++ b/docs/knowledge-base/operations/validation-gates.md
@@ -44,6 +44,19 @@ kubectl kustomize clusters/homelab/apps/argocd-image-updater
 rg -n "writeBackTarget|imageName|manifestTargets" clusters/homelab/apps/argocd-image-updater/imageupdater.yaml
 ```
 
+## Octelium Cutover Checks
+
+Before removing any Tailscale-backed app route, the Octelium replacement path
+must pass:
+
+```sh
+scripts/octelium-e2e-check.sh
+```
+
+The gate checks the Octelium control plane, synced workload credential, ready
+connector replica, non-Istio Cluster/API/portal responses, the complete homelab
+WEB Service catalog, and a tunnel to `homelab-demo.homelab`.
+
 ## Policy Bot Checks
 
 Repository-local `.policy.yml` changes need Policy Bot validation, not just YAML

--- a/docs/knowledge-base/runbooks/octelium.md
+++ b/docs/knowledge-base/runbooks/octelium.md
@@ -94,6 +94,11 @@ the synced workload credential, a ready `octelium-client` replica, non-Istio
 responses from the Cluster/API/portal hostnames, every homelab WEB Service in
 the Octelium catalog, and a tunnel to `homelab-demo.homelab`.
 
+When the Octelium control plane is external to homelab, run the gate with
+separate `--octelium-context` and `--homelab-context` values so the
+control-plane namespace checks and connector checks target the correct
+clusters.
+
 If the gate fails, keep the app `VirtualService` objects and the Tailscale
 Istio `LoadBalancer` fallback in place. Treat the failure output as the
 remaining cutover work queue.

--- a/docs/knowledge-base/runbooks/octelium.md
+++ b/docs/knowledge-base/runbooks/octelium.md
@@ -6,16 +6,17 @@ Source: `docs/octelium.md`
 
 ## Model
 
-Octelium runs as a parallel client bridge, not as a replacement for Tailscale.
+Octelium is the replacement target for human access to homelab applications.
 The current app registration is `octelium`, the Kubernetes namespace is
-`octelium-client`, and Tailscale continues to own the active tailnet ingress
-and homelab exit node.
+`octelium-client`, and Tailscale remains only the temporary fallback for app
+routes until the Octelium e2e gate passes. Tailscale can still have separate
+non-app duties, such as CI cluster reachability or reviewed public webhook
+exceptions, until those are replaced in their own change.
 
 The Argo CD Application installs the official Octelium client Helm chart plus
 repo-owned support manifests. The connector is prepared for rootless gVisor
 mode, enrolled in Istio ambient mesh, and kept at `replicaCount: 0` until the
-external Octelium API, Enterprise package, service catalog, and workload
-credential are verified.
+Octelium API, service catalog, and workload credential are verified.
 
 ## Service Catalog
 
@@ -85,6 +86,18 @@ Then run `octelium login --domain octelium.stinkyboi.com`, apply
 Application. Remove the temporary host entries after real DNS or the first VPN
 path reaches the same Octelium ingress.
 
+## Cutover Gate
+
+`scripts/octelium-e2e-check.sh` is the required gate before removing old
+Tailscale-backed app routes. It checks the Octelium control-plane namespace,
+the synced workload credential, a ready `octelium-client` replica, non-Istio
+responses from the Cluster/API/portal hostnames, every homelab WEB Service in
+the Octelium catalog, and a tunnel to `homelab-demo.homelab`.
+
+If the gate fails, keep the app `VirtualService` objects and the Tailscale
+Istio `LoadBalancer` fallback in place. Treat the failure output as the
+remaining cutover work queue.
+
 ## Secret Contract
 
 `octelium-client-auth` reads `/homelab/octelium/client-auth-token` from AWS SSM.
@@ -122,6 +135,7 @@ helm template octelium-client oci://ghcr.io/octelium/helm-charts/octelium \
   --namespace octelium-client \
   -f clusters/homelab/apps/octelium/values.yaml
 scripts/octelium-enterprise-package.sh --help
+scripts/octelium-e2e-check.sh --help
 ```
 
 After activation, confirm External Secrets, the service catalog, and the

--- a/docs/knowledge-base/runbooks/runtime-isolation.md
+++ b/docs/knowledge-base/runbooks/runtime-isolation.md
@@ -12,7 +12,8 @@ documentation placeholders until an enforcing CNI or policy engine exists.
 
 Current enforced controls:
 
-- tailnet-only Istio ingress routes;
+- fallback Istio ingress routes while the Octelium cutover gate is still
+  failing;
 - workload-scoped Istio policy only where namespace mesh enrollment is proven;
 - explicit namespace Pod Security labels.
 
@@ -31,8 +32,8 @@ Current enforced controls:
 repo-owned namespace manifests. `octelium-client` is ambient-enrolled so the
 Octelium connector can be allowed as
 `cluster.local/ns/octelium-client/sa/octelium-client` by protected workloads.
-`finance` is not mesh-enrolled; OctoBot's current route is a tailnet UI path,
-not a service-to-service or trading API path.
+`finance` is not mesh-enrolled; OctoBot's current fallback route is a tailnet UI
+path, not a service-to-service or trading API path.
 
 ## Network Policy Gate
 

--- a/docs/knowledge-base/runbooks/tailnet-ingress.md
+++ b/docs/knowledge-base/runbooks/tailnet-ingress.md
@@ -6,22 +6,26 @@ Source: `docs/networking-tailnet-ingress.md`
 
 ## Model
 
-Istio is the reverse proxy for app access. Tailscale is the reachability layer.
-Most routes are internal-only. Public Tailscale Funnel is reserved for reviewed
-webhook paths that external SaaS systems must reach.
+Octelium is the target access plane for human app access. Istio plus Tailscale
+remain the fallback app route until `scripts/octelium-e2e-check.sh` proves the
+Octelium Cluster, service catalog, connector, and client tunnel work end to
+end. Public Tailscale Funnel is reserved for reviewed webhook paths that
+external SaaS systems must reach.
 
 `*.stinkyboi.com` is expected to resolve to the Tailscale-exposed Istio ingress
-address from tailnet clients. DNS is not managed by this repo yet.
+address from tailnet clients while those fallback routes remain. DNS is not
+managed by this repo yet.
 
-Octelium is a separate client bridge under [[octelium]] for the same private
-homelab service set. It does not own the current `*.stinkyboi.com` Istio routes
-and does not replace the Tailscale exit node.
+Octelium is documented under [[octelium]] for the same private homelab service
+set. It replaces app access only after the e2e gate passes; it does not
+automatically replace the Tailscale exit node, CI route, or reviewed public
+webhook exceptions.
 
 ## Current Route Rules
 
 - Argo CD, Grafana, Kiali, Deluge, Prowlarr, Radarr, Sonarr, LiteLLM,
-  OpenClaw, n8n editor/UI, Policy Bot UI and normal routes, and OctoBot UI are
-  tailnet-only.
+  OpenClaw, n8n editor/UI, Policy Bot UI and normal routes, and OctoBot UI
+  still have tailnet-only fallback routes.
 - n8n webhooks are a reviewed public Funnel exception:
   `https://n8n-webhook.tail67beb.ts.net` for `/webhook`, `/webhook-test`, and
   `/webhook-waiting` only.
@@ -29,12 +33,13 @@ and does not replace the Tailscale exit node.
   `https://policy-bot-hook.<tailnet-name>.ts.net/api/github/hook`.
 - Prometheus is intentionally not exposed; Grafana is the metrics UI and Kiali
   is the read-only mesh UI.
-- OctoBot exposes only `https://octobot.stinkyboi.com` through the tailnet
-  gateway. Its exchange credentials and strategy state live on PVC-backed
-  runtime configuration, not in public repository files.
+- OctoBot uses `octobot.homelab` through Octelium after cutover; the
+  `https://octobot.stinkyboi.com` route is fallback until the gate passes. Its
+  exchange credentials and strategy state live on PVC-backed runtime
+  configuration, not in public repository files.
 - Octelium serves private WEB Services from
   `docs/examples/octelium/homelab-services.yaml`; public webhook callbacks stay
-  on their reviewed Tailscale Funnel exceptions.
+  on their reviewed Tailscale Funnel exceptions until separately redesigned.
 
 ## TLS And Certificates
 

--- a/docs/knowledge-base/runbooks/validation.md
+++ b/docs/knowledge-base/runbooks/validation.md
@@ -52,7 +52,9 @@ considered available. Check `external-secrets`, `cert-manager`, `istio`,
 `tailscale`, `argocd-image-updater`, `kiali`, `platform-dns`, and
 `platform-storage`.
 
-Policy Bot has extra route checks: the tailnet UI should redirect to auth, the
+Octelium app access has a dedicated gate in `scripts/octelium-e2e-check.sh`.
+Keep fallback tailnet app UI routes in place until that gate passes. Policy Bot
+has extra route checks: the fallback tailnet UI should redirect to auth, the
 public webhook should return `400` for an unsigned empty request, and the
 Funnel root should not route.
 

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -16,8 +16,10 @@ and app-specific README notes. No file in this tree may contain secret values,
 private keys, raw certificate material, private kubeconfigs, or private
 hostnames.
 
-Most routes are tailnet-only. Public Funnel is limited to reviewed webhook
-exceptions such as n8n's webhook prefixes and Policy Bot's `/api/github/hook`.
+Human app access targets the Octelium `.homelab` service catalog. Existing
+tailnet app routes are fallback until `scripts/octelium-e2e-check.sh` passes.
+Public Funnel is limited to reviewed webhook exceptions such as n8n's webhook
+prefixes and Policy Bot's `/api/github/hook`.
 
 ## Platform DNS
 
@@ -110,15 +112,17 @@ allow `kiali-service-account` to query Grafana and Prometheus.
 ## Octelium
 
 Octelium runs as a rootless client connector in the `octelium-client`
-namespace, not as a full Octelium Cluster and not as a Tailscale replacement.
+namespace and is the target replacement path for human app access. It is not a
+full Octelium Cluster; the old Tailscale-backed app routes stay as fallback
+until `scripts/octelium-e2e-check.sh` passes.
 The Argo CD Application installs the official `ghcr.io/octelium/helm-charts`
 client chart plus repo-owned support manifests in
 `clusters/homelab/apps/octelium`. The Helm values pin the `0.35.0` Octelium
 image by digest and force `--implementation=gvisor` so the namespace can keep
 baseline Pod Security.
 
-The connector is prepared with `replicaCount: 0` until the external Octelium
-API, Enterprise package, service catalog, and workload credential are verified.
+The connector is prepared with `replicaCount: 0` until the Octelium API,
+service catalog, and workload credential are verified.
 When activated, it serves only the explicit WEB Service catalog declared in
 `docs/examples/octelium/homelab-services.yaml`: Argo CD, Compass, Deluge,
 Grafana, Kiali, LiteLLM, n8n, OctoBot, OpenClaw, Policy Bot, Prowlarr, Radarr,
@@ -134,11 +138,17 @@ domain is `octelium.stinkyboi.com`, so clients contact
 keep the Cluster domain covered by `*.stinkyboi.com` and the API/portal names
 covered by `*.octelium.stinkyboi.com`.
 
+Before removing any old app `VirtualService` or the Tailscale-backed Istio
+`LoadBalancer`, run `scripts/octelium-e2e-check.sh` and confirm the service
+catalog plus `homelab-demo.homelab` tunnel succeed.
+
 ## OctoBot
 
 OctoBot is the finance namespace trading bot with a real web UI. It runs from
 the upstream `drakkarsoftware/octobot` image, listens on container port `5001`,
-and exposes only the tailnet Istio route at `https://octobot.stinkyboi.com`.
+and should be reached as `octobot.homelab` through Octelium after cutover. The
+old `https://octobot.stinkyboi.com` Istio route is fallback until the Octelium
+e2e gate passes.
 State persists on the `octobot-user`, `octobot-tentacles`, and `octobot-logs`
 PVCs using `nfs-default`.
 
@@ -255,18 +265,21 @@ The PostgreSQL desired state preserves the old SQLite file on the PVC but does
 not automatically import rows from it. Export workflows and credentials before
 rollout when existing SQLite contents must be preserved.
 
-n8n keeps the editor and API on `https://n8n.stinkyboi.com`, but advertises
-workflow webhook URLs through `https://n8n-webhook.tail67beb.ts.net`. The
-Funnel route is limited to `/webhook`, `/webhook-test`, and
+n8n targets editor and API access through Octelium as `n8n.homelab`, while the
+fallback editor route stays on `https://n8n.stinkyboi.com` until the cutover
+gate passes. It advertises workflow webhook URLs through
+`https://n8n-webhook.tail67beb.ts.net`. The Funnel route is limited to
+`/webhook`, `/webhook-test`, and
 `/webhook-waiting`, and forwards through the Istio ingress gateway so the n8n
 workload AuthorizationPolicy can continue allowing only the gateway service
 account.
 
 ## Policy Bot
 
-Policy Bot is an in-flight stateless automation workload. The tailnet UI lives
-at `https://policy-bot.stinkyboi.com`, including the root page, details pages,
-static assets, and OAuth callback.
+Policy Bot is an in-flight stateless automation workload. Human UI access
+targets Octelium as `policy-bot.homelab`; the fallback tailnet UI lives at
+`https://policy-bot.stinkyboi.com`, including the root page, details pages,
+static assets, and OAuth callback, until the cutover gate passes.
 The public GitHub webhook is:
 
 ```text
@@ -325,11 +338,11 @@ their library mounts now target the QNAP `/media` export: Radarr uses
 migration sources until the `/media` copy is verified.
 
 Radarr uses `AuthenticationMethod=External` in `/config/config.xml`, managed by
-the startup init container in `clusters/homelab/apps/radarr/values.yaml`. The
-app is tailnet-only with Funnel disabled, so the tailnet gateway is the external
-access boundary. This avoids recurring Radarr password lockouts from internal
-auth drift. If Radarr is ever exposed beyond the tailnet, restore Forms auth or
-add a forward-auth layer first.
+the startup init container in `clusters/homelab/apps/radarr/values.yaml`.
+Octelium is the target access boundary, and the tailnet gateway remains fallback
+with Funnel disabled until the cutover gate passes. This avoids recurring Radarr
+password lockouts from internal auth drift while keeping browser access behind a
+reviewed private access layer.
 
 ## Tailscale
 

--- a/docs/knowledge-base/workloads/inventory.md
+++ b/docs/knowledge-base/workloads/inventory.md
@@ -9,7 +9,8 @@ units as the source of truth when they disagree with this note.
 ## Import Note
 
 This note reflects the current working tree. OctoBot is the finance namespace
-trading workload with a tailnet-only UI.
+trading workload with Octelium-targeted UI access and tailnet fallback until the
+Octelium e2e gate passes.
 
 ## Platform And Support Applications
 
@@ -29,11 +30,11 @@ trading workload with a tailnet-only UI.
 | `cert-manager` | `cert-manager` | `clusters/homelab/apps/cert-manager` | `IaC/live/argocd-apps/cert-manager` | controller-managed certificates | external-secrets |
 | `istio` | `istio-system` | `clusters/homelab/apps/istio` | `IaC/live/argocd-apps/istio` | controller state only | cert-manager |
 | `tailscale` | `tailscale` | `clusters/homelab/apps/tailscale` | `IaC/live/argocd-apps/tailscale` | controller state only | external-secrets, istio |
-| `octelium` | `octelium-client` | `clusters/homelab/apps/octelium` | `IaC/live/argocd-apps/octelium` | stateless rootless Octelium client bridge for Cluster domain `octelium.stinkyboi.com`; serves the explicit homelab WEB Service catalog from `docs/examples/octelium/homelab-services.yaml`, plus Podinfo demo service; auth token is `/homelab/octelium/client-auth-token`; Enterprise package `octeliumee` desired version `0.22.0` is installed with `scripts/octelium-enterprise-package.sh` | external-secrets, istio |
+| `octelium` | `octelium-client` | `clusters/homelab/apps/octelium` | `IaC/live/argocd-apps/octelium` | stateless rootless Octelium client bridge and target human app access plane for Cluster domain `octelium.stinkyboi.com`; serves the explicit homelab WEB Service catalog from `docs/examples/octelium/homelab-services.yaml`, plus Podinfo demo service; auth token is `/homelab/octelium/client-auth-token`; cutover is gated by `scripts/octelium-e2e-check.sh`; Enterprise package `octeliumee` desired version `0.22.0` is installed with `scripts/octelium-enterprise-package.sh` | external-secrets, istio |
 | `prometheus` | `monitoring` | `clusters/homelab/apps/prometheus` | `IaC/live/argocd-apps/prometheus` | persistent metrics, Alertmanager state, Argo CD scrape config, and Alertmanager Discord/OpenClaw notification secrets | external-secrets, platform-storage |
 | `grafana` | `monitoring` | `clusters/homelab/apps/grafana` | `IaC/live/argocd-apps/grafana` | persistent config, dashboards, alert rules, public GitHub API PR/status polling, and stale direct receiver cleanup | external-secrets, cert-manager, istio, tailscale, prometheus, platform-storage |
 | `kiali` | `monitoring` | `clusters/homelab/apps/kiali` | `IaC/live/argocd-apps/kiali` | controller state only; read-only mesh UI | istio, tailscale, prometheus, grafana |
-| `compass` | `monitoring` | `clusters/homelab/apps/compass` | `IaC/live/argocd-apps/compass` | stateless Kubernetes service discovery dashboard with tailnet-only UI from the `ghcr.io/adinhodovic/charts` OCI Helm source | cert-manager, istio, tailscale, prometheus |
+| `compass` | `monitoring` | `clusters/homelab/apps/compass` | `IaC/live/argocd-apps/compass` | stateless Kubernetes service discovery dashboard with Octelium service-name launch links and fallback tailnet UI from the `ghcr.io/adinhodovic/charts` OCI Helm source | cert-manager, istio, tailscale, prometheus |
 | `descheduler` | `kube-system` | `clusters/homelab/apps/descheduler` | `IaC/live/argocd-apps/descheduler` | controller state only | prometheus |
 | `deluge` | `media` | `clusters/homelab/apps/deluge` | `IaC/live/argocd-apps/deluge` | persistent config on `nfs-default`; shared downloads on QNAP `/media`; SSM-backed WireGuard profile via `deluge-vpn` | cert-manager, istio, tailscale, platform-storage |
 | `prowlarr` | `media` | `clusters/homelab/apps/prowlarr` | `IaC/live/argocd-apps/prowlarr` | persistent config and PostgreSQL databases | cert-manager, istio, media-postgres, tailscale, platform-storage |
@@ -43,7 +44,7 @@ trading workload with a tailnet-only UI.
 | `openclaw` | `ai` | `clusters/homelab/apps/openclaw` | `IaC/live/argocd-apps/openclaw` | persistent runtime state, SSM-backed gateway auth, Discord channel config, SSM-backed GitHub App credentials, Codex OAuth credentials on PVC, and explicit agent resource profile | external-secrets, cert-manager, istio, tailscale, litellm, platform-storage |
 | `n8n` | `automation` | `clusters/homelab/apps/n8n` | `IaC/live/argocd-apps/n8n` | persistent workflows, credential metadata, users, and execution history in n8n-postgres; instance settings and file-backed runtime data on PVC; SSM key bootstraps fresh PVCs only; public Funnel is limited to webhook prefixes | external-secrets, cert-manager, istio, tailscale, platform-storage, n8n-postgres |
 | `policy-bot` | `automation` | `clusters/homelab/apps/policy-bot` | `IaC/live/argocd-apps/policy-bot` | stateless GitHub App policy evaluator; one replica after SSM placeholders are replaced | external-secrets, cert-manager, istio, tailscale |
-| `octobot` | `finance` | `clusters/homelab/apps/octobot` | `IaC/live/argocd-apps/octobot` | UI-configured bot state, tentacles, exchange credentials after operator setup, logs, and tailnet-only UI route | cert-manager, istio, tailscale, platform-storage |
+| `octobot` | `finance` | `clusters/homelab/apps/octobot` | `IaC/live/argocd-apps/octobot` | UI-configured bot state, tentacles, exchange credentials after operator setup, logs, and Octelium-targeted UI access with tailnet fallback until the e2e gate passes | cert-manager, istio, tailscale, platform-storage |
 
 ## Mesh Policy Summary
 

--- a/docs/networking-tailnet-ingress.md
+++ b/docs/networking-tailnet-ingress.md
@@ -1,27 +1,25 @@
 # Tailnet Ingress
 
-Istio is the reverse proxy for tailnet app access. Tailscale is the
-reachability layer. Most routes are internal-only; public Tailscale Funnel is
-reserved for reviewed webhook paths that must be reachable by external SaaS
-systems.
-
-Octelium is documented separately in `docs/octelium.md` as a parallel client
-bridge for the same private homelab service set. It does not replace the
-Tailscale operator, tailnet gateway, Funnel exceptions, or homelab exit node in
-this runbook.
+Octelium is the target access plane for human access to homelab apps. The
+Tailscale-backed Istio gateway remains the fallback route until
+`scripts/octelium-e2e-check.sh` proves that the Octelium Cluster, service
+catalog, connector, and client tunnel all work end to end. Public Tailscale
+Funnel remains reserved for reviewed webhook paths that must be reachable by
+external SaaS systems until those callbacks are explicitly redesigned.
 
 ## Initial DNS Assumption
 
-The repository expects one initial DNS or tailnet naming setup that covers all
-internal app routes. For this homelab, `*.stinkyboi.com` must resolve to the
-Tailscale-exposed Istio ingress address from tailnet clients. This feature does
-not add or edit public DNS records after that initial setup.
+The repository still has one fallback DNS or tailnet naming setup that covers
+the old internal app routes. For this homelab, `*.stinkyboi.com` resolves to
+the Tailscale-exposed Istio ingress address from tailnet clients until Octelium
+passes the cutover gate. This feature does not add or edit public DNS records
+after that initial setup.
 
 Because no DNS provider resources are added in this repository, external DNS
 infrastructure is unaffected by this change. If DNS becomes repo-managed later,
 that must be added through a separate Terragrunt/OpenTofu entry point.
 
-## First-Rollout Route Inventory
+## Fallback Route Inventory
 
 | App | HTTPS host | Public Funnel |
 |-----|------------------|---------------|
@@ -59,7 +57,8 @@ n8n now adds a reviewed Funnel exception for workflow webhook delivery. The
 annotated with `homelab.rst.io/public-funnel: "true"` and
 `homelab.rst.io/public-funnel-reviewed: "true"`; the Policy Bot UI and n8n
 editor routes remain private. Every other Istio gateway and VirtualService
-route manifest remains tailnet-only.
+route manifest is fallback app access only until Octelium e2e validation
+passes.
 
 The Istio ingressgateway Service is a Tailscale `LoadBalancer` and sets
 `allocateLoadBalancerNodePorts: false` so the gateway is not exposed through
@@ -75,21 +74,23 @@ and rollback path.
 
 Octelium serves the private app set through
 `docs/examples/octelium/homelab-services.yaml` with service names in the
-`homelab` Octelium namespace. Keep public Funnel exceptions and Octelium
-Services separate: the n8n and Policy Bot webhook paths remain Tailscale Funnel
-exceptions unless a later PR explicitly redesigns those callbacks through
-Octelium.
+`homelab` Octelium namespace. The old app `VirtualService` objects and the
+Tailscale-backed Istio `LoadBalancer` are removable only after
+`scripts/octelium-e2e-check.sh` passes. Keep public Funnel exceptions and
+Octelium Services separate: the n8n and Policy Bot webhook paths remain
+Tailscale Funnel exceptions unless a later PR explicitly redesigns those
+callbacks through Octelium.
 
-OctoBot exposes its UI only through the tailnet Istio route at
-`https://octobot.stinkyboi.com`. The route is intended for private setup,
+OctoBot currently has a fallback UI route at `https://octobot.stinkyboi.com`.
+After Octelium cutover, use `octobot.homelab` through Octelium for private setup,
 paper trading, and operator-reviewed live trading; exchange credentials and
 strategy state are configured through OctoBot and persist on its NFS-backed
 volumes, not in public repository files.
 
-Compass exposes the service catalog only through the tailnet Istio route at
-`https://compass.stinkyboi.com`. It discovers Kubernetes ingress and Gateway API
-routes with read-only RBAC, disables operator debug routes, and does not persist
-application state.
+Compass currently has a fallback route at `https://compass.stinkyboi.com`, but
+its launch links and discovery-only entries point at Octelium service names. It
+discovers Kubernetes ingress and Gateway API routes with read-only RBAC,
+disables operator debug routes, and does not persist application state.
 
 Because the homelab's reviewed ingress path is still Istio `VirtualService`,
 Compass also owns discovery-only `Ingress` resources in the `monitoring`
@@ -154,8 +155,9 @@ Data exposed: webhook request body and headers sent by GitHub.
 ```
 
 The Policy Bot UI, details routes, static assets, OAuth callback, and root path
-stay on `https://policy-bot.stinkyboi.com` through the tailnet-only Istio
-gateway. Only `/api/github/hook` is exposed through Funnel.
+target `policy-bot.homelab` through Octelium after cutover. The
+`https://policy-bot.stinkyboi.com` tailnet Istio route remains fallback until
+the Octelium gate passes. Only `/api/github/hook` is exposed through Funnel.
 
 ## n8n Webhook Funnel Exception
 
@@ -173,9 +175,10 @@ Rollback command: revert clusters/homelab/apps/n8n/ingress-funnel.yaml, clusters
 Data exposed: request bodies and headers sent to active n8n webhook workflows.
 ```
 
-The n8n editor, REST API, static assets, and root path stay on
-`https://n8n.stinkyboi.com` through the tailnet-only Istio gateway. The Funnel
-Ingress forwards only webhook path prefixes to the Istio gateway, and the n8n
+The n8n editor, REST API, static assets, and root path target `n8n.homelab`
+through Octelium after cutover. The `https://n8n.stinkyboi.com` tailnet Istio
+route remains fallback until the Octelium gate passes. The Funnel Ingress
+forwards only webhook path prefixes to the Istio gateway, and the n8n
 VirtualService only routes those prefixes on the public webhook gateway.
 
 ## Future Funnel Webhook Exception Template

--- a/docs/octelium.md
+++ b/docs/octelium.md
@@ -99,6 +99,16 @@ Run the e2e gate before removing any old Tailscale-backed app route:
 scripts/octelium-e2e-check.sh
 ```
 
+If the Octelium control plane is external to the homelab cluster, pass separate
+Kubernetes contexts so control-plane checks run against the Octelium Cluster and
+connector checks run against homelab:
+
+```sh
+scripts/octelium-e2e-check.sh \
+  --octelium-context <octelium-cluster-context> \
+  --homelab-context <homelab-context>
+```
+
 The gate verifies:
 
 - the Octelium control-plane namespace and services exist;
@@ -248,7 +258,9 @@ After activation with `replicaCount: 1`:
 kubectl -n octelium-client get externalsecret,secret octelium-client-auth
 kubectl -n octelium-client get deploy,pod -l app.kubernetes.io/instance=octelium-client
 kubectl -n octelium-client logs deploy/octelium-client
-scripts/octelium-e2e-check.sh
+scripts/octelium-e2e-check.sh \
+  --octelium-context <octelium-cluster-context> \
+  --homelab-context <homelab-context>
 ```
 
 Check the in-cluster demo locally:

--- a/docs/octelium.md
+++ b/docs/octelium.md
@@ -1,10 +1,14 @@
 # Octelium Client Bridge
 
-This repository prepares Octelium as a parallel secure-access path without removing
-Tailscale. Tailscale remains the active tailnet ingress and homelab exit-node
-layer; Octelium is modeled as a client connector that can serve selected
-in-cluster services to an external Octelium Cluster once the external API and
-workload credential are verified.
+This repository prepares Octelium to replace Tailscale for human access to
+homelab applications. Tailscale remains the temporary fallback for app routes
+until the Octelium Cluster, service catalog, workload credential, connector, and
+client tunnel all pass the e2e gate in `scripts/octelium-e2e-check.sh`.
+
+The Tailscale operator can still have non-app responsibilities, such as CI
+cluster reachability or reviewed public webhook exceptions, until those are
+separately replaced. Do not remove the current tailnet app routes before the
+Octelium e2e check passes.
 
 ## Current Model
 
@@ -20,7 +24,8 @@ The Kubernetes namespace is `octelium-client`. It contains:
 - `octelium-client-auth`, an ExternalSecret that reads
   `/homelab/octelium/client-auth-token`.
 - `octelium-client`, the Helm-managed Octelium client Deployment prepared with
-  `replicaCount: 0` until activation.
+  `replicaCount: 0` until the Octelium API serves real traffic and the catalog
+  credential has been stored in SSM.
 - `octelium-demo`, a small Podinfo HTTP service exposed only as a ClusterIP.
 - `octelium-demo-allow-client`, a NetworkPolicy that allows only the Octelium
   client pod to call the demo service once a policy-enforcing CNI exists.
@@ -86,6 +91,31 @@ aws ssm put-parameter \
   --value '<authentication-token>'
 ```
 
+## Cutover Gate
+
+Run the e2e gate before removing any old Tailscale-backed app route:
+
+```sh
+scripts/octelium-e2e-check.sh
+```
+
+The gate verifies:
+
+- the Octelium control-plane namespace and services exist;
+- `octelium-client-auth` is synced from SSM;
+- `octelium-client` has at least one ready replica;
+- `octelium.stinkyboi.com`, `portal.octelium.stinkyboi.com`, and
+  `octelium-api.octelium.stinkyboi.com` are not generic Istio `404` responses;
+- every homelab WEB Service in `docs/examples/octelium/homelab-services.yaml`
+  exists in the Octelium Cluster;
+- a client tunnel can reach `homelab-demo.homelab`.
+
+When it passes, remove the old application `VirtualService` objects that point
+at `istio-system/tailnet-gateway`, remove the Tailscale-backed Istio
+`LoadBalancer` path for app UI access, and keep only separately reviewed
+non-app exceptions such as webhooks or CI cluster access. If it fails, treat the
+failure output as the cutover work queue.
+
 ## Bootstrap UI Access
 
 The Octelium Cluster domain for this homelab is `octelium.stinkyboi.com`.
@@ -134,8 +164,10 @@ curl -vI https://octelium-api.octelium.stinkyboi.com
 
 The TLS certificate must match `octelium-api.octelium.stinkyboi.com`, and the
 endpoint must be the Octelium API rather than a generic Istio `404` or gRPC
-`Unimplemented` response. Once that is true, set `replicaCount` to `1` in
-`clusters/homelab/apps/octelium/values.yaml` in a follow-up PR.
+`Unimplemented` response. Once that is true and the
+`homelab-octelium-client` credential is stored in SSM, set `replicaCount` to
+`1` in `clusters/homelab/apps/octelium/values.yaml`, sync the `octelium` Argo
+CD Application, then run `scripts/octelium-e2e-check.sh`.
 
 ## Octelium Enterprise Package
 
@@ -178,12 +210,13 @@ scripts/octelium-enterprise-package.sh \
 Use `--kubeconfig <path>` when the Octelium Cluster kubeconfig is not the
 default kubeconfig for the operator shell.
 
-## Why Not A Full Cluster Yet
+## Full Cluster Bootstrap Requirements
 
 Octelium's production install path for an existing Kubernetes cluster uses
 `octops init`, labels data-plane and control-plane nodes, requires Multus CNI,
 and needs PostgreSQL, Redis, public DNS, and a wildcard-capable TLS certificate.
-Those are real platform decisions, not a small Helm app.
+Those are real platform decisions, not a small Helm app. The current cluster
+does not yet have a repo-owned full Octelium control-plane bootstrap.
 
 Before self-hosting the Octelium Cluster inside this homelab, add a separate
 design PR that models:
@@ -206,6 +239,7 @@ helm template octelium-client oci://ghcr.io/octelium/helm-charts/octelium \
   --namespace octelium-client \
   -f clusters/homelab/apps/octelium/values.yaml
 scripts/octelium-enterprise-package.sh --help
+scripts/octelium-e2e-check.sh --help
 ```
 
 After activation with `replicaCount: 1`:
@@ -214,6 +248,7 @@ After activation with `replicaCount: 1`:
 kubectl -n octelium-client get externalsecret,secret octelium-client-auth
 kubectl -n octelium-client get deploy,pod -l app.kubernetes.io/instance=octelium-client
 kubectl -n octelium-client logs deploy/octelium-client
+scripts/octelium-e2e-check.sh
 ```
 
 Check the in-cluster demo locally:

--- a/docs/runtime-isolation.md
+++ b/docs/runtime-isolation.md
@@ -14,8 +14,8 @@ than a reliable isolation control.
 
 Current enforced controls are therefore:
 
-- tailnet-only Istio ingress routes reviewed in
-  `docs/networking-tailnet-ingress.md`;
+- fallback Istio ingress routes reviewed in `docs/networking-tailnet-ingress.md`
+  while the Octelium cutover gate is still failing;
 - workload-scoped Istio policy only where the namespace is explicitly
   mesh-enrolled and the gateway path is proven to keep working;
 - namespace Pod Security labels that are explicit in repo-owned namespace
@@ -47,22 +47,22 @@ The current service access contract is:
 
 | Destination workload | Namespace | Allowed source principal | Reason |
 |----------------------|-----------|--------------------------|--------|
-| `litellm` | `ai` | `cluster.local/ns/istio-system/sa/istio-ingressgateway` | Tailnet UI/API ingress. |
+| `litellm` | `ai` | `cluster.local/ns/istio-system/sa/istio-ingressgateway` | Fallback tailnet UI/API ingress. |
 | `litellm` | `ai` | `cluster.local/ns/ai/sa/openclaw` | OpenClaw model gateway calls. |
 | `litellm` | `ai` | `cluster.local/ns/octelium-client/sa/octelium-client` | Octelium private service bridge. |
-| `openclaw` | `ai` | `cluster.local/ns/istio-system/sa/istio-ingressgateway` | Tailnet UI ingress. |
+| `openclaw` | `ai` | `cluster.local/ns/istio-system/sa/istio-ingressgateway` | Fallback tailnet UI ingress. |
 | `openclaw` | `ai` | `cluster.local/ns/octelium-client/sa/octelium-client` | Octelium private service bridge. |
 | `openclaw` | `ai` | `cluster.local/ns/monitoring/sa/prometheus-kube-prometheus-alertmanager` | Alertmanager direct `/hooks/agent` delivery. |
-| `n8n` | `automation` | `cluster.local/ns/istio-system/sa/istio-ingressgateway` | Tailnet UI ingress and reviewed n8n webhook Funnel traffic forwarded through the Istio gateway. |
+| `n8n` | `automation` | `cluster.local/ns/istio-system/sa/istio-ingressgateway` | Fallback tailnet UI ingress and reviewed n8n webhook Funnel traffic forwarded through the Istio gateway. |
 | `n8n` | `automation` | `cluster.local/ns/octelium-client/sa/octelium-client` | Octelium private service bridge. |
-| `grafana` | `monitoring` | `cluster.local/ns/istio-system/sa/istio-ingressgateway` | Tailnet UI ingress. |
+| `grafana` | `monitoring` | `cluster.local/ns/istio-system/sa/istio-ingressgateway` | Fallback tailnet UI ingress. |
 | `grafana` | `monitoring` | `cluster.local/ns/monitoring/sa/kiali-service-account` | Kiali dashboard links and health checks. |
 | `grafana` | `monitoring` | `cluster.local/ns/monitoring/sa/prometheus-kube-prometheus-prometheus` | Prometheus scrapes Grafana metrics. |
 | `grafana` | `monitoring` | `cluster.local/ns/octelium-client/sa/octelium-client` | Octelium private service bridge. |
-| `kiali` | `monitoring` | `cluster.local/ns/istio-system/sa/istio-ingressgateway` | Tailnet UI ingress. |
+| `kiali` | `monitoring` | `cluster.local/ns/istio-system/sa/istio-ingressgateway` | Fallback tailnet UI ingress. |
 | `kiali` | `monitoring` | `cluster.local/ns/monitoring/sa/prometheus-kube-prometheus-prometheus` | Prometheus scrape or health access. |
 | `kiali` | `monitoring` | `cluster.local/ns/octelium-client/sa/octelium-client` | Octelium private service bridge. |
-| `compass` | `monitoring` | `cluster.local/ns/istio-system/sa/istio-ingressgateway` | Tailnet UI ingress. |
+| `compass` | `monitoring` | `cluster.local/ns/istio-system/sa/istio-ingressgateway` | Fallback tailnet UI ingress. |
 | `compass` | `monitoring` | `cluster.local/ns/monitoring/sa/prometheus-kube-prometheus-prometheus` | Prometheus scrape access. |
 | `compass` | `monitoring` | `cluster.local/ns/octelium-client/sa/octelium-client` | Octelium private service bridge. |
 | `prometheus` | `monitoring` | `cluster.local/ns/monitoring/sa/grafana` | Grafana Prometheus datasource queries. |
@@ -90,9 +90,9 @@ Ambient is intentionally not enabled for:
 - `media`, because Deluge Gluetun/WireGuard and the current media app traffic
   model still need a repo-owned waypoint or equivalent policy design before
   re-enrollment;
-- `finance`, because OctoBot is exposed only through a tailnet UI route today
-  and needs a separate identity-policy design before any service-to-service or
-  trading API control path is mesh-enrolled;
+- `finance`, because OctoBot has only a fallback tailnet UI route until the
+  Octelium gate passes and needs a separate identity-policy design before any
+  service-to-service or trading API control path is mesh-enrolled;
 - `argocd`, `cert-manager`, `external-secrets`, and `storage`, because their
   API server, webhook, NFS, and controller paths need separate validation;
 - `istio-system` and `tailscale`, because they are privileged networking

--- a/docs/secrets-aws-ssm.md
+++ b/docs/secrets-aws-ssm.md
@@ -154,8 +154,8 @@ a normal GitOps rollout.
 
 Octelium reads `/homelab/octelium/client-auth-token` through
 `octelium-client-auth` as the workload authentication token for the
-`homelab-octelium-client` User in the external Octelium Cluster. Keep the
-token out of git; after replacing the placeholder directly in SSM, bump
+`homelab-octelium-client` User in the Octelium Cluster. Keep the token out of
+git; after replacing the placeholder directly in SSM, bump
 `homelab.rst.io/octelium-credential-ssm-version` in
 `clusters/homelab/apps/octelium/externalsecret.yaml` if External Secrets needs
 to reread the value.

--- a/docs/validation-runbook.md
+++ b/docs/validation-runbook.md
@@ -67,7 +67,7 @@ argocd app get platform-dns
 argocd app get platform-storage
 ```
 
-For Kiali, verify the operator-created custom resource and tailnet UI:
+For Kiali, verify the operator-created custom resource and current fallback UI:
 
 ```sh
 kubectl -n monitoring get kiali kiali
@@ -75,9 +75,22 @@ kubectl -n monitoring get deploy,svc kiali
 curl -I https://kiali.stinkyboi.com
 ```
 
-Expected result: the Kiali Application is synced and healthy, the Kiali custom
-resource is successfully reconciled, and the tailnet HTTPS route reaches the
-read-only UI.
+Expected result before the Octelium cutover gate passes: the Kiali Application
+is synced and healthy, the Kiali custom resource is successfully reconciled,
+and the fallback tailnet HTTPS route reaches the read-only UI.
+
+For Octelium app-access cutover, run the e2e gate before removing any
+Tailscale-backed app route:
+
+```sh
+scripts/octelium-e2e-check.sh
+```
+
+Expected result: the Octelium control plane exists, `octelium-client` has a
+ready replica, the Cluster/API/portal hostnames are serving Octelium instead of
+generic Istio 404 responses, every homelab WEB Service is present in the
+Octelium catalog, and `homelab-demo.homelab` is reachable through an Octelium
+client tunnel.
 
 For image automation, confirm the controller and selector CR exist before
 relying on update pull requests:
@@ -132,9 +145,9 @@ to PostgreSQL.
 
 n8n webhooks use the reviewed Tailscale Funnel route at
 `https://n8n-webhook.tail67beb.ts.net`. After sync, verify the Tailscale
-Ingress and operator proxy exist, then check that the editor host remains on
-the tailnet-only route and the public host only reaches n8n under webhook path
-prefixes:
+Ingress and operator proxy exist, then check that the fallback editor host still
+works until the Octelium gate passes and the public host only reaches n8n under
+webhook path prefixes:
 
 ```sh
 kubectl -n istio-system get gateway,ingress n8n-webhook-funnel

--- a/docs/validation-runbook.md
+++ b/docs/validation-runbook.md
@@ -86,6 +86,10 @@ Tailscale-backed app route:
 scripts/octelium-e2e-check.sh
 ```
 
+Use `--octelium-context <octelium-cluster-context>` and
+`--homelab-context <homelab-context>` when those are separate Kubernetes
+clusters.
+
 Expected result: the Octelium control plane exists, `octelium-client` has a
 ready replica, the Cluster/API/portal hostnames are serving Octelium instead of
 generic Istio 404 responses, every homelab WEB Service is present in the

--- a/scripts/octelium-e2e-check.sh
+++ b/scripts/octelium-e2e-check.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DOMAIN="octelium.stinkyboi.com"
+CLIENT_NAMESPACE="octelium-client"
+CONTROL_NAMESPACE="octelium"
+CATALOG="docs/examples/octelium/homelab-services.yaml"
+TEST_SERVICE="homelab-demo.homelab"
+TEST_PATH="/version"
+LOCAL_PORT="18081"
+OCTELIUMCTL_TIMEOUT_SECONDS=20
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/octelium-e2e-check.sh [options]
+
+Validate that Octelium has fully replaced Tailscale for homelab app access.
+The check requires a running Octelium Cluster, an applied homelab service
+catalog, an active octelium-client connector, and a working client tunnel.
+
+Options:
+  --domain DOMAIN             Octelium Cluster domain. Default: octelium.stinkyboi.com
+  --catalog PATH              Octelium catalog file. Default: docs/examples/octelium/homelab-services.yaml
+  --service NAME              Service to tunnel for the final probe. Default: homelab-demo.homelab
+  --path PATH                 HTTP path to probe through the tunnel. Default: /version
+  --local-port PORT           Local port for the tunnel. Default: 18081
+  -h, --help                  Show this help.
+USAGE
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --domain)
+      DOMAIN="$2"
+      shift 2
+      ;;
+    --catalog)
+      CATALOG="$2"
+      shift 2
+      ;;
+    --service)
+      TEST_SERVICE="$2"
+      shift 2
+      ;;
+    --path)
+      TEST_PATH="$2"
+      shift 2
+      ;;
+    --local-port)
+      LOCAL_PORT="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+API_HOST="octelium-api.${DOMAIN}"
+PORTAL_HOST="portal.${DOMAIN}"
+
+REQUIRED_SERVICES="
+argocd.homelab
+compass.homelab
+deluge.homelab
+grafana.homelab
+homelab-demo.homelab
+kiali.homelab
+litellm.homelab
+n8n.homelab
+octobot.homelab
+openclaw.homelab
+policy-bot.homelab
+prowlarr.homelab
+radarr.homelab
+sonarr.homelab
+"
+
+FAILURES=0
+CONNECT_PID=""
+
+note() {
+  printf '==> %s\n' "$*"
+}
+
+pass() {
+  printf 'PASS: %s\n' "$*"
+}
+
+fail() {
+  FAILURES=$((FAILURES + 1))
+  printf 'FAIL: %s\n' "$*" >&2
+}
+
+require_command() {
+  if command -v "$1" >/dev/null 2>&1; then
+    pass "found $1"
+  else
+    fail "missing required command: $1"
+  fi
+}
+
+run_with_timeout() {
+  timeout_seconds="$1"
+  shift
+
+  "$@" &
+  command_pid="$!"
+  elapsed_seconds=0
+
+  while kill -0 "${command_pid}" >/dev/null 2>&1; do
+    if [ "${elapsed_seconds}" -ge "${timeout_seconds}" ]; then
+      kill "${command_pid}" >/dev/null 2>&1 || true
+      wait "${command_pid}" >/dev/null 2>&1 || true
+      return 124
+    fi
+    sleep 1
+    elapsed_seconds=$((elapsed_seconds + 1))
+  done
+
+  wait "${command_pid}"
+}
+
+cleanup() {
+  if [ -n "${CONNECT_PID}" ]; then
+    kill "${CONNECT_PID}" >/dev/null 2>&1 || true
+    wait "${CONNECT_PID}" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+note "Checking local tools"
+require_command kubectl
+require_command curl
+require_command octelium
+require_command octeliumctl
+
+if [ "${FAILURES}" -gt 0 ]; then
+  echo "Cannot continue without required local tools." >&2
+  exit 1
+fi
+
+note "Checking Kubernetes control-plane and connector state"
+if kubectl get namespace "${CONTROL_NAMESPACE}" >/dev/null 2>&1; then
+  pass "Octelium control namespace exists: ${CONTROL_NAMESPACE}"
+else
+  fail "Octelium control namespace is missing: ${CONTROL_NAMESPACE}"
+fi
+
+CONTROL_SERVICES="$(kubectl -n "${CONTROL_NAMESPACE}" get svc -o name 2>/dev/null || true)"
+if [ -n "${CONTROL_SERVICES}" ]; then
+  pass "Octelium control-plane services are visible"
+else
+  fail "Octelium control-plane services are not visible"
+fi
+
+if kubectl get namespace "${CLIENT_NAMESPACE}" >/dev/null 2>&1; then
+  pass "Octelium client namespace exists: ${CLIENT_NAMESPACE}"
+else
+  fail "Octelium client namespace is missing: ${CLIENT_NAMESPACE}"
+fi
+
+if kubectl -n "${CLIENT_NAMESPACE}" get externalsecret octelium-client-auth >/dev/null 2>&1; then
+  READY="$(kubectl -n "${CLIENT_NAMESPACE}" get externalsecret octelium-client-auth -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')"
+  if [ "${READY}" = "True" ]; then
+    pass "octelium-client-auth ExternalSecret is Ready"
+  else
+    fail "octelium-client-auth ExternalSecret is not Ready"
+  fi
+else
+  fail "octelium-client-auth ExternalSecret is missing"
+fi
+
+if kubectl -n "${CLIENT_NAMESPACE}" get secret octelium-client-auth >/dev/null 2>&1; then
+  pass "octelium-client-auth Secret exists"
+else
+  fail "octelium-client-auth Secret is missing"
+fi
+
+if kubectl -n "${CLIENT_NAMESPACE}" get deploy octelium-client >/dev/null 2>&1; then
+  REPLICAS="$(kubectl -n "${CLIENT_NAMESPACE}" get deploy octelium-client -o jsonpath='{.spec.replicas}')"
+  READY_REPLICAS="$(kubectl -n "${CLIENT_NAMESPACE}" get deploy octelium-client -o jsonpath='{.status.readyReplicas}')"
+  READY_REPLICAS="${READY_REPLICAS:-0}"
+  if [ "${REPLICAS}" -ge 1 ] && [ "${READY_REPLICAS}" -ge 1 ]; then
+    pass "octelium-client Deployment is active (${READY_REPLICAS}/${REPLICAS})"
+  else
+    fail "octelium-client Deployment is not active (${READY_REPLICAS}/${REPLICAS})"
+  fi
+else
+  fail "octelium-client Deployment is missing"
+fi
+
+note "Checking Octelium TLS/API endpoints"
+for HOST in "${DOMAIN}" "${PORTAL_HOST}" "${API_HOST}"; do
+  HEADER_FILE="$(mktemp "${TMPDIR:-/tmp}/octelium-headers.XXXXXX")"
+  HTTP_CODE="$(curl -sS -I --max-time 15 -o "${HEADER_FILE}" -w '%{http_code}' "https://${HOST}" || true)"
+  SERVER="$(awk 'tolower($1) == "server:" {print $2}' "${HEADER_FILE}" | tr -d '\r' | tail -1)"
+  rm -f "${HEADER_FILE}"
+  case "${HTTP_CODE}" in
+    200|204|301|302|307|308|401|403|405)
+      pass "https://${HOST} responded with HTTP ${HTTP_CODE}"
+      ;;
+    404)
+      if [ "${SERVER}" = "istio-envoy" ]; then
+        fail "https://${HOST} is still a generic Istio 404, not Octelium"
+      else
+        fail "https://${HOST} returned HTTP 404"
+      fi
+      ;;
+    000|"")
+      fail "https://${HOST} did not respond"
+      ;;
+    *)
+      fail "https://${HOST} returned unexpected HTTP ${HTTP_CODE}"
+      ;;
+  esac
+done
+
+note "Checking Octelium service catalog"
+if [ ! -f "${CATALOG}" ]; then
+  fail "catalog file is missing: ${CATALOG}"
+else
+  pass "catalog file exists: ${CATALOG}"
+fi
+
+if run_with_timeout "${OCTELIUMCTL_TIMEOUT_SECONDS}" octeliumctl get service --domain "${DOMAIN}" >/tmp/octelium-services.$$ 2>/tmp/octelium-services.err.$$; then
+  for SERVICE in ${REQUIRED_SERVICES}; do
+    if grep -F "${SERVICE}" /tmp/octelium-services.$$ >/dev/null 2>&1; then
+      pass "Octelium Service exists: ${SERVICE}"
+    else
+      fail "Octelium Service is missing: ${SERVICE}"
+    fi
+  done
+else
+  if [ -s /tmp/octelium-services.err.$$ ]; then
+    fail "octeliumctl could not list services for ${DOMAIN}: $(tr '\n' ' ' </tmp/octelium-services.err.$$)"
+  else
+    fail "octeliumctl could not list services for ${DOMAIN} within ${OCTELIUMCTL_TIMEOUT_SECONDS}s"
+  fi
+fi
+rm -f /tmp/octelium-services.$$ /tmp/octelium-services.err.$$
+
+note "Checking client tunnel to ${TEST_SERVICE}"
+octelium connect --domain "${DOMAIN}" -p "${TEST_SERVICE}:${LOCAL_PORT}" >/tmp/octelium-connect.$$ 2>/tmp/octelium-connect.err.$$ &
+CONNECT_PID="$!"
+
+TUNNEL_READY=0
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  if curl -fsS --max-time 3 "http://127.0.0.1:${LOCAL_PORT}${TEST_PATH}" >/tmp/octelium-e2e-response.$$ 2>/tmp/octelium-e2e-curl.err.$$; then
+    TUNNEL_READY=1
+    break
+  fi
+  if ! kill -0 "${CONNECT_PID}" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 2
+done
+
+if [ "${TUNNEL_READY}" -eq 1 ]; then
+  pass "tunneled ${TEST_SERVICE}${TEST_PATH} through Octelium on localhost:${LOCAL_PORT}"
+else
+  fail "could not tunnel ${TEST_SERVICE}${TEST_PATH}; connect log: $(tr '\n' ' ' </tmp/octelium-connect.err.$$)"
+fi
+rm -f /tmp/octelium-connect.$$ /tmp/octelium-connect.err.$$ /tmp/octelium-e2e-response.$$ /tmp/octelium-e2e-curl.err.$$
+
+if [ "${FAILURES}" -gt 0 ]; then
+  echo "Octelium e2e check failed with ${FAILURES} failure(s)." >&2
+  exit 1
+fi
+
+echo "Octelium e2e check passed."

--- a/scripts/octelium-e2e-check.sh
+++ b/scripts/octelium-e2e-check.sh
@@ -9,6 +9,10 @@ TEST_SERVICE="homelab-demo.homelab"
 TEST_PATH="/version"
 LOCAL_PORT="18081"
 OCTELIUMCTL_TIMEOUT_SECONDS=20
+HOMELAB_KUBECONFIG=""
+HOMELAB_CONTEXT=""
+OCTELIUM_KUBECONFIG=""
+OCTELIUM_CONTEXT=""
 
 usage() {
   cat <<'USAGE'
@@ -24,6 +28,10 @@ Options:
   --service NAME              Service to tunnel for the final probe. Default: homelab-demo.homelab
   --path PATH                 HTTP path to probe through the tunnel. Default: /version
   --local-port PORT           Local port for the tunnel. Default: 18081
+  --homelab-kubeconfig PATH   Kubeconfig for the homelab cluster. Default: kubectl default
+  --homelab-context NAME      Kube context for homelab connector checks. Default: kubectl current context
+  --octelium-kubeconfig PATH  Kubeconfig for the Octelium control-plane cluster. Default: kubectl default
+  --octelium-context NAME     Kube context for Octelium control-plane checks. Default: kubectl current context
   -h, --help                  Show this help.
 USAGE
 }
@@ -48,6 +56,22 @@ while [ "$#" -gt 0 ]; do
       ;;
     --local-port)
       LOCAL_PORT="$2"
+      shift 2
+      ;;
+    --homelab-kubeconfig)
+      HOMELAB_KUBECONFIG="$2"
+      shift 2
+      ;;
+    --homelab-context)
+      HOMELAB_CONTEXT="$2"
+      shift 2
+      ;;
+    --octelium-kubeconfig)
+      OCTELIUM_KUBECONFIG="$2"
+      shift 2
+      ;;
+    --octelium-context)
+      OCTELIUM_CONTEXT="$2"
       shift 2
       ;;
     -h|--help)
@@ -106,6 +130,30 @@ require_command() {
   fi
 }
 
+kubectl_homelab() {
+  local kubectl_args=()
+  if [ -n "${HOMELAB_KUBECONFIG}" ]; then
+    kubectl_args+=(--kubeconfig "${HOMELAB_KUBECONFIG}")
+  fi
+  if [ -n "${HOMELAB_CONTEXT}" ]; then
+    kubectl_args+=(--context "${HOMELAB_CONTEXT}")
+  fi
+
+  kubectl "${kubectl_args[@]}" "$@"
+}
+
+kubectl_octelium() {
+  local kubectl_args=()
+  if [ -n "${OCTELIUM_KUBECONFIG}" ]; then
+    kubectl_args+=(--kubeconfig "${OCTELIUM_KUBECONFIG}")
+  fi
+  if [ -n "${OCTELIUM_CONTEXT}" ]; then
+    kubectl_args+=(--context "${OCTELIUM_CONTEXT}")
+  fi
+
+  kubectl "${kubectl_args[@]}" "$@"
+}
+
 run_with_timeout() {
   timeout_seconds="$1"
   shift
@@ -147,27 +195,27 @@ if [ "${FAILURES}" -gt 0 ]; then
 fi
 
 note "Checking Kubernetes control-plane and connector state"
-if kubectl get namespace "${CONTROL_NAMESPACE}" >/dev/null 2>&1; then
+if kubectl_octelium get namespace "${CONTROL_NAMESPACE}" >/dev/null 2>&1; then
   pass "Octelium control namespace exists: ${CONTROL_NAMESPACE}"
 else
   fail "Octelium control namespace is missing: ${CONTROL_NAMESPACE}"
 fi
 
-CONTROL_SERVICES="$(kubectl -n "${CONTROL_NAMESPACE}" get svc -o name 2>/dev/null || true)"
+CONTROL_SERVICES="$(kubectl_octelium -n "${CONTROL_NAMESPACE}" get svc -o name 2>/dev/null || true)"
 if [ -n "${CONTROL_SERVICES}" ]; then
   pass "Octelium control-plane services are visible"
 else
   fail "Octelium control-plane services are not visible"
 fi
 
-if kubectl get namespace "${CLIENT_NAMESPACE}" >/dev/null 2>&1; then
+if kubectl_homelab get namespace "${CLIENT_NAMESPACE}" >/dev/null 2>&1; then
   pass "Octelium client namespace exists: ${CLIENT_NAMESPACE}"
 else
   fail "Octelium client namespace is missing: ${CLIENT_NAMESPACE}"
 fi
 
-if kubectl -n "${CLIENT_NAMESPACE}" get externalsecret octelium-client-auth >/dev/null 2>&1; then
-  READY="$(kubectl -n "${CLIENT_NAMESPACE}" get externalsecret octelium-client-auth -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')"
+if kubectl_homelab -n "${CLIENT_NAMESPACE}" get externalsecret octelium-client-auth >/dev/null 2>&1; then
+  READY="$(kubectl_homelab -n "${CLIENT_NAMESPACE}" get externalsecret octelium-client-auth -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')"
   if [ "${READY}" = "True" ]; then
     pass "octelium-client-auth ExternalSecret is Ready"
   else
@@ -177,15 +225,15 @@ else
   fail "octelium-client-auth ExternalSecret is missing"
 fi
 
-if kubectl -n "${CLIENT_NAMESPACE}" get secret octelium-client-auth >/dev/null 2>&1; then
+if kubectl_homelab -n "${CLIENT_NAMESPACE}" get secret octelium-client-auth >/dev/null 2>&1; then
   pass "octelium-client-auth Secret exists"
 else
   fail "octelium-client-auth Secret is missing"
 fi
 
-if kubectl -n "${CLIENT_NAMESPACE}" get deploy octelium-client >/dev/null 2>&1; then
-  REPLICAS="$(kubectl -n "${CLIENT_NAMESPACE}" get deploy octelium-client -o jsonpath='{.spec.replicas}')"
-  READY_REPLICAS="$(kubectl -n "${CLIENT_NAMESPACE}" get deploy octelium-client -o jsonpath='{.status.readyReplicas}')"
+if kubectl_homelab -n "${CLIENT_NAMESPACE}" get deploy octelium-client >/dev/null 2>&1; then
+  REPLICAS="$(kubectl_homelab -n "${CLIENT_NAMESPACE}" get deploy octelium-client -o jsonpath='{.spec.replicas}')"
+  READY_REPLICAS="$(kubectl_homelab -n "${CLIENT_NAMESPACE}" get deploy octelium-client -o jsonpath='{.status.readyReplicas}')"
   READY_REPLICAS="${READY_REPLICAS:-0}"
   if [ "${REPLICAS}" -ge 1 ] && [ "${READY_REPLICAS}" -ge 1 ]; then
     pass "octelium-client Deployment is active (${READY_REPLICAS}/${REPLICAS})"


### PR DESCRIPTION
## Summary
- add a repo-owned Octelium app-access e2e gate for the control plane, catalog, connector, hostnames, and client tunnel
- move Compass launch/discovery links and app docs toward the Octelium .homelab service catalog
- document the Tailscale app routes as fallback only, while keeping webhook/CI-style Tailscale exceptions separate

## Validation
- PASS: bash scripts/ci/static-checks.sh
- PASS: helm template octelium-client oci://ghcr.io/octelium/helm-charts/octelium --version 0.3.0 --namespace octelium-client -f clusters/homelab/apps/octelium/values.yaml
- FAIL: env PATH=/private/tmp/octelium-tools:$PATH scripts/octelium-e2e-check.sh

## E2E blocker evidence
The e2e gate failed with 8 failure(s): missing octelium control namespace, no visible Octelium control-plane services, octelium-client is 0/0, octelium.stinkyboi.com / portal.octelium.stinkyboi.com / octelium-api.octelium.stinkyboi.com still return generic Istio 404, octeliumctl could not list services within 20s, and the homelab-demo.homelab tunnel could not be opened.

This PR intentionally does not remove fallback Tailscale app routes or set octelium-client replicaCount to 1 until that e2e gate passes.

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `88d6846fd6337a29e81d4380d813894648e9531b`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
