### PR TITLE
feat: deploy octelium control plane prerequisites

### DIFF
--- a/IaC/live/argocd-apps/octelium-cluster/.terraform.lock.hcl
+++ b/IaC/live/argocd-apps/octelium-cluster/.terraform.lock.hcl
@@ -1,0 +1,47 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/helm" {
+  version = "3.1.2"
+  hashes = [
+    "h1:6jUglYAslvNAMz9z2IRtN+8WfscWiuKT87g4+RrqJos=",
+    "zh:159f79c708c60338503bcdee64977b93c11c1a4fa62fb96e70dadc1909e58f51",
+    "zh:1c126fa68dc6b6cae1a944eb305be856ce623a636dd7bf7751e6b2dba69a28b4",
+    "zh:2c6cf5c667bbfde908e8284d861c0d75786576d5a85ae914356837bed9a75348",
+    "zh:32a515c7eb3c7e9d4b1f6e191fac05004cdff56396eb3e2c84f0ae1e31b897e8",
+    "zh:4991c33b11d6d9c3ec7daabf6de5917ef5660e3402150b36e6da7196c4f336f1",
+    "zh:4e346bb727b155054a59538c966f0874ff8732917d974099ce51a29cdfacafdc",
+    "zh:590bfc70b4b466d5dccd5eca229a956c76b113ac8dc4cebf60919396aef26bdb",
+    "zh:7b4906da5f41466651f5eba630e4644d43767423c6a846a4189519dd7d6605f4",
+    "zh:a023f1c4c8d547de26d2f8a3347feae7beb17927eb0d08a4bc6edb6639be49b6",
+    "zh:ae873346811ac7946ae229b73cff670541bcf37eadc5b31a2d4feed1659de715",
+    "zh:b85e4f9245e9766476e6890dcfa13c238dbf59c905f730c41f53b7890b91993b",
+    "zh:c644abe6f05cee80d07bbacdadd8df9a376b25f44e2aa7b1d7631fab4e3625f8",
+    "zh:cdeb911f0ceb6e8b8b2f58dc40ce05edf7bf670cee0ad9e37eb90208869e7062",
+    "zh:ecb5302f085a0c29aa3b63aea54c435c3302e39bd605ffedd08c2d8ce2ccba99",
+    "zh:ff62b1e9267d5ee55013051563ceeaa7ec1f77b38afceaac28555f3545571ade",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/kubernetes" {
+  version     = "3.2.0"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:1xM7fCzNnIpoeAg0+R3ryHkZ1jFniMnTZMQkdvZqiMs=",
+    "zh:0d96396a15bb95e33c5a7e37cf10910d247707038c9dc39e68ac4446e4b2467b",
+    "zh:113faa7f4db0418cf3dbb134c5beb3ea72d475d6a993c88807457ec82760cd07",
+    "zh:228276eb046f745b55dbdf79e8082f103005f5bbdfd32f199057c4d31eede8e1",
+    "zh:4e2fa299456344ebfd0ea992b6ba90fa6249bfbf09ba0a4723f08a7a99daf8dc",
+    "zh:4f7894f1fd293bdb9e82d852ff6373ef22b94038a8f99d5fafd2d9cb167533c9",
+    "zh:61a6fc46f3ceb1777ae7937219b691bc6fb2727136a43eb3091aecc22f1e1f19",
+    "zh:7b832a7fba8e2c828aaaa45011104bc7d6da06f9289fa6f82bed9f49eb45cb93",
+    "zh:802e8b05dac4e4936192d59ed4f1225269bc6ec4c79d9ac1c0d78854eabb4b41",
+    "zh:8738a01afbb13428d4aeaa2de26befd0bca506fa7df05969aaccb782d028812f",
+    "zh:9fecf2d4cc94fd00fceb58356f07664dc59c33fc19fde030fa3ae390fd3589e1",
+    "zh:ab67e285a324d8199affdeccb94b022e6efa6503191d4f974e4d75627fb69955",
+    "zh:be9ff9d1ba3c4ea14de62adf24e09a96c5e784cac12e759bae778b39652a1c0a",
+    "zh:c3d87169dc01496d515db7b3086d77d5065fca0186dabcc7ce985d7f3d68d9a2",
+    "zh:c6416de5da1e57f86dd21fc1ac6144783f765d54b4c0f5d28be3decda516dcc3",
+    "zh:e1497c84c987007c1a1a5c1973bf3d0eb15972eeaf1f58f06d85402c38c2f72a",
+  ]
+}

--- a/IaC/live/argocd-apps/octelium-cluster/terragrunt.hcl
+++ b/IaC/live/argocd-apps/octelium-cluster/terragrunt.hcl
@@ -1,0 +1,73 @@
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "../../../modules/argocd-application-kubernetes"
+}
+
+dependencies {
+  paths = [
+    "../istio",
+    "../platform-multus",
+    "../octelium-storage"
+  ]
+}
+
+locals {
+  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
+  target_revision = "main"
+}
+
+inputs = {
+  metadata = {
+    name      = "octelium-cluster"
+    namespace = "argocd"
+    labels = {
+      "app.kubernetes.io/managed-by" = "terragrunt"
+      "app.kubernetes.io/part-of"    = "homelab"
+    }
+  }
+
+  project = "homelab"
+
+  destination = {
+    server    = "https://kubernetes.default.svc"
+    namespace = "octelium"
+  }
+
+  sources = [
+    {
+      repo_url        = local.repo_url
+      target_revision = local.target_revision
+      path            = "clusters/homelab/apps/octelium-cluster"
+      kustomize       = {}
+    }
+  ]
+
+  sync_policy = {
+    automated = {
+      prune     = true
+      self_heal = true
+    }
+    sync_options = [
+      "CreateNamespace=true",
+      "ServerSideApply=true"
+    ]
+    retry = {
+      limit = "5"
+      backoff = {
+        duration     = "30s"
+        factor       = "2"
+        max_duration = "2m"
+      }
+    }
+  }
+
+  info = [
+    {
+      name  = "bootstrap"
+      value = "Run scripts/octelium-cluster-bootstrap.sh after platform-multus and octelium-storage are healthy"
+    }
+  ]
+}

--- a/IaC/live/argocd-apps/octelium-storage/.terraform.lock.hcl
+++ b/IaC/live/argocd-apps/octelium-storage/.terraform.lock.hcl
@@ -1,0 +1,47 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/helm" {
+  version = "3.1.2"
+  hashes = [
+    "h1:6jUglYAslvNAMz9z2IRtN+8WfscWiuKT87g4+RrqJos=",
+    "zh:159f79c708c60338503bcdee64977b93c11c1a4fa62fb96e70dadc1909e58f51",
+    "zh:1c126fa68dc6b6cae1a944eb305be856ce623a636dd7bf7751e6b2dba69a28b4",
+    "zh:2c6cf5c667bbfde908e8284d861c0d75786576d5a85ae914356837bed9a75348",
+    "zh:32a515c7eb3c7e9d4b1f6e191fac05004cdff56396eb3e2c84f0ae1e31b897e8",
+    "zh:4991c33b11d6d9c3ec7daabf6de5917ef5660e3402150b36e6da7196c4f336f1",
+    "zh:4e346bb727b155054a59538c966f0874ff8732917d974099ce51a29cdfacafdc",
+    "zh:590bfc70b4b466d5dccd5eca229a956c76b113ac8dc4cebf60919396aef26bdb",
+    "zh:7b4906da5f41466651f5eba630e4644d43767423c6a846a4189519dd7d6605f4",
+    "zh:a023f1c4c8d547de26d2f8a3347feae7beb17927eb0d08a4bc6edb6639be49b6",
+    "zh:ae873346811ac7946ae229b73cff670541bcf37eadc5b31a2d4feed1659de715",
+    "zh:b85e4f9245e9766476e6890dcfa13c238dbf59c905f730c41f53b7890b91993b",
+    "zh:c644abe6f05cee80d07bbacdadd8df9a376b25f44e2aa7b1d7631fab4e3625f8",
+    "zh:cdeb911f0ceb6e8b8b2f58dc40ce05edf7bf670cee0ad9e37eb90208869e7062",
+    "zh:ecb5302f085a0c29aa3b63aea54c435c3302e39bd605ffedd08c2d8ce2ccba99",
+    "zh:ff62b1e9267d5ee55013051563ceeaa7ec1f77b38afceaac28555f3545571ade",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/kubernetes" {
+  version     = "3.2.0"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:1xM7fCzNnIpoeAg0+R3ryHkZ1jFniMnTZMQkdvZqiMs=",
+    "zh:0d96396a15bb95e33c5a7e37cf10910d247707038c9dc39e68ac4446e4b2467b",
+    "zh:113faa7f4db0418cf3dbb134c5beb3ea72d475d6a993c88807457ec82760cd07",
+    "zh:228276eb046f745b55dbdf79e8082f103005f5bbdfd32f199057c4d31eede8e1",
+    "zh:4e2fa299456344ebfd0ea992b6ba90fa6249bfbf09ba0a4723f08a7a99daf8dc",
+    "zh:4f7894f1fd293bdb9e82d852ff6373ef22b94038a8f99d5fafd2d9cb167533c9",
+    "zh:61a6fc46f3ceb1777ae7937219b691bc6fb2727136a43eb3091aecc22f1e1f19",
+    "zh:7b832a7fba8e2c828aaaa45011104bc7d6da06f9289fa6f82bed9f49eb45cb93",
+    "zh:802e8b05dac4e4936192d59ed4f1225269bc6ec4c79d9ac1c0d78854eabb4b41",
+    "zh:8738a01afbb13428d4aeaa2de26befd0bca506fa7df05969aaccb782d028812f",
+    "zh:9fecf2d4cc94fd00fceb58356f07664dc59c33fc19fde030fa3ae390fd3589e1",
+    "zh:ab67e285a324d8199affdeccb94b022e6efa6503191d4f974e4d75627fb69955",
+    "zh:be9ff9d1ba3c4ea14de62adf24e09a96c5e784cac12e759bae778b39652a1c0a",
+    "zh:c3d87169dc01496d515db7b3086d77d5065fca0186dabcc7ce985d7f3d68d9a2",
+    "zh:c6416de5da1e57f86dd21fc1ac6144783f765d54b4c0f5d28be3decda516dcc3",
+    "zh:e1497c84c987007c1a1a5c1973bf3d0eb15972eeaf1f58f06d85402c38c2f72a",
+  ]
+}

