### PR TITLE
fix: keep octelium bootstrap upgrade unattended

### DIFF
--- a/docs/knowledge-base/runbooks/octelium.md
+++ b/docs/knowledge-base/runbooks/octelium.md
@@ -155,7 +155,10 @@ after those prerequisites are synced and healthy. The wrapper generates a
 temporary bootstrap file from the Kubernetes Secret, runs `octops init` with
 Octelium ingress front-proxy mode, labels the `octelium` namespace with the
 privileged Pod Security profile required by the Octelium data plane, and waits
-for the namespace pods.
+for the namespace workloads. When an Octelium deployment already exists, the
+same wrapper runs `octops upgrade`, answers the upgrade confirmation, and then
+waits on Kubernetes rollout status; it does not use Octelium's
+portal-authenticated `octops upgrade --wait` mode.
 
 ## Validation
 

--- a/docs/octelium.md
+++ b/docs/octelium.md
@@ -264,7 +264,9 @@ for Octelium v0.35 and also sets the older `OCTELIUM_FRONT_PROXY_MODE=true`
 name for documentation compatibility. The wrapper also labels the `octelium`
 namespace with the privileged Pod Security profile that Octelium data-plane
 workloads require. If an Octelium deployment already exists, the same wrapper
-runs `octops upgrade --wait` instead.
+runs `octops upgrade`, answers the upgrade confirmation, and waits for the
+Kubernetes workloads to roll out instead of using Octelium's portal-authenticated
+wait mode.
 
 After `octops` completes, apply the service catalog and create the connector
 credential:

--- a/scripts/octelium-cluster-bootstrap.sh
+++ b/scripts/octelium-cluster-bootstrap.sh
@@ -193,7 +193,7 @@ spec:
 EOF
 
 if [[ -n "$("${kubectl_cmd[@]}" -n octelium get deploy -o name 2>/dev/null || true)" ]]; then
-  action=(upgrade "$domain" --wait)
+  action=(upgrade "$domain")
 else
   action=(init "$domain" --bootstrap "$bootstrap_file")
 fi


### PR DESCRIPTION
## Summary

- remove the portal-authenticated octops upgrade wait flag from the homelab bootstrap wrapper
- keep the wrapper responsible for answering the upgrade confirmation and waiting on Kubernetes workload rollouts
- update Octelium docs and the knowledge-base runbook so future bootstraps stay unattended

## Validation

- bash -n scripts/octelium-cluster-bootstrap.sh
- kubectl kustomize clusters/homelab/apps/octelium-cluster
- git diff --check
- bash scripts/ci/static-checks.sh
- live Octelium upgrade job octelium-genesis-upgrade-y6yk3d completed successfully
- live endpoints: octelium.stinkyboi.com 200, portal.octelium.stinkyboi.com 401, octelium-api.octelium.stinkyboi.com 404

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `4557dafed10cf5e56c91aa4e7c692da6b04c27c1`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
