### PR TITLE
fix: make octelium bootstrap temp file portable

### DIFF
--- a/scripts/octelium-cluster-bootstrap.sh
+++ b/scripts/octelium-cluster-bootstrap.sh
@@ -165,7 +165,7 @@ for secret_name in POSTGRES_PASSWORD REDIS_PASSWORD; do
   fi
 done
 
-bootstrap_file="$(mktemp "${TMPDIR:-/tmp}/octelium-bootstrap.XXXXXX.yaml")"
+bootstrap_file="$(mktemp "${TMPDIR:-/tmp}/octelium-bootstrap.XXXXXX")"
 cleanup() {
   rm -f "$bootstrap_file"
 }


### PR DESCRIPTION
## Summary
- make the Octelium bootstrap temp-file template portable across macOS and Linux mktemp implementations

## Validation
- bash -n scripts/octelium-cluster-bootstrap.sh
- git diff --check
- bash scripts/ci/static-checks.sh

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `3f45cfd27be2dd0b4ccb16ca5adaa01f4c0b8cd5`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
