### PR TITLE
fix: make octelium bootstrap upgrades noninteractive

### DIFF
--- a/scripts/octelium-cluster-bootstrap.sh
+++ b/scripts/octelium-cluster-bootstrap.sh
@@ -203,7 +203,11 @@ if [[ "$version" != "latest" ]]; then
 fi
 
 echo "Running octops ${action[0]} for ${domain} in front-proxy mode..."
-OCTELIUM_FRONT_PROXY_MODE=true "${octops_cmd[@]}" "${action[@]}"
+if [[ "${action[0]}" == "upgrade" ]]; then
+  printf 'y\n' | OCTELIUM_FRONT_PROXY_MODE=true "${octops_cmd[@]}" "${action[@]}"
+else
+  OCTELIUM_FRONT_PROXY_MODE=true "${octops_cmd[@]}" "${action[@]}"
+fi
 ensure_octelium_namespace_labels
 
 echo "Waiting for Octelium control-plane pods..."


### PR DESCRIPTION
## Summary
- feed the octops upgrade confirmation from the repo-owned bootstrap script
- keep first-time octops init behavior unchanged

## Validation
- bash -n scripts/octelium-cluster-bootstrap.sh
- git diff --check
- bash scripts/ci/static-checks.sh

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `d4a7436b9c4e54eaa208e4c1a2dcde8e5d0f3900`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
