### PR TITLE
fix: use octelium ingress front proxy mode

### DIFF
--- a/clusters/homelab/apps/octelium-cluster/README.md
+++ b/clusters/homelab/apps/octelium-cluster/README.md
@@ -10,10 +10,9 @@ namespace because Octelium genesis deletes and recreates that namespace during
 the previous repo-owned `Namespace/octelium` object is not pruned during the
 handoff to `octops` ownership.
 
-The bootstrap script runs `octops init` with `OCTELIUM_FRONT_PROXY_MODE=true`,
+The bootstrap script runs `octops init` with Octelium ingress front-proxy mode,
 so Istio terminates TLS and proxies HTTP to
-`octelium-ingress-dataplane.octelium.svc.cluster.local:443`. The service's
-targetPort is `8080`, but Istio routes by the Kubernetes service port.
+`octelium-ingress-dataplane.octelium.svc.cluster.local:8080`.
 
 ## Validation
 

--- a/clusters/homelab/apps/octelium-cluster/virtualservice.yaml
+++ b/clusters/homelab/apps/octelium-cluster/virtualservice.yaml
@@ -17,4 +17,4 @@ spec:
         - destination:
             host: octelium-ingress-dataplane.octelium.svc.cluster.local
             port:
-              number: 443
+              number: 8080

--- a/docs/knowledge-base/runbooks/octelium.md
+++ b/docs/knowledge-base/runbooks/octelium.md
@@ -138,9 +138,10 @@ the Octelium-native `octops init` command. The steady-state prerequisites are:
   `/homelab/octelium/redis-password`.
 - `octelium-cluster` in `clusters/homelab/apps/octelium-cluster` for the Istio
   `VirtualService` that routes the Cluster, portal, and API hostnames to the
-  Octelium data-plane ingress service in front-proxy mode. The route must use
-  the `octelium-ingress-dataplane` Kubernetes service port `443`; its targetPort
-  is `8080`, but Istio destination ports refer to service ports.
+  Octelium data-plane ingress service in front-proxy mode. The wrapper sets
+  `OCTELIUM_INGRESS_FRONT_PROXY=true` for Octelium v0.35 and also keeps the
+  older `OCTELIUM_FRONT_PROXY_MODE=true` compatibility name so the dataplane
+  exposes cleartext HTTP on port `8080` behind the trusted Istio TLS edge.
 
 The `octelium-cluster` Argo CD Application must not own the `octelium`
 namespace. Octelium genesis deletes and recreates that namespace during
@@ -152,7 +153,7 @@ the ownership handoff.
 Run `scripts/octelium-cluster-bootstrap.sh --domain octelium.stinkyboi.com`
 after those prerequisites are synced and healthy. The wrapper generates a
 temporary bootstrap file from the Kubernetes Secret, runs `octops init` with
-`OCTELIUM_FRONT_PROXY_MODE=true`, labels the `octelium` namespace with the
+Octelium ingress front-proxy mode, labels the `octelium` namespace with the
 privileged Pod Security profile required by the Octelium data plane, and waits
 for the namespace pods.
 

--- a/docs/octelium.md
+++ b/docs/octelium.md
@@ -240,7 +240,7 @@ Argo CD manages:
 - `octelium-cluster`, the Istio `VirtualService` that routes
   `octelium.stinkyboi.com`, `portal.octelium.stinkyboi.com`, and
   `octelium-api.octelium.stinkyboi.com` to
-  `octelium-ingress-dataplane.octelium.svc.cluster.local:443`.
+  `octelium-ingress-dataplane.octelium.svc.cluster.local:8080`.
 
 The `octelium-cluster` Application deliberately keeps the `VirtualService` in
 `istio-system` and does not manage the `octelium` namespace. The Octelium
@@ -258,11 +258,13 @@ scripts/octelium-cluster-bootstrap.sh \
 
 The wrapper reads the generated storage credentials from
 `octelium-storage-auth`, writes a temporary bootstrap file outside git, and runs
