### PR TITLE
fix: disable openclaw codex docker sandbox

### DIFF
--- a/clusters/homelab/apps/openclaw/README.md
+++ b/clusters/homelab/apps/openclaw/README.md
@@ -184,6 +184,15 @@ The bootstrap also enables the bundled `memory-wiki` plugin. OpenClaw uses that
 plugin for Imported Insights and Memory Palace, so reload the Control UI tab
 after the synced pod restarts if those views still show an enable-plugin prompt.
 
+Startup bootstrap pins `agents.defaults.sandbox.mode` to `off`. The Codex
+harness otherwise tries to create a Docker-backed sandbox for every Discord
+agent run, but the OpenClaw application image does not ship Docker and this pod
+does not run Docker-in-Docker. The containment boundary for this deployment is
+the Kubernetes workload itself: the pod has its service account token disabled,
+uses the committed NetworkPolicy and ambient mesh policies, and writes durable
+agent state only under the OpenClaw PVC. If Docker or another sandbox runtime is
+added to the workload later, revisit this setting before enabling it.
+
 During startup, the bootstrap runs OpenClaw's safe doctor repairs when the
 persisted PVC config no longer matches the current OpenClaw schema. This keeps
 version upgrades from blocking on stale runtime config while preserving secrets

--- a/clusters/homelab/apps/openclaw/values.yaml
+++ b/clusters/homelab/apps/openclaw/values.yaml
@@ -183,6 +183,10 @@ controllers:
               agents.defaults.model \
               '{"primary":"openai/gpt-5.5"}'
 
+            openclaw config set --strict-json \
+              agents.defaults.sandbox.mode \
+              '"off"'
+
             if [ -z "${DISCORD_BOT_TOKEN:-}" ] || [ "$DISCORD_BOT_TOKEN" = "REPLACE_ME" ]; then
               echo "DISCORD_BOT_TOKEN is not populated; skipping Discord channel bootstrap"
             else

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -185,9 +185,15 @@ plugin and sets the default agent model to `openai/gpt-5.5`, which is the
 canonical Codex-backed OpenAI model route for new OpenClaw config. The
 bootstrap enables the bundled `memory-wiki` plugin so Imported Insights and
 Memory Palace are available after the Control UI tab is reloaded. The
-bootstrap runs safe `openclaw doctor --fix --non-interactive` repairs when the
-persisted PVC config does not validate against the current OpenClaw schema, and
-sets `gateway.mode` to `local` for the container-managed gateway process.
+bootstrap pins `agents.defaults.sandbox.mode` to `off` because the Codex
+harness otherwise tries to start a Docker sandbox, while the OpenClaw app image
+does not include Docker and this Kubernetes workload does not run
+Docker-in-Docker. The pod boundary, disabled service account token, NetworkPolicy
+and ambient mesh policies are the runtime containment model for Discord-triggered
+agent work. The bootstrap runs safe `openclaw doctor --fix --non-interactive`
+repairs when the persisted PVC config does not validate against the current
+OpenClaw schema, and sets `gateway.mode` to `local` for the container-managed
+gateway process.
 GitHub App identity is SSM-backed: `GITHUB_APP_ID` and
 `GITHUB_APP_INSTALLATION_ID` come from `openclaw-secrets`, while the private key
 is mounted from `openclaw-github-app-private-key` and referenced by


### PR DESCRIPTION
## Summary

This fixes the OpenClaw Discord failure where the bot responded with:

> Something went wrong while processing your request. Please try again, or use /new to start a fresh session.

The Kubernetes and Argo CD surfaces were healthy: the OpenClaw Argo CD
Application was `Synced` and `Healthy`, the deployment had one available pod,
the OpenClaw ExternalSecrets were synced, and `openclaw channels status --probe`
reported Discord as enabled, configured, running, connected, and working.

## Issue And User Impact

Discord could reach OpenClaw, but every Discord-triggered agent run failed
before producing an answer. From the user's perspective this looked like a
generic Discord bot failure even though the channel and pod were up.

The OpenClaw app logs showed the real failure at agent startup:

```text
Sandbox mode requires Docker, but the "docker" command was not found in PATH.
Install Docker (and ensure "docker" is available), or set `agents.defaults.sandbox.mode=off` to disable sandboxing.
```

## Root Cause

OpenClaw's persisted runtime config had `agents.defaults.sandbox.mode` set to
`all`. With the Codex harness, that makes OpenClaw try to create a
Docker-backed sandbox for agent work. The homelab OpenClaw workload runs inside
Kubernetes and does not include Docker or run Docker-in-Docker, so the harness
failed immediately.

## Fix

The startup bootstrap now pins:

```text
agents.defaults.sandbox.mode = "off"
```

This keeps the desired runtime config repo-owned and lets GitOps restore the
setting on pod restart. The workload documentation and knowledge base now also
explain that this deployment relies on the Kubernetes pod boundary, disabled
service account token, NetworkPolicy, and ambient mesh policies rather than a
Docker sandbox inside the OpenClaw container.

## Validation

Validated locally:

```sh
kubectl kustomize clusters/homelab/apps/openclaw
helm template openclaw app-template --repo https://bjw-s-labs.github.io/helm-charts --version 4.4.0 -f clusters/homelab/apps/openclaw/values.yaml
bash scripts/ci/static-checks.sh
bash scripts/ci/conftest-policies.sh
git diff --check
```

`nix develop --command bash scripts/ci/static-checks.sh` could not run because
`nix` is not installed in this shell, so the static check script was run
directly. Checkov completed with zero failed checks, though it warned that it
could not resolve Prisma guideline metadata from `api0.prismacloud.io` in this
environment.

Live cluster state was only inspected with read-only `kubectl` and OpenClaw CLI
commands. No live resources were patched, deleted, applied, annotated, or
restarted.
