### PR TITLE
fix: check octelium node labels by selector

### DIFF
--- a/scripts/octelium-cluster-bootstrap.sh
+++ b/scripts/octelium-cluster-bootstrap.sh
@@ -114,7 +114,7 @@ jsonpath_secret() {
 require_label() {
   local node="$1"
   local label="$2"
-  if ! "${kubectl_cmd[@]}" get node "$node" -l "$label" -o name | grep -Fxq "node/${node}"; then
+  if ! "${kubectl_cmd[@]}" get node -l "$label" -o name | grep -Fxq "node/${node}"; then
     echo "error: node ${node} is missing required label ${label}" >&2
     exit 1
   fi


### PR DESCRIPTION
## Summary
- fix Octelium bootstrap preflight to query node labels by selector
- keep the expected-node check by matching the selector result

## Validation
- bash -n scripts/octelium-cluster-bootstrap.sh
- git diff --check
- bash scripts/ci/static-checks.sh

## Deployment
- required before rerunning scripts/octelium-cluster-bootstrap.sh for octelium.stinkyboi.com

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `554e40935a4d160d793fb207399ac27678d3171e`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