--- a/IaC/live/argocd-apps/octelium-storage/terragrunt.hcl
+++ b/IaC/live/argocd-apps/octelium-storage/terragrunt.hcl
@@ -1,0 +1,72 @@
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "../../../modules/argocd-application-kubernetes"
+}
+
+dependencies {
+  paths = [
+    "../external-secrets",
+    "../platform-storage"
+  ]
+}
+
+locals {
+  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
+  target_revision = "main"
+}
+
+inputs = {
+  metadata = {
+    name      = "octelium-storage"
+    namespace = "argocd"
+    labels = {
+      "app.kubernetes.io/managed-by" = "terragrunt"
+      "app.kubernetes.io/part-of"    = "homelab"
+    }
+  }
+
+  project = "homelab"
+
+  destination = {
+    server    = "https://kubernetes.default.svc"
+    namespace = "octelium-storage"
+  }
+
+  sources = [
+    {
+      repo_url        = local.repo_url
+      target_revision = local.target_revision
+      path            = "clusters/homelab/apps/octelium-storage"
+      kustomize       = {}
+    }
+  ]
+
+  sync_policy = {
+    automated = {
+      prune     = true
+      self_heal = true
+    }
+    sync_options = [
+      "CreateNamespace=true",
+      "ServerSideApply=true"
+    ]
+    retry = {
+      limit = "5"
+      backoff = {
+        duration     = "30s"
+        factor       = "2"
+        max_duration = "2m"
+      }
+    }
+  }
+
+  info = [
+    {
+      name  = "state"
+      value = "PostgreSQL and Redis backing stores for octops init"
+    }
+  ]
+}

--- a/IaC/live/argocd-apps/platform-multus/.terraform.lock.hcl
+++ b/IaC/live/argocd-apps/platform-multus/.terraform.lock.hcl
@@ -1,0 +1,47 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/helm" {
+  version = "3.1.2"
+  hashes = [
+    "h1:6jUglYAslvNAMz9z2IRtN+8WfscWiuKT87g4+RrqJos=",
+    "zh:159f79c708c60338503bcdee64977b93c11c1a4fa62fb96e70dadc1909e58f51",
+    "zh:1c126fa68dc6b6cae1a944eb305be856ce623a636dd7bf7751e6b2dba69a28b4",
+    "zh:2c6cf5c667bbfde908e8284d861c0d75786576d5a85ae914356837bed9a75348",
+    "zh:32a515c7eb3c7e9d4b1f6e191fac05004cdff56396eb3e2c84f0ae1e31b897e8",
+    "zh:4991c33b11d6d9c3ec7daabf6de5917ef5660e3402150b36e6da7196c4f336f1",
+    "zh:4e346bb727b155054a59538c966f0874ff8732917d974099ce51a29cdfacafdc",
+    "zh:590bfc70b4b466d5dccd5eca229a956c76b113ac8dc4cebf60919396aef26bdb",
+    "zh:7b4906da5f41466651f5eba630e4644d43767423c6a846a4189519dd7d6605f4",
+    "zh:a023f1c4c8d547de26d2f8a3347feae7beb17927eb0d08a4bc6edb6639be49b6",
+    "zh:ae873346811ac7946ae229b73cff670541bcf37eadc5b31a2d4feed1659de715",
+    "zh:b85e4f9245e9766476e6890dcfa13c238dbf59c905f730c41f53b7890b91993b",
+    "zh:c644abe6f05cee80d07bbacdadd8df9a376b25f44e2aa7b1d7631fab4e3625f8",
+    "zh:cdeb911f0ceb6e8b8b2f58dc40ce05edf7bf670cee0ad9e37eb90208869e7062",
+    "zh:ecb5302f085a0c29aa3b63aea54c435c3302e39bd605ffedd08c2d8ce2ccba99",
+    "zh:ff62b1e9267d5ee55013051563ceeaa7ec1f77b38afceaac28555f3545571ade",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/kubernetes" {
+  version     = "3.2.0"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:1xM7fCzNnIpoeAg0+R3ryHkZ1jFniMnTZMQkdvZqiMs=",
+    "zh:0d96396a15bb95e33c5a7e37cf10910d247707038c9dc39e68ac4446e4b2467b",
+    "zh:113faa7f4db0418cf3dbb134c5beb3ea72d475d6a993c88807457ec82760cd07",
+    "zh:228276eb046f745b55dbdf79e8082f103005f5bbdfd32f199057c4d31eede8e1",
+    "zh:4e2fa299456344ebfd0ea992b6ba90fa6249bfbf09ba0a4723f08a7a99daf8dc",
+    "zh:4f7894f1fd293bdb9e82d852ff6373ef22b94038a8f99d5fafd2d9cb167533c9",
+    "zh:61a6fc46f3ceb1777ae7937219b691bc6fb2727136a43eb3091aecc22f1e1f19",
+    "zh:7b832a7fba8e2c828aaaa45011104bc7d6da06f9289fa6f82bed9f49eb45cb93",
+    "zh:802e8b05dac4e4936192d59ed4f1225269bc6ec4c79d9ac1c0d78854eabb4b41",
+    "zh:8738a01afbb13428d4aeaa2de26befd0bca506fa7df05969aaccb782d028812f",
+    "zh:9fecf2d4cc94fd00fceb58356f07664dc59c33fc19fde030fa3ae390fd3589e1",
+    "zh:ab67e285a324d8199affdeccb94b022e6efa6503191d4f974e4d75627fb69955",
+    "zh:be9ff9d1ba3c4ea14de62adf24e09a96c5e784cac12e759bae778b39652a1c0a",
+    "zh:c3d87169dc01496d515db7b3086d77d5065fca0186dabcc7ce985d7f3d68d9a2",
+    "zh:c6416de5da1e57f86dd21fc1ac6144783f765d54b4c0f5d28be3decda516dcc3",
+    "zh:e1497c84c987007c1a1a5c1973bf3d0eb15972eeaf1f58f06d85402c38c2f72a",
+  ]
+}

--- a/IaC/live/argocd-apps/platform-multus/terragrunt.hcl
+++ b/IaC/live/argocd-apps/platform-multus/terragrunt.hcl
@@ -1,0 +1,64 @@
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "../../../modules/argocd-application-kubernetes"
+}
+
+locals {
+  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
+  target_revision = "main"
+}
+
+inputs = {
+  metadata = {
+    name      = "platform-multus"
+    namespace = "argocd"
+    labels = {
+      "app.kubernetes.io/managed-by" = "terragrunt"
+      "app.kubernetes.io/part-of"    = "homelab"
+    }
+  }
+
+  project = "homelab"
+
+  destination = {
+    server    = "https://kubernetes.default.svc"
+    namespace = "kube-system"
+  }
+
+  sources = [
+    {
+      repo_url        = local.repo_url
+      target_revision = local.target_revision
+      path            = "clusters/homelab/platform/multus"
+      kustomize       = {}
+    }
+  ]
+
+  sync_policy = {
+    automated = {
+      prune     = true
+      self_heal = true
+    }
+    sync_options = [
+      "ServerSideApply=true"
+    ]
+    retry = {
+      limit = "5"
+      backoff = {
+        duration     = "30s"
+        factor       = "2"
+        max_duration = "2m"
+      }
+    }
+  }
+
+  info = [
+    {
+      name  = "platform"
+      value = "Talos-compatible Multus thick CNI for Octelium data-plane workloads"
+    }
+  ]
+}

