### PR TITLE
fix: route octelium front door to service port

### DIFF
--- a/clusters/homelab/apps/octelium-cluster/README.md
+++ b/clusters/homelab/apps/octelium-cluster/README.md
@@ -12,7 +12,8 @@ handoff to `octops` ownership.
 
 The bootstrap script runs `octops init` with `OCTELIUM_FRONT_PROXY_MODE=true`,
 so Istio terminates TLS and proxies HTTP to
-`octelium-ingress-dataplane.octelium.svc.cluster.local:8080`.
+`octelium-ingress-dataplane.octelium.svc.cluster.local:443`. The service's
+targetPort is `8080`, but Istio routes by the Kubernetes service port.
 
 ## Validation
 

--- a/clusters/homelab/apps/octelium-cluster/virtualservice.yaml
+++ b/clusters/homelab/apps/octelium-cluster/virtualservice.yaml
@@ -17,4 +17,4 @@ spec:
         - destination:
             host: octelium-ingress-dataplane.octelium.svc.cluster.local
             port:
-              number: 8080
+              number: 443

--- a/docs/knowledge-base/runbooks/octelium.md
+++ b/docs/knowledge-base/runbooks/octelium.md
@@ -138,7 +138,9 @@ the Octelium-native `octops init` command. The steady-state prerequisites are:
   `/homelab/octelium/redis-password`.
 - `octelium-cluster` in `clusters/homelab/apps/octelium-cluster` for the Istio
   `VirtualService` that routes the Cluster, portal, and API hostnames to the
-  Octelium data-plane ingress service in front-proxy mode.
+  Octelium data-plane ingress service in front-proxy mode. The route must use
+  the `octelium-ingress-dataplane` Kubernetes service port `443`; its targetPort
+  is `8080`, but Istio destination ports refer to service ports.
 
 The `octelium-cluster` Argo CD Application must not own the `octelium`
 namespace. Octelium genesis deletes and recreates that namespace during

--- a/docs/octelium.md
+++ b/docs/octelium.md
@@ -240,7 +240,7 @@ Argo CD manages:
 - `octelium-cluster`, the Istio `VirtualService` that routes
   `octelium.stinkyboi.com`, `portal.octelium.stinkyboi.com`, and
   `octelium-api.octelium.stinkyboi.com` to
-  `octelium-ingress-dataplane.octelium.svc.cluster.local:8080`.
+  `octelium-ingress-dataplane.octelium.svc.cluster.local:443`.
 
 The `octelium-cluster` Application deliberately keeps the `VirtualService` in
 `istio-system` and does not manage the `octelium` namespace. The Octelium


### PR DESCRIPTION
## Summary
- route the Octelium front-door VirtualService to the exposed Kubernetes service port 443 instead of targetPort 8080
- document the service-port versus targetPort distinction in the Octelium docs/runbook

## Validation
- kubectl kustomize clusters/homelab/apps/octelium-cluster
- git diff --check
- bash scripts/ci/static-checks.sh
- live pre-fix verification: Octelium workloads rolled out; public hostnames returned Istio 503 while VirtualService pointed at service port 8080

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `9579f03ad18f7a34f02754b4b16697eed914e226`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
