### PR TITLE
fix: raise multus memory for octelium bootstrap

### DIFF
--- a/clusters/homelab/platform/multus/README.md
+++ b/clusters/homelab/platform/multus/README.md
@@ -9,6 +9,10 @@ This app intentionally owns only Multus. Octelium node labels are managed by the
 `IaC/live/kubernetes-node-labels` Terragrunt unit, and the Octelium Cluster is
 initialized through `scripts/octelium-cluster-bootstrap.sh`.
 
+The Multus daemon keeps a 128Mi request and 256Mi limit because Octelium service
+pod attachment churn exceeded the upstream-thin 50Mi budget during bootstrap on
+`zimaboard-0`.
+
 ## Validation
 
 After Argo CD syncs this app:

--- a/clusters/homelab/platform/multus/multus.yaml
+++ b/clusters/homelab/platform/multus/multus.yaml
@@ -209,10 +209,10 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 50Mi
+              memory: 128Mi
             limits:
               cpu: 100m
-              memory: 50Mi
+              memory: 256Mi
           securityContext:
             privileged: true
           terminationMessagePolicy: FallbackToLogsOnError

--- a/docs/knowledge-base/runbooks/octelium.md
+++ b/docs/knowledge-base/runbooks/octelium.md
@@ -198,3 +198,8 @@ was verified. The nested Octelium domain makes the client call
 `replicaCount: 0` until the real Octelium API/package path is ready and the
 nested API hostname serves Octelium instead of a generic Istio `404` or gRPC
 `Unimplemented` response.
+
+During full Cluster bootstrap, Multus must stay ready on every node that can
+host Octelium service pods. A 50Mi daemon limit OOMKilled Multus on
+`zimaboard-0` while it processed Octelium network attachments; the platform
+manifest now uses a 128Mi request and 256Mi limit.


### PR DESCRIPTION
## Summary
- raise the Multus daemon memory request/limit from 50Mi to 128Mi/256Mi after an Octelium bootstrap OOM on zimaboard-0
- document the observed failure mode in the platform README and Octelium KB runbook

## Validation
- kubectl kustomize clusters/homelab/platform/multus
- git diff --check
- bash scripts/ci/static-checks.sh

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `f651a27605af2e4bae5541eb8c1d0501e71bbb9a`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