--- a/IaC/live/aws-ssm-parameters/terragrunt.hcl
+++ b/IaC/live/aws-ssm-parameters/terragrunt.hcl
@@ -86,6 +86,22 @@ inputs = {
       description   = "Octelium authentication token for the homelab workload client connector."
       initial_value = local.placeholder
     }
+    "/homelab/octelium/postgres-password" = {
+      description = "Octelium Cluster PostgreSQL password."
+      generated = {
+        length  = 40
+        special = false
+      }
+      initial_value = local.placeholder
+    }
+    "/homelab/octelium/redis-password" = {
+      description = "Octelium Cluster Redis password."
+      generated = {
+        length  = 40
+        special = false
+      }
+      initial_value = local.placeholder
+    }
     "/homelab/grafana/admin-user" = {
       description   = "Grafana admin username."
       initial_value = local.placeholder

--- a/IaC/live/kubernetes-node-labels/.terraform.lock.hcl
+++ b/IaC/live/kubernetes-node-labels/.terraform.lock.hcl
@@ -1,0 +1,47 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/helm" {
+  version = "3.1.2"
+  hashes = [
+    "h1:6jUglYAslvNAMz9z2IRtN+8WfscWiuKT87g4+RrqJos=",
+    "zh:159f79c708c60338503bcdee64977b93c11c1a4fa62fb96e70dadc1909e58f51",
+    "zh:1c126fa68dc6b6cae1a944eb305be856ce623a636dd7bf7751e6b2dba69a28b4",
+    "zh:2c6cf5c667bbfde908e8284d861c0d75786576d5a85ae914356837bed9a75348",
+    "zh:32a515c7eb3c7e9d4b1f6e191fac05004cdff56396eb3e2c84f0ae1e31b897e8",
+    "zh:4991c33b11d6d9c3ec7daabf6de5917ef5660e3402150b36e6da7196c4f336f1",
+    "zh:4e346bb727b155054a59538c966f0874ff8732917d974099ce51a29cdfacafdc",
+    "zh:590bfc70b4b466d5dccd5eca229a956c76b113ac8dc4cebf60919396aef26bdb",
+    "zh:7b4906da5f41466651f5eba630e4644d43767423c6a846a4189519dd7d6605f4",
+    "zh:a023f1c4c8d547de26d2f8a3347feae7beb17927eb0d08a4bc6edb6639be49b6",
+    "zh:ae873346811ac7946ae229b73cff670541bcf37eadc5b31a2d4feed1659de715",
+    "zh:b85e4f9245e9766476e6890dcfa13c238dbf59c905f730c41f53b7890b91993b",
+    "zh:c644abe6f05cee80d07bbacdadd8df9a376b25f44e2aa7b1d7631fab4e3625f8",
+    "zh:cdeb911f0ceb6e8b8b2f58dc40ce05edf7bf670cee0ad9e37eb90208869e7062",
+    "zh:ecb5302f085a0c29aa3b63aea54c435c3302e39bd605ffedd08c2d8ce2ccba99",
+    "zh:ff62b1e9267d5ee55013051563ceeaa7ec1f77b38afceaac28555f3545571ade",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/kubernetes" {
+  version     = "3.2.0"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:1xM7fCzNnIpoeAg0+R3ryHkZ1jFniMnTZMQkdvZqiMs=",
+    "zh:0d96396a15bb95e33c5a7e37cf10910d247707038c9dc39e68ac4446e4b2467b",
+    "zh:113faa7f4db0418cf3dbb134c5beb3ea72d475d6a993c88807457ec82760cd07",
+    "zh:228276eb046f745b55dbdf79e8082f103005f5bbdfd32f199057c4d31eede8e1",
+    "zh:4e2fa299456344ebfd0ea992b6ba90fa6249bfbf09ba0a4723f08a7a99daf8dc",
+    "zh:4f7894f1fd293bdb9e82d852ff6373ef22b94038a8f99d5fafd2d9cb167533c9",
+    "zh:61a6fc46f3ceb1777ae7937219b691bc6fb2727136a43eb3091aecc22f1e1f19",
+    "zh:7b832a7fba8e2c828aaaa45011104bc7d6da06f9289fa6f82bed9f49eb45cb93",
+    "zh:802e8b05dac4e4936192d59ed4f1225269bc6ec4c79d9ac1c0d78854eabb4b41",
+    "zh:8738a01afbb13428d4aeaa2de26befd0bca506fa7df05969aaccb782d028812f",
+    "zh:9fecf2d4cc94fd00fceb58356f07664dc59c33fc19fde030fa3ae390fd3589e1",
+    "zh:ab67e285a324d8199affdeccb94b022e6efa6503191d4f974e4d75627fb69955",
+    "zh:be9ff9d1ba3c4ea14de62adf24e09a96c5e784cac12e759bae778b39652a1c0a",
+    "zh:c3d87169dc01496d515db7b3086d77d5065fca0186dabcc7ce985d7f3d68d9a2",
+    "zh:c6416de5da1e57f86dd21fc1ac6144783f765d54b4c0f5d28be3decda516dcc3",
+    "zh:e1497c84c987007c1a1a5c1973bf3d0eb15972eeaf1f58f06d85402c38c2f72a",
+  ]
+}

--- a/IaC/live/kubernetes-node-labels/terragrunt.hcl
+++ b/IaC/live/kubernetes-node-labels/terragrunt.hcl
@@ -1,0 +1,21 @@
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "../../modules/kubernetes-node-labels"
+}
+
+inputs = {
+  node_labels = {
+    zimaboard-0 = {
+      "octelium.com/node-mode-dataplane" = ""
+    }
+    zimaboard-1 = {
+      "octelium.com/node-mode-controlplane" = ""
+    }
+    zimaboard-2 = {
+      "octelium.com/node-mode-dataplane" = ""
+    }
+  }
+}

--- a/IaC/modules/kubernetes-node-labels/main.tf
+++ b/IaC/modules/kubernetes-node-labels/main.tf
@@ -1,0 +1,47 @@
+terraform {
+  required_version = ">= 1.10"
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 3.0"
+    }
+  }
+
+  encryption {
+    key_provider "aws_kms" "main" {
+      kms_key_id = var.kms_key_id
+      key_spec   = var.kms_key_spec
+      region     = var.kms_region
+    }
+
+    method "aes_gcm" "main" {
+      keys = key_provider.aws_kms.main
+    }
+
+    state {
+      method   = method.aes_gcm.main
+      enforced = true
+    }
+
+    plan {
+      method   = method.aes_gcm.main
+      enforced = true
+    }
+  }
+}
+
+resource "kubernetes_labels" "nodes" {
+  for_each = var.node_labels
+
+  api_version = "v1"
+  kind        = "Node"
+  labels      = each.value
+
+  metadata {
+    name = each.key
+  }
+
+  field_manager = "terragrunt"
+  force         = true
+}

--- a/IaC/modules/kubernetes-node-labels/outputs.tf
+++ b/IaC/modules/kubernetes-node-labels/outputs.tf
@@ -1,0 +1,4 @@
+output "node_labels" {
+  description = "Node labels managed by this module."
+  value       = var.node_labels
+}

--- a/IaC/modules/kubernetes-node-labels/variables.tf
+++ b/IaC/modules/kubernetes-node-labels/variables.tf
@@ -1,0 +1,21 @@
+variable "kms_key_id" {
+  description = "AWS KMS key ID for OpenTofu state encryption"
+  type        = string
+}
+
+variable "kms_region" {
+  description = "AWS region for the KMS key used by OpenTofu state encryption"
+  type        = string
+  default     = "us-west-2"
+}
+
+variable "kms_key_spec" {
+  description = "AWS KMS key spec for OpenTofu state encryption"
+  type        = string
+  default     = "AES_256"
+}
+
+variable "node_labels" {
+  description = "Map of node name to labels that should be managed by OpenTofu."
+  type        = map(map(string))
+}

--- a/clusters/homelab/apps/external-secrets/cluster-secret-store.yaml
+++ b/clusters/homelab/apps/external-secrets/cluster-secret-store.yaml
@@ -14,6 +14,7 @@ spec:
         - media
         - monitoring
         - octelium-client
+        - octelium-storage
         - tailscale
   provider:
     aws:

