### PR TITLE
fix: ignore octelium storage statefulset drift

### DIFF
--- a/IaC/live/argocd-apps/octelium-storage/terragrunt.hcl
+++ b/IaC/live/argocd-apps/octelium-storage/terragrunt.hcl
@@ -63,6 +63,29 @@ inputs = {
     }
   }
 
+  ignore_differences = [
+    {
+      group     = "apps"
+      kind      = "StatefulSet"
+      name      = "octelium-postgres"
+      namespace = "octelium-storage"
+      json_pointers = [
+        "/metadata/annotations",
+        "/spec/volumeClaimTemplates"
+      ]
+    },
+    {
+      group     = "apps"
+      kind      = "StatefulSet"
+      name      = "octelium-redis"
+      namespace = "octelium-storage"
+      json_pointers = [
+        "/metadata/annotations",
+        "/spec/volumeClaimTemplates"
+      ]
+    }
+  ]
+
   info = [
     {
       name  = "state"


### PR DESCRIPTION
## Summary
- add Argo CD ignoreDifferences for the Octelium PostgreSQL and Redis StatefulSets
- match the existing repo pattern for StatefulSet annotations and volumeClaimTemplates drift
- restore octelium-storage to a stable Synced/Healthy desired state

## Validation
- terragrunt hcl fmt --check
- terragrunt hcl validate
- bash scripts/ci/static-checks.sh
- git diff --check

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `42e2046d1e35b739843c8811e91884d22ff4838c`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