-`octops init` with `OCTELIUM_FRONT_PROXY_MODE=true` so the existing Istio gateway
-terminates TLS. The wrapper also labels the `octelium` namespace with the
-privileged Pod Security profile that Octelium data-plane workloads require. If
-an Octelium deployment already exists, the same wrapper runs `octops upgrade`
-instead.
+`octops init` with Octelium ingress front-proxy mode so the existing Istio
+gateway terminates TLS. The wrapper sets `OCTELIUM_INGRESS_FRONT_PROXY=true`
+for Octelium v0.35 and also sets the older `OCTELIUM_FRONT_PROXY_MODE=true`
+name for documentation compatibility. The wrapper also labels the `octelium`
+namespace with the privileged Pod Security profile that Octelium data-plane
+workloads require. If an Octelium deployment already exists, the same wrapper
+runs `octops upgrade --wait` instead.
 
 After `octops` completes, apply the service catalog and create the connector
 credential:

--- a/scripts/octelium-cluster-bootstrap.sh
+++ b/scripts/octelium-cluster-bootstrap.sh
@@ -15,8 +15,8 @@ Bootstrap or upgrade the self-hosted Octelium Cluster in the homelab.
 
 The script reads generated PostgreSQL and Redis passwords from the
 octelium-storage-auth Kubernetes Secret, writes a temporary Octelium bootstrap
-file outside git, then runs octops with OCTELIUM_FRONT_PROXY_MODE=true so the
-existing Istio gateway terminates TLS for:
+file outside git, then runs octops with Octelium ingress front-proxy mode so
+the existing Istio gateway terminates TLS for:
 
   octelium.stinkyboi.com
   portal.octelium.stinkyboi.com
@@ -193,7 +193,7 @@ spec:
 EOF
 
 if [[ -n "$("${kubectl_cmd[@]}" -n octelium get deploy -o name 2>/dev/null || true)" ]]; then
-  action=(upgrade "$domain")
+  action=(upgrade "$domain" --wait)
 else
   action=(init "$domain" --bootstrap "$bootstrap_file")
 fi
@@ -203,13 +203,21 @@ if [[ "$version" != "latest" ]]; then
 fi
 
 echo "Running octops ${action[0]} for ${domain} in front-proxy mode..."
+run_octops() {
+  OCTELIUM_INGRESS_FRONT_PROXY=true OCTELIUM_FRONT_PROXY_MODE=true "${octops_cmd[@]}" "$@"
+}
+
 if [[ "${action[0]}" == "upgrade" ]]; then
-  printf 'y\n' | OCTELIUM_FRONT_PROXY_MODE=true "${octops_cmd[@]}" "${action[@]}"
+  printf 'y\n' | run_octops "${action[@]}"
 else
-  OCTELIUM_FRONT_PROXY_MODE=true "${octops_cmd[@]}" "${action[@]}"
+  run_octops "${action[@]}"
 fi
 ensure_octelium_namespace_labels
 
-echo "Waiting for Octelium control-plane pods..."
-"${kubectl_cmd[@]}" -n octelium wait --for=condition=Ready pod --all --timeout="${wait_timeout}"
-"${kubectl_cmd[@]}" -n octelium get deploy,sts,svc,pod
+echo "Waiting for Octelium workloads..."
+for kind in deployment daemonset statefulset; do
+  for workload in $("${kubectl_cmd[@]}" -n octelium get "$kind" -o name); do
+    "${kubectl_cmd[@]}" -n octelium rollout status "$workload" --timeout="${wait_timeout}"
+  done
+done
+"${kubectl_cmd[@]}" -n octelium get deploy,sts,ds,svc,pod


### PR DESCRIPTION
## Summary
- set the Octelium v0.35 ingress front-proxy env var in the bootstrap wrapper
- keep the older documented front-proxy env name for compatibility
- run octops upgrade with --wait and wait on workload rollouts instead of completed Jobs
- restore the Octelium front-door route/docs to the cleartext dataplane port 8080

## Validation
- bash -n scripts/octelium-cluster-bootstrap.sh
- kubectl kustomize clusters/homelab/apps/octelium-cluster
- git diff --check
- bash scripts/ci/static-checks.sh
- live diagnosis: direct SNI/TLS to dataplane works, but public Istio TLS termination 503s because the prior bootstrap env left dataplane TLS-only

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `a76933312de820e508df1ec555511f8bdf4c5d9c`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