--- a/clusters/homelab/apps/octelium-cluster/README.md
+++ b/clusters/homelab/apps/octelium-cluster/README.md
@@ -1,0 +1,21 @@
+# Octelium Cluster Front Door
+
+This app owns the repo-side Octelium Cluster ingress route. `octops init`
+creates and manages the Octelium control-plane workloads in the `octelium`
+namespace, while this Argo CD Application keeps the homelab's Istio bootstrap
+gateway routing the nested Octelium hostnames to the Octelium data-plane
+ingress service.
+
+The bootstrap script runs `octops init` with `OCTELIUM_FRONT_PROXY_MODE=true`,
+so Istio terminates TLS and proxies HTTP to
+`octelium-ingress-dataplane.octelium.svc.cluster.local:8080`.
+
+## Validation
+
+```sh
+kubectl -n octelium get svc octelium-ingress-dataplane
+kubectl -n octelium get virtualservice octelium-cluster
+curl -I https://octelium.stinkyboi.com
+curl -I https://portal.octelium.stinkyboi.com
+curl -I https://octelium-api.octelium.stinkyboi.com
+```

--- a/clusters/homelab/apps/octelium-cluster/kustomization.yaml
+++ b/clusters/homelab/apps/octelium-cluster/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - virtualservice.yaml

--- a/clusters/homelab/apps/octelium-cluster/namespace.yaml
+++ b/clusters/homelab/apps/octelium-cluster/namespace.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: octelium
+  annotations:
+    homelab.rst.io/privileged-namespace-justification: Octelium data-plane workloads are installed by octops and require privileged network access.
+  labels:
+    app.kubernetes.io/name: octelium
+    app.kubernetes.io/part-of: octelium
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest

--- a/clusters/homelab/apps/octelium-cluster/virtualservice.yaml
+++ b/clusters/homelab/apps/octelium-cluster/virtualservice.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: octelium-cluster
+  namespace: octelium
+  annotations:
+    homelab.rst.io/public-funnel: "false"
+spec:
+  hosts:
+    - octelium.stinkyboi.com
+    - portal.octelium.stinkyboi.com
+    - octelium-api.octelium.stinkyboi.com
+  gateways:
+    - istio-system/tailnet-gateway
+  http:
+    - route:
+        - destination:
+            host: octelium-ingress-dataplane.octelium.svc.cluster.local
+            port:
+              number: 8080

--- a/clusters/homelab/apps/octelium-storage/README.md
+++ b/clusters/homelab/apps/octelium-storage/README.md
@@ -1,0 +1,35 @@
+# Octelium Storage
+
+`octelium-storage` provides the in-cluster PostgreSQL and Redis stores required
+by `octops init` for the self-hosted Octelium Cluster. The stores are dedicated
+to Octelium and are not shared with application data.
+
+## Secret Contract
+
+Terragrunt generates these SSM SecureStrings:
+
+- `/homelab/octelium/postgres-password`
+- `/homelab/octelium/redis-password`
+
+The `octelium-storage-auth` ExternalSecret materializes the values into the
+`octelium-storage` namespace. The bootstrap script reads the Kubernetes Secret,
+creates a temporary Octelium bootstrap file outside git, runs `octops init`, and
+then deletes the temporary file.
+
+## Storage
+
+PostgreSQL uses a 20Gi `nfs-default` PVC. Redis uses a 5Gi `nfs-default` PVC
+with AOF enabled. The QNAP NFS export squashes ownership, so both pods run as
+UID/GID 65534 like the other file-backed PostgreSQL workloads in this repo.
+
+## Validation
+
+```sh
+kubectl -n octelium-storage get externalsecret,secret octelium-storage-auth
+kubectl -n octelium-storage get statefulset,pod,pvc,svc
+kubectl -n octelium-storage exec statefulset/octelium-postgres -- pg_isready -U octelium -d octelium
+kubectl -n octelium-storage exec statefulset/octelium-redis -- redis-cli ping
+```
+
+Redis requires authentication for real clients; the unauthenticated `PING` can
+return `NOAUTH` while still proving the TCP listener is reachable.

--- a/clusters/homelab/apps/octelium-storage/externalsecret.yaml
+++ b/clusters/homelab/apps/octelium-storage/externalsecret.yaml
@@ -1,0 +1,42 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: octelium-storage-auth
+  namespace: octelium-storage
+  annotations:
+    homelab.stuhlmuller.dev/generated-secret-revision: "v1"
+spec:
+  refreshPolicy: OnChange
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: aws-ssm
+  target:
+    name: octelium-storage-auth
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      engineVersion: v2
+      type: Opaque
+      data:
+        POSTGRES_PASSWORD: "{{ .postgres_password }}"
+        REDIS_PASSWORD: "{{ .redis_password }}"
+        redis.conf: |
+          appendonly yes
+          dir /data
+          port 6379
+          bind 0.0.0.0
+          protected-mode yes
+          requirepass {{ .redis_password }}
+  data:
+    - secretKey: postgres_password
+      remoteRef:
+        key: /homelab/octelium/postgres-password
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+    - secretKey: redis_password
+      remoteRef:
+        key: /homelab/octelium/redis-password
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None

--- a/clusters/homelab/apps/octelium-storage/kustomization.yaml
+++ b/clusters/homelab/apps/octelium-storage/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - externalsecret.yaml
+  - postgres.yaml
+  - redis.yaml
+  - networkpolicy.yaml

--- a/clusters/homelab/apps/octelium-storage/namespace.yaml
+++ b/clusters/homelab/apps/octelium-storage/namespace.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: octelium-storage
+  labels:
+    app.kubernetes.io/name: octelium-storage
+    app.kubernetes.io/part-of: octelium
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest

--- a/clusters/homelab/apps/octelium-storage/networkpolicy.yaml
+++ b/clusters/homelab/apps/octelium-storage/networkpolicy.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: octelium-storage
+  namespace: octelium-storage
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: octelium
+      ports:
+        - protocol: TCP
+          port: 5432
+        - protocol: TCP
+          port: 6379

--- a/clusters/homelab/apps/octelium-storage/postgres.yaml
+++ b/clusters/homelab/apps/octelium-storage/postgres.yaml
@@ -1,0 +1,153 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: octelium-postgres
+  namespace: octelium-storage
+  labels:
+    app.kubernetes.io/name: octelium-postgres
+    app.kubernetes.io/part-of: octelium
+spec:
+  selector:
+    app.kubernetes.io/name: octelium-postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: postgres
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: octelium-postgres
+  namespace: octelium-storage
+  annotations:
+    checkov.io/skip1: CKV_K8S_40=The pod runs as the QNAP NFS anonymous UID 65534 so PostgreSQL owns the squashed data directory without root.
+    checkov.io/skip2: CKV_K8S_22=PostgreSQL requires writable image-managed runtime paths; persistent data is isolated on the data PVC.
+    checkov.io/skip3: CKV2_K8S_6=octelium-storage is covered by networkpolicy.yaml; diff-only scans do not include sibling manifests.
+  labels:
+    app.kubernetes.io/name: octelium-postgres
+    app.kubernetes.io/part-of: octelium
+spec:
+  serviceName: octelium-postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: octelium-postgres
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: octelium-postgres
+        app.kubernetes.io/part-of: octelium
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        fsGroup: 65534
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        - name: require-real-password
+          image: postgres:14.23-bookworm@sha256:70b9c8977b5fb87bd55c9e29472d778d76d56a6266143d47259da13d78a72afa
+          imagePullPolicy: Always
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              password="$(cat /run/secrets/octelium-storage/POSTGRES_PASSWORD)"
+              if [ -z "$password" ] || [ "$password" = "REPLACE_ME" ]; then
+                echo "Octelium PostgreSQL password is empty or still uses REPLACE_ME in SSM" >&2
+                exit 1
+              fi
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: auth
+              mountPath: /run/secrets/octelium-storage
+              readOnly: true
+      containers:
+        - name: postgres
+          image: postgres:14.23-bookworm@sha256:70b9c8977b5fb87bd55c9e29472d778d76d56a6266143d47259da13d78a72afa
+          imagePullPolicy: Always
+          env:
+            - name: POSTGRES_USER
+              value: octelium
+            - name: POSTGRES_DB
+              value: octelium
+            - name: POSTGRES_PASSWORD_FILE
+              value: /run/secrets/octelium-storage/POSTGRES_PASSWORD
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          ports:
+            - name: postgres
+              containerPort: 5432
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - octelium
+                - -d
+                - octelium
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - octelium
+                - -d
+                - octelium
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: auth
+              mountPath: /run/secrets/octelium-storage
+              readOnly: true
+            - name: data
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: auth
+          secret:
+            secretName: octelium-storage-auth
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          app.kubernetes.io/name: octelium-postgres
+          app.kubernetes.io/part-of: octelium
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: nfs-default
+        resources:
+          requests:
+            storage: 20Gi

--- a/clusters/homelab/apps/octelium-storage/redis.yaml
+++ b/clusters/homelab/apps/octelium-storage/redis.yaml
@@ -1,0 +1,136 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: octelium-redis
+  namespace: octelium-storage
+  labels:
+    app.kubernetes.io/name: octelium-redis
+    app.kubernetes.io/part-of: octelium
+spec:
+  selector:
+    app.kubernetes.io/name: octelium-redis
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: redis
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: octelium-redis
+  namespace: octelium-storage
+  annotations:
+    checkov.io/skip1: CKV_K8S_22=Redis requires a writable data directory for append-only persistence.
+    checkov.io/skip2: CKV2_K8S_6=octelium-storage is covered by networkpolicy.yaml; diff-only scans do not include sibling manifests.
+  labels:
+    app.kubernetes.io/name: octelium-redis
+    app.kubernetes.io/part-of: octelium
+spec:
+  serviceName: octelium-redis
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: octelium-redis
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: octelium-redis
+        app.kubernetes.io/part-of: octelium
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        fsGroup: 65534
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        - name: require-real-password
+          image: redis:7.4.2-alpine@sha256:02419de7eddf55aa5bcf49efb74e88fa8d931b4d77c07eff8a6b2144472b6952
+          imagePullPolicy: Always
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              password="$(cat /run/secrets/octelium-storage/REDIS_PASSWORD)"
+              if [ -z "$password" ] || [ "$password" = "REPLACE_ME" ]; then
+                echo "Octelium Redis password is empty or still uses REPLACE_ME in SSM" >&2
+                exit 1
+              fi
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: auth
+              mountPath: /run/secrets/octelium-storage
+              readOnly: true
+      containers:
+        - name: redis
+          image: redis:7.4.2-alpine@sha256:02419de7eddf55aa5bcf49efb74e88fa8d931b4d77c07eff8a6b2144472b6952
+          imagePullPolicy: Always
+          command:
+            - redis-server
+            - /run/secrets/octelium-storage/redis.conf
+          ports:
+            - name: redis
+              containerPort: 6379
+          readinessProbe:
+            tcpSocket:
+              port: redis
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 6
+          livenessProbe:
+            tcpSocket:
+              port: redis
+            initialDelaySeconds: 20
+            periodSeconds: 30
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: auth
+              mountPath: /run/secrets/octelium-storage
+              readOnly: true
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: auth
+          secret:
+            secretName: octelium-storage-auth
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          app.kubernetes.io/name: octelium-redis
+          app.kubernetes.io/part-of: octelium
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: nfs-default
+        resources:
+          requests:
+            storage: 5Gi

--- a/clusters/homelab/argocd/self-management/appproject.yaml
+++ b/clusters/homelab/argocd/self-management/appproject.yaml
@@ -48,6 +48,10 @@ spec:
     - server: https://kubernetes.default.svc
       namespace: octelium-client
     - server: https://kubernetes.default.svc
+      namespace: octelium
+    - server: https://kubernetes.default.svc
+      namespace: octelium-storage
+    - server: https://kubernetes.default.svc
       namespace: storage
     - server: https://kubernetes.default.svc
       namespace: tailscale

--- a/clusters/homelab/platform/multus/README.md
+++ b/clusters/homelab/platform/multus/README.md
@@ -1,0 +1,23 @@
+# Multus CNI
+
+`platform-multus` installs the Multus thick DaemonSet in `kube-system` so the
+homelab can run Octelium data-plane workloads. Talos requires the Multus netns
+mount at `/var/run/netns`, and the init container uses `install_multus -t thick`
+so reboot races do not leave the CNI binary missing.
+
+This app intentionally owns only Multus. Octelium node labels are managed by the
+`IaC/live/kubernetes-node-labels` Terragrunt unit, and the Octelium Cluster is
+initialized through `scripts/octelium-cluster-bootstrap.sh`.
+
+## Validation
+
+After Argo CD syncs this app:
+
+```sh
+kubectl get crd network-attachment-definitions.k8s.cni.cncf.io
+kubectl -n kube-system rollout status daemonset/kube-multus-ds
+kubectl -n kube-system get pods -l app=multus
+```
+
+Rollback is to remove the `platform-multus` Argo CD Application only after all
+workloads that require Multus have been removed.

--- a/clusters/homelab/platform/multus/kustomization.yaml
+++ b/clusters/homelab/platform/multus/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - multus.yaml

--- a/clusters/homelab/platform/multus/multus.yaml
+++ b/clusters/homelab/platform/multus/multus.yaml
@@ -1,0 +1,283 @@
+# Adapted from the upstream Multus thick DaemonSet v4.2.4 for Talos Linux.
+# Source: https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/v4.2.4/deployments/multus-daemonset-thick.yml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: network-attachment-definitions.k8s.cni.cncf.io
+  annotations:
+    checkov.io/skip1: CKV_K8S_11=CRD schemas do not define CPU requests.
+    checkov.io/skip2: CKV_K8S_12=CRD schemas do not define memory requests.
+    checkov.io/skip3: CKV_K8S_13=CRD schemas do not define memory limits.
+    checkov.io/skip4: CKV_K8S_14=CRD schemas do not define image tags.
+    checkov.io/skip5: CKV_K8S_15=CRD schemas do not define image pull policies.
+    checkov.io/skip6: CKV_K8S_20=CRD schemas do not define container security contexts.
+    checkov.io/skip7: CKV_K8S_21=CRD schemas do not define default namespaces.
+    checkov.io/skip8: CKV_K8S_22=CRD schemas do not mount filesystems.
+    checkov.io/skip9: CKV_K8S_23=CRD schemas do not define host namespaces.
+    checkov.io/skip10: CKV_K8S_28=CRD schemas do not define probes.
+    checkov.io/skip11: CKV_K8S_29=CRD schemas do not define probes.
+    checkov.io/skip12: CKV_K8S_30=CRD schemas do not define probes.
+    checkov.io/skip13: CKV_K8S_31=CRD schemas do not define seccomp.
+    checkov.io/skip14: CKV_K8S_37=CRD schemas do not define capabilities.
+    checkov.io/skip15: CKV_K8S_38=CRD schemas do not define ServiceAccounts.
+    checkov.io/skip16: CKV_K8S_40=CRD schemas do not run containers.
+    checkov.io/skip17: CKV_K8S_43=CRD schemas do not define container images.
+    checkov.io/skip18: CKV2_K8S_6=The Multus DaemonSet below is the networked workload; the CRD itself is inert.
+spec:
+  group: k8s.cni.cncf.io
+  scope: Namespaced
+  names:
+    plural: network-attachment-definitions
+    singular: network-attachment-definition
+    kind: NetworkAttachmentDefinition
+    shortNames:
+      - net-attach-def
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          description: NetworkAttachmentDefinition is a CRD schema specified by the Network Plumbing Working Group.
+          type: object
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NetworkAttachmentDefinition spec defines the desired state of a network attachment.
+              type: object
+              properties:
+                config:
+                  description: NetworkAttachmentDefinition config is a JSON-formatted CNI configuration.
+                  type: string
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: multus
+  annotations:
+    checkov.io/skip1: CKV_K8S_49=The upstream Multus ClusterRole watches and updates NetworkAttachmentDefinitions and pod status across namespaces as a CNI plugin.
+rules:
+  - apiGroups:
+      - k8s.cni.cncf.io
+    resources:
+      - "*"
+    verbs:
+      - "*"
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/status
+    verbs:
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - ""
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: multus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: multus
+subjects:
+  - kind: ServiceAccount
+    name: multus
+    namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: multus
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: multus-daemon-config
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: multus
+    app.kubernetes.io/part-of: homelab-platform
+data:
+  daemon-config.json: |
+    {
+        "chrootDir": "/hostroot",
+        "cniVersion": "0.3.1",
+        "logLevel": "verbose",
+        "logToStderr": true,
+        "cniConfigDir": "/host/etc/cni/net.d",
+        "multusAutoconfigDir": "/host/etc/cni/net.d",
+        "multusConfigFile": "auto",
+        "socketDir": "/host/run/multus/"
+    }
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-multus-ds
+  namespace: kube-system
+  annotations:
+    checkov.io/skip1: CKV_K8S_20=Multus is a privileged host CNI plugin that installs node CNI binaries.
+    checkov.io/skip2: CKV_K8S_22=Multus requires write access to host CNI and kubelet paths.
+    checkov.io/skip3: CKV_K8S_23=Multus requires hostNetwork and hostPID to configure pod networking.
+    checkov.io/skip4: CKV_K8S_28=The upstream Multus DaemonSet does not expose an HTTP liveness endpoint.
+    checkov.io/skip5: CKV_K8S_29=The upstream Multus DaemonSet does not expose an HTTP readiness endpoint.
+    checkov.io/skip6: CKV_K8S_31=Privileged host CNI plugins manage seccomp at the host boundary.
+    checkov.io/skip7: CKV_K8S_37=Privileged host CNI plugins need host capabilities to install and serve CNI.
+    checkov.io/skip8: CKV_K8S_38=The dedicated multus ServiceAccount is required for pod status and NAD watch access.
+    checkov.io/skip9: CKV_K8S_40=Multus must run as root/privileged to write host CNI binaries.
+    checkov.io/skip10: CKV2_K8S_6=This cluster still uses flannel; NetworkPolicy intent is documented until a policy-enforcing CNI is introduced.
+    checkov.io/skip11: CKV_K8S_8=The upstream Multus daemon does not expose a kubelet liveness probe surface.
+    checkov.io/skip12: CKV_K8S_9=The upstream Multus daemon does not expose a kubelet readiness probe surface.
+    checkov.io/skip13: CKV_K8S_16=Multus must run privileged to install and serve host CNI binaries.
+    checkov.io/skip14: CKV_K8S_17=Multus uses hostPID as part of the upstream thick CNI DaemonSet.
+    checkov.io/skip15: CKV_K8S_19=Multus uses hostNetwork as part of the upstream thick CNI DaemonSet.
+  labels:
+    app: multus
+    app.kubernetes.io/name: multus
+    app.kubernetes.io/part-of: homelab-platform
+spec:
+  selector:
+    matchLabels:
+      name: multus
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: multus
+        app.kubernetes.io/name: multus
+        app.kubernetes.io/part-of: homelab-platform
+        name: multus
+    spec:
+      automountServiceAccountToken: true
+      hostNetwork: true
+      hostPID: true
+      tolerations:
+        - operator: Exists
+          effect: NoSchedule
+        - operator: Exists
+          effect: NoExecute
+      serviceAccountName: multus
+      initContainers:
+        - name: install-multus-binary
+          image: ghcr.io/k8snetworkplumbingwg/multus-cni:v4.2.4-thick@sha256:3c20900b5381fac7f9cbbdfac8370ea10a2f6ed7fbecc678384a9db57047abb1
+          imagePullPolicy: Always
+          command:
+            - /usr/src/multus-cni/bin/install_multus
+            - -d
+            - /host/opt/cni/bin
+            - -t
+            - thick
+          resources:
+            requests:
+              cpu: 10m
+              memory: 15Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+          securityContext:
+            privileged: true
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+            - name: cnibin
+              mountPath: /host/opt/cni/bin
+              mountPropagation: Bidirectional
+      containers:
+        - name: kube-multus
+          image: ghcr.io/k8snetworkplumbingwg/multus-cni:v4.2.4-thick@sha256:3c20900b5381fac7f9cbbdfac8370ea10a2f6ed7fbecc678384a9db57047abb1
+          imagePullPolicy: Always
+          command:
+            - /usr/src/multus-cni/bin/multus-daemon
+          resources:
+            requests:
+              cpu: 100m
+              memory: 50Mi
+            limits:
+              cpu: 100m
+              memory: 50Mi
+          securityContext:
+            privileged: true
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+            - name: cni
+              mountPath: /host/etc/cni/net.d
+            - name: cnibin
+              mountPath: /opt/cni/bin
+            - name: host-run
+              mountPath: /host/run
+            - name: host-var-lib-cni-multus
+              mountPath: /var/lib/cni/multus
+            - name: host-var-lib-kubelet
+              mountPath: /var/lib/kubelet
+              mountPropagation: HostToContainer
+            - name: host-run-k8s-cni-cncf-io
+              mountPath: /run/k8s.cni.cncf.io
+            - name: host-run-netns
+              mountPath: /var/run/netns
+              mountPropagation: HostToContainer
+            - name: multus-daemon-config
+              mountPath: /etc/cni/net.d/multus.d
+              readOnly: true
+            - name: hostroot
+              mountPath: /hostroot
+              mountPropagation: HostToContainer
+            - name: multus-conf-dir
+              mountPath: /etc/cni/multus/net.d
+          env:
+            - name: MULTUS_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+      terminationGracePeriodSeconds: 10
+      volumes:
+        - name: cni
+          hostPath:
+            path: /etc/cni/net.d
+        - name: cnibin
+          hostPath:
+            path: /opt/cni/bin
+        - name: hostroot
+          hostPath:
+            path: /
+        - name: multus-daemon-config
+          configMap:
+            name: multus-daemon-config
+            items:
+              - key: daemon-config.json
+                path: daemon-config.json
+        - name: host-run
+          hostPath:
+            path: /run
+        - name: host-var-lib-cni-multus
+          hostPath:
+            path: /var/lib/cni/multus
+        - name: host-var-lib-kubelet
+          hostPath:
+            path: /var/lib/kubelet
+        - name: host-run-k8s-cni-cncf-io
+          hostPath:
+            path: /run/k8s.cni.cncf.io
+        - name: host-run-netns
+          hostPath:
+            path: /run/netns
+        - name: multus-conf-dir
+          hostPath:
+            path: /etc/cni/multus/net.d

--- a/docs/knowledge-base/architecture/secrets-and-identity.md
+++ b/docs/knowledge-base/architecture/secrets-and-identity.md
@@ -67,6 +67,12 @@ roles need identity-based KMS permissions for both keys.
   `octelium-client`, sourced from `/homelab/octelium/client-auth-token`. The
   token belongs to the Octelium workload User `homelab-octelium-client` and is
   created outside git with `octeliumctl`.
+  The self-hosted Octelium Cluster storage layer uses generated
+  `/homelab/octelium/postgres-password` and
+  `/homelab/octelium/redis-password` values materialized by
+  `octelium-storage-auth`; `scripts/octelium-cluster-bootstrap.sh` reads those
+  Kubernetes Secret values into a temporary `octops init` bootstrap file that is
+  never committed.
   Octelium Enterprise license material, if required for commercial or
   production use, also stays outside git; add only a safe SSM or
   ExternalSecret contract in a future change if the package needs one.

--- a/docs/knowledge-base/architecture/storage-and-state.md
+++ b/docs/knowledge-base/architecture/storage-and-state.md
@@ -37,8 +37,9 @@ ready, but they must not be treated as production-ready until:
 ## Stateful Apps
 
 The current stateful set includes Prometheus, Grafana, Deluge, media-postgres,
-n8n-postgres, Prowlarr, Radarr, Sonarr, LiteLLM, OpenClaw, n8n, and OctoBot. See
-[[workloads/inventory]] for ownership and dependency notes.
+n8n-postgres, octelium-storage PostgreSQL/Redis, Prowlarr, Radarr, Sonarr,
+LiteLLM, OpenClaw, n8n, and OctoBot. See [[workloads/inventory]] for ownership
+and dependency notes.
 
 ## Source Files
 

--- a/docs/knowledge-base/operations/validation-gates.md
+++ b/docs/knowledge-base/operations/validation-gates.md
@@ -46,6 +46,19 @@ rg -n "writeBackTarget|imageName|manifestTargets" clusters/homelab/apps/argocd-i
 
 ## Octelium Cutover Checks
 
+Before running `octops init`, validate the self-hosted Cluster prerequisites:
+
+```sh
+kubectl kustomize clusters/homelab/platform/multus
+kubectl kustomize clusters/homelab/apps/octelium-storage
+kubectl kustomize clusters/homelab/apps/octelium-cluster
+scripts/octelium-cluster-bootstrap.sh --help
+```
+
+After the prerequisite apps are applied, `scripts/octelium-cluster-bootstrap.sh`
+checks the Multus CRD, Multus DaemonSet rollout, Octelium node labels, and
+PostgreSQL/Redis readiness before it calls `octops init` in front-proxy mode.
+
 Before removing any Tailscale-backed app route, the Octelium replacement path
 must pass:
 

--- a/docs/knowledge-base/runbooks/octelium.md
+++ b/docs/knowledge-base/runbooks/octelium.md
@@ -122,12 +122,28 @@ principal in their `AuthorizationPolicy`. Workloads with Kubernetes
 `NetworkPolicy` should also allow the `octelium-client` namespace, but that is
 intent-only while kube-flannel remains the CNI.
 
-## Full Cluster Gate
+## Full Cluster Bootstrap
 
-A full in-homelab Octelium Cluster is not modeled yet. The official existing
-Kubernetes install path needs `octops init`, Multus, node labels, PostgreSQL,
-Redis, DNS, and TLS. Treat that as a separate platform design before any live
-cluster mutation.
+The in-homelab Octelium Cluster is bootstrapped by repo-owned prerequisites and
+the Octelium-native `octops init` command. The steady-state prerequisites are:
+
+- `platform-multus` in `clusters/homelab/platform/multus` for the
+  Talos-compatible Multus thick DaemonSet.
+- `IaC/live/kubernetes-node-labels` for
+  `octelium.com/node-mode-dataplane=` on `zimaboard-0` and `zimaboard-2`, and
+  `octelium.com/node-mode-controlplane=` on `zimaboard-1`.
+- `octelium-storage` in `clusters/homelab/apps/octelium-storage` for
+  PostgreSQL and Redis, with generated SSM passwords at
+  `/homelab/octelium/postgres-password` and
+  `/homelab/octelium/redis-password`.
+- `octelium-cluster` in `clusters/homelab/apps/octelium-cluster` for the Istio
+  `VirtualService` that routes the Cluster, portal, and API hostnames to the
+  Octelium data-plane ingress service in front-proxy mode.
+
+Run `scripts/octelium-cluster-bootstrap.sh --domain octelium.stinkyboi.com`
+after those prerequisites are synced and healthy. The wrapper generates a
+temporary bootstrap file from the Kubernetes Secret, runs `octops init` with
+`OCTELIUM_FRONT_PROXY_MODE=true`, and waits for the `octelium` namespace pods.
 
 ## Validation
 
@@ -135,10 +151,14 @@ Render the Kubernetes side with:
 
 ```sh
 kubectl kustomize clusters/homelab/apps/octelium
+kubectl kustomize clusters/homelab/apps/octelium-cluster
+kubectl kustomize clusters/homelab/apps/octelium-storage
+kubectl kustomize clusters/homelab/platform/multus
 helm template octelium-client oci://ghcr.io/octelium/helm-charts/octelium \
   --version 0.3.0 \
   --namespace octelium-client \
   -f clusters/homelab/apps/octelium/values.yaml
+scripts/octelium-cluster-bootstrap.sh --help
 scripts/octelium-enterprise-package.sh --help
 scripts/octelium-e2e-check.sh --help
 ```

--- a/docs/knowledge-base/workloads/inventory.md
+++ b/docs/knowledge-base/workloads/inventory.md
@@ -17,7 +17,9 @@ Octelium e2e gate passes.
 | App | Kind | Namespace | GitOps path | Terragrunt path | Depends on |
 | --- | --- | --- | --- | --- | --- |
 | `platform-dns` | support | `kube-system` | `clusters/homelab/platform/dns` | `IaC/live/argocd-apps/platform-dns` | Argo CD bootstrap |
+| `platform-multus` | support | `kube-system` | `clusters/homelab/platform/multus` | `IaC/live/argocd-apps/platform-multus` | Octelium data-plane prerequisites |
 | `platform-storage` | support | cluster-scoped | `clusters/homelab/platform/storage` | `IaC/live/argocd-apps/platform-storage` | QNAP NFS export |
+| `octelium-storage` | support | `octelium-storage` | `clusters/homelab/apps/octelium-storage` | `IaC/live/argocd-apps/octelium-storage` | external-secrets, platform-storage |
 | `media-postgres` | support | `media` | `clusters/homelab/apps/media-postgres` | `IaC/live/argocd-apps/media-postgres` | external-secrets, platform-storage |
 | `n8n-postgres` | support | `automation` | `clusters/homelab/apps/n8n-postgres` | `IaC/live/argocd-apps/n8n-postgres` | external-secrets, platform-storage |
 
@@ -30,6 +32,7 @@ Octelium e2e gate passes.
 | `cert-manager` | `cert-manager` | `clusters/homelab/apps/cert-manager` | `IaC/live/argocd-apps/cert-manager` | controller-managed certificates | external-secrets |
 | `istio` | `istio-system` | `clusters/homelab/apps/istio` | `IaC/live/argocd-apps/istio` | controller state only | cert-manager |
 | `tailscale` | `tailscale` | `clusters/homelab/apps/tailscale` | `IaC/live/argocd-apps/tailscale` | controller state only | external-secrets, istio |
+| `octelium-cluster` | `octelium` | `clusters/homelab/apps/octelium-cluster` | `IaC/live/argocd-apps/octelium-cluster` | Istio front-proxy route for the self-hosted Octelium Cluster domain, portal, and API hostnames; Octelium workloads are installed by `scripts/octelium-cluster-bootstrap.sh` through `octops` | istio, platform-multus, octelium-storage |
 | `octelium` | `octelium-client` | `clusters/homelab/apps/octelium` | `IaC/live/argocd-apps/octelium` | stateless rootless Octelium client bridge and target human app access plane for Cluster domain `octelium.stinkyboi.com`; serves the explicit homelab WEB Service catalog from `docs/examples/octelium/homelab-services.yaml`, plus Podinfo demo service; auth token is `/homelab/octelium/client-auth-token`; cutover is gated by `scripts/octelium-e2e-check.sh`; Enterprise package `octeliumee` desired version `0.22.0` is installed with `scripts/octelium-enterprise-package.sh` | external-secrets, istio |
 | `prometheus` | `monitoring` | `clusters/homelab/apps/prometheus` | `IaC/live/argocd-apps/prometheus` | persistent metrics, Alertmanager state, Argo CD scrape config, and Alertmanager Discord/OpenClaw notification secrets | external-secrets, platform-storage |
 | `grafana` | `monitoring` | `clusters/homelab/apps/grafana` | `IaC/live/argocd-apps/grafana` | persistent config, dashboards, platform/workload alert rules, expected hardware-node and Kubernetes-node alerting, public GitHub API PR/status polling, and stale direct receiver cleanup | external-secrets, cert-manager, istio, tailscale, prometheus, platform-storage |

--- a/docs/octelium.md
+++ b/docs/octelium.md
@@ -220,23 +220,54 @@ scripts/octelium-enterprise-package.sh \
 Use `--kubeconfig <path>` when the Octelium Cluster kubeconfig is not the
 default kubeconfig for the operator shell.
 
-## Full Cluster Bootstrap Requirements
+## Full Cluster Bootstrap
 
-Octelium's production install path for an existing Kubernetes cluster uses
-`octops init`, labels data-plane and control-plane nodes, requires Multus CNI,
-and needs PostgreSQL, Redis, public DNS, and a wildcard-capable TLS certificate.
-Those are real platform decisions, not a small Helm app. The current cluster
-does not yet have a repo-owned full Octelium control-plane bootstrap.
+The self-hosted Octelium Cluster bootstrap is now represented by repo-owned
+prerequisites plus the Octelium-native `octops init` operation.
 
-Before self-hosting the Octelium Cluster inside this homelab, add a separate
-design PR that models:
+Terragrunt/OpenTofu manages the Octelium node labels:
 
-- Multus installation and Talos CNI compatibility.
-- Which workers are Octelium data-plane and control-plane nodes.
-- PostgreSQL and Redis persistence, backup, and restore.
-- Public DNS and TLS ownership for the Octelium Cluster domain.
-- A repo-owned `octops init` or equivalent bootstrap workflow that does not rely
-  on manual live mutation as steady state.
+| Node | Octelium label |
+| --- | --- |
+| `zimaboard-0` | `octelium.com/node-mode-dataplane=` |
+| `zimaboard-1` | `octelium.com/node-mode-controlplane=` |
+| `zimaboard-2` | `octelium.com/node-mode-dataplane=` |
+
+Argo CD manages:
+
+- `platform-multus`, a Talos-compatible Multus thick DaemonSet in `kube-system`.
+- `octelium-storage`, PostgreSQL and Redis stores in `octelium-storage`.
+- `octelium-cluster`, the Istio `VirtualService` that routes
+  `octelium.stinkyboi.com`, `portal.octelium.stinkyboi.com`, and
+  `octelium-api.octelium.stinkyboi.com` to
+  `octelium-ingress-dataplane.octelium.svc.cluster.local:8080`.
+
+The Octelium Cluster workloads themselves are created and upgraded by `octops`.
+Use the repo-owned wrapper after the prerequisite apps are synced:
+
+```sh
+scripts/octelium-cluster-bootstrap.sh \
+  --domain octelium.stinkyboi.com \
+  --version 0.35.0
+```
+
+The wrapper reads the generated storage credentials from
+`octelium-storage-auth`, writes a temporary bootstrap file outside git, and runs
+`octops init` with `OCTELIUM_FRONT_PROXY_MODE=true` so the existing Istio gateway
+terminates TLS. If an Octelium deployment already exists, the same wrapper runs
+`octops upgrade` instead.
+
+After `octops` completes, apply the service catalog and create the connector
+credential:
+
+```sh
+octeliumctl apply docs/examples/octelium/homelab-services.yaml
+octeliumctl create cred --user homelab-octelium-client homelab-octelium-client
+```
+
+Store the printed credential in `/homelab/octelium/client-auth-token`, then set
+`replicaCount` to `1` in `clusters/homelab/apps/octelium/values.yaml`, sync the
+`octelium` Argo CD Application, and run `scripts/octelium-e2e-check.sh`.
 
 ## Validation
 
@@ -244,10 +275,14 @@ Before rollout:
 
 ```sh
 kubectl kustomize clusters/homelab/apps/octelium
+kubectl kustomize clusters/homelab/apps/octelium-cluster
+kubectl kustomize clusters/homelab/apps/octelium-storage
+kubectl kustomize clusters/homelab/platform/multus
 helm template octelium-client oci://ghcr.io/octelium/helm-charts/octelium \
   --version 0.3.0 \
   --namespace octelium-client \
   -f clusters/homelab/apps/octelium/values.yaml
+scripts/octelium-cluster-bootstrap.sh --help
 scripts/octelium-enterprise-package.sh --help
 scripts/octelium-e2e-check.sh --help
 ```

--- a/policy/kubernetes.rego
+++ b/policy/kubernetes.rego
@@ -97,6 +97,7 @@ external_secret_allowed_prefixes := {
 	"media": {"/homelab/deluge/", "/homelab/media-postgres/"},
 	"monitoring": {"/homelab/grafana/"},
 	"octelium-client": {"/homelab/octelium/"},
+	"octelium-storage": {"/homelab/octelium/"},
 	"tailscale": {"/homelab/tailscale/"},
 }
 

--- a/scripts/ci/terragrunt-apply.sh
+++ b/scripts/ci/terragrunt-apply.sh
@@ -114,6 +114,17 @@ echo "::group::AWS SSM parameter declaration plan and apply"
 )
 echo "::endgroup::"
 
+echo "::group::Kubernetes node label apply"
+(
+  cd IaC/live/kubernetes-node-labels
+  rm -f plan.out plan.json
+  terragrunt plan -out plan.out -no-color
+  terragrunt --log-disable show -json plan.out >plan.json
+  conftest test --policy ../../../policy --output github plan.json
+  terragrunt apply -no-color plan.out
+)
+echo "::endgroup::"
+
 echo "::group::AzureAD application registration apply"
 if azuread_credentials_available; then
   (

--- a/scripts/octelium-cluster-bootstrap.sh
+++ b/scripts/octelium-cluster-bootstrap.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+domain="octelium.stinkyboi.com"
+version="0.35.0"
+kubeconfig=""
+kubecontext=""
+wait_timeout="20m"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/octelium-cluster-bootstrap.sh [options]
+
+Bootstrap or upgrade the self-hosted Octelium Cluster in the homelab.
+
+The script reads generated PostgreSQL and Redis passwords from the
+octelium-storage-auth Kubernetes Secret, writes a temporary Octelium bootstrap
+file outside git, then runs octops with OCTELIUM_FRONT_PROXY_MODE=true so the
+existing Istio gateway terminates TLS for:
+
+  octelium.stinkyboi.com
+  portal.octelium.stinkyboi.com
+  octelium-api.octelium.stinkyboi.com
+
+Options:
+  --domain DOMAIN       Octelium Cluster domain. Default: octelium.stinkyboi.com
+  --version VERSION     Octelium Cluster version. Default: 0.35.0
+                        Use "latest" to omit --version.
+  --kubeconfig PATH     Kubeconfig for the homelab cluster.
+  --context NAME        Kube context for the homelab cluster.
+  --wait-timeout VALUE  kubectl wait timeout. Default: 20m
+  -h, --help            Show this help text.
+
+Prerequisites:
+  - platform-multus Argo CD Application synced and healthy
+  - octelium-storage Argo CD Application synced and healthy
+  - IaC/live/kubernetes-node-labels applied
+  - octops, kubectl, and base64 installed locally
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --domain)
+      domain="$2"
+      shift 2
+      ;;
+    --version)
+      version="$2"
+      shift 2
+      ;;
+    --kubeconfig)
+      kubeconfig="$2"
+      shift 2
+      ;;
+    --context)
+      kubecontext="$2"
+      shift 2
+      ;;
+    --wait-timeout)
+      wait_timeout="$2"
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "error: $1 is required" >&2
+    exit 127
+  fi
+}
+
+kubectl_cmd=(kubectl)
+octops_cmd=(octops)
+
+if [[ -n "$kubeconfig" ]]; then
+  kubectl_cmd+=(--kubeconfig "$kubeconfig")
+  octops_cmd+=(--kubeconfig "$kubeconfig")
+fi
+
+if [[ -n "$kubecontext" ]]; then
+  kubectl_cmd+=(--context "$kubecontext")
+  octops_cmd+=(--kubecontext "$kubecontext")
+fi
+
+require_command kubectl
+require_command octops
+require_command base64
+
+decode_base64() {
+  if base64 --decode >/dev/null 2>&1 <<<""; then
+    base64 --decode
+  else
+    base64 -D
+  fi
+}
+
+jsonpath_secret() {
+  local key="$1"
+  "${kubectl_cmd[@]}" -n octelium-storage get secret octelium-storage-auth \
+    -o "jsonpath={.data.${key}}" | decode_base64
+}
+
+require_label() {
+  local node="$1"
+  local label="$2"
+  if ! "${kubectl_cmd[@]}" get node "$node" -l "$label" -o name | grep -Fxq "node/${node}"; then
+    echo "error: node ${node} is missing required label ${label}" >&2
+    exit 1
+  fi
+}
+
+echo "Checking Octelium bootstrap prerequisites..."
+"${kubectl_cmd[@]}" get crd network-attachment-definitions.k8s.cni.cncf.io >/dev/null
+"${kubectl_cmd[@]}" -n kube-system rollout status daemonset/kube-multus-ds --timeout="${wait_timeout}"
+"${kubectl_cmd[@]}" -n octelium-storage wait --for=condition=Ready pod -l app.kubernetes.io/name=octelium-postgres --timeout="${wait_timeout}"
+"${kubectl_cmd[@]}" -n octelium-storage wait --for=condition=Ready pod -l app.kubernetes.io/name=octelium-redis --timeout="${wait_timeout}"
+require_label zimaboard-0 octelium.com/node-mode-dataplane
+require_label zimaboard-1 octelium.com/node-mode-controlplane
+require_label zimaboard-2 octelium.com/node-mode-dataplane
+
+postgres_password="$(jsonpath_secret POSTGRES_PASSWORD)"
+redis_password="$(jsonpath_secret REDIS_PASSWORD)"
+
+for secret_name in POSTGRES_PASSWORD REDIS_PASSWORD; do
+  secret_value="${postgres_password}"
+  if [[ "$secret_name" == "REDIS_PASSWORD" ]]; then
+    secret_value="${redis_password}"
+  fi
+  if [[ -z "$secret_value" || "$secret_value" == "REPLACE_ME" ]]; then
+    echo "error: ${secret_name} is empty or still set to REPLACE_ME" >&2
+    exit 1
+  fi
+done
+
+bootstrap_file="$(mktemp "${TMPDIR:-/tmp}/octelium-bootstrap.XXXXXX.yaml")"
+cleanup() {
+  rm -f "$bootstrap_file"
+}
+trap cleanup EXIT
+
+chmod 0600 "$bootstrap_file"
+cat >"$bootstrap_file" <<EOF
+spec:
+  primaryStorage:
+    postgresql:
+      username: octelium
+      password: "${postgres_password}"
+      host: octelium-postgres.octelium-storage.svc.cluster.local
+      port: 5432
+      database: octelium
+      isTLS: false
+  secondaryStorage:
+    redis:
+      username: default
+      password: "${redis_password}"
+      host: octelium-redis.octelium-storage.svc.cluster.local
+      port: 6379
+      database: 0
+      isTLS: false
+EOF
+
+if [[ -n "$("${kubectl_cmd[@]}" -n octelium get deploy -o name 2>/dev/null || true)" ]]; then
+  action=(upgrade "$domain")
+else
+  action=(init "$domain" --bootstrap "$bootstrap_file")
+fi
+
+if [[ "$version" != "latest" ]]; then
+  action+=(--version "$version")
+fi
+
+echo "Running octops ${action[0]} for ${domain} in front-proxy mode..."
+OCTELIUM_FRONT_PROXY_MODE=true "${octops_cmd[@]}" "${action[@]}"
+
+echo "Waiting for Octelium control-plane pods..."
+"${kubectl_cmd[@]}" -n octelium wait --for=condition=Ready pod --all --timeout="${wait_timeout}"
+"${kubectl_cmd[@]}" -n octelium get deploy,sts,svc,pod


### PR DESCRIPTION
## Summary
- add Talos-compatible Multus, Octelium storage, and Octelium front-door Argo CD apps
- add repo-owned Kubernetes node label management for Octelium data/control plane nodes
- add scripts/octelium-cluster-bootstrap.sh to run octops init/upgrade in Istio front-proxy mode
- document the bootstrap, storage, secret, and validation flow in docs and the knowledge base

## Validation
- kubectl kustomize clusters/homelab/platform/multus
- kubectl kustomize clusters/homelab/apps/octelium-storage
- kubectl kustomize clusters/homelab/apps/octelium-cluster
- scripts/octelium-cluster-bootstrap.sh --help
- bash scripts/ci/static-checks.sh
- bash scripts/ci/conftest-policies.sh
- terragrunt --log-disable init -backend=false for kubernetes-node-labels, platform-multus, octelium-storage, and octelium-cluster

## Notes
- local terragrunt validate hit a macOS Kubernetes-provider handshake issue after provider init; GitHub Actions validates on Linux
- bootstrap still requires octops on the operator host and a successful production apply of the prerequisite apps

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `fa85ff2d18d263235db7ec704741e13772e67afa`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->

