### PR TITLE
fix: wait for octelium upgrade jobs

### DIFF
--- a/docs/knowledge-base/runbooks/octelium.md
+++ b/docs/knowledge-base/runbooks/octelium.md
@@ -156,9 +156,10 @@ temporary bootstrap file from the Kubernetes Secret, runs `octops init` with
 Octelium ingress front-proxy mode, labels the `octelium` namespace with the
 privileged Pod Security profile required by the Octelium data plane, and waits
 for the namespace workloads. When an Octelium deployment already exists, the
-same wrapper runs `octops upgrade`, answers the upgrade confirmation, and then
-waits on Kubernetes rollout status; it does not use Octelium's
-portal-authenticated `octops upgrade --wait` mode.
+same wrapper runs `octops upgrade`, answers the upgrade confirmation, waits for
+the newly created `octelium-genesis-upgrade-*` Job to complete, and then waits
+on Kubernetes rollout status; it does not use Octelium's portal-authenticated
+`octops upgrade --wait` mode.
 
 ## Validation
 

--- a/docs/octelium.md
+++ b/docs/octelium.md
@@ -265,8 +265,8 @@ name for documentation compatibility. The wrapper also labels the `octelium`
 namespace with the privileged Pod Security profile that Octelium data-plane
 workloads require. If an Octelium deployment already exists, the same wrapper
 runs `octops upgrade`, answers the upgrade confirmation, and waits for the
-Kubernetes workloads to roll out instead of using Octelium's portal-authenticated
-wait mode.
+newly created `octelium-genesis-upgrade-*` Job and Kubernetes workloads to roll
+out instead of using Octelium's portal-authenticated wait mode.
 
 After `octops` completes, apply the service catalog and create the connector
 credential:

--- a/scripts/octelium-cluster-bootstrap.sh
+++ b/scripts/octelium-cluster-bootstrap.sh
@@ -141,6 +141,49 @@ ensure_octelium_namespace_labels() {
     --overwrite
 }
 
+latest_upgrade_job() {
+  local job
+  local latest=""
+
+  while IFS= read -r job; do
+    if [[ "$job" == octelium-genesis-upgrade-* ]]; then
+      latest="$job"
+    fi
+  done < <(
+    "${kubectl_cmd[@]}" -n octelium get job \
+      -l app=octelium,octelium.com/component=genesis,octelium.com/component-type=cluster \
+      --sort-by=.metadata.creationTimestamp \
+      -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null || true
+  )
+
+  printf '%s\n' "$latest"
+}
+
+wait_for_upgrade_job() {
+  local previous="$1"
+  local job=""
+
+  for ((attempt = 1; attempt <= 30; attempt++)); do
+    job="$(latest_upgrade_job)"
+    if [[ -n "$job" && "$job" != "$previous" ]]; then
+      break
+    fi
+    sleep 2
+  done
+
+  if [[ -z "$job" || "$job" == "$previous" ]]; then
+    echo "error: octops upgrade did not create a new octelium-genesis-upgrade Job" >&2
+    exit 1
+  fi
+
+  echo "Waiting for Octelium upgrade job ${job}..."
+  if ! "${kubectl_cmd[@]}" -n octelium wait --for=condition=complete "job/${job}" --timeout="${wait_timeout}"; then
+    echo "error: Octelium upgrade job ${job} did not complete" >&2
+    "${kubectl_cmd[@]}" -n octelium logs "job/${job}" --tail=200 >&2 || true
+    exit 1
+  fi
+}
+
 echo "Checking Octelium bootstrap prerequisites..."
 "${kubectl_cmd[@]}" get crd network-attachment-definitions.k8s.cni.cncf.io >/dev/null
 "${kubectl_cmd[@]}" -n kube-system rollout status daemonset/kube-multus-ds --timeout="${wait_timeout}"
@@ -192,7 +235,9 @@ spec:
       isTLS: false
 EOF
 
+previous_upgrade_job=""
 if [[ -n "$("${kubectl_cmd[@]}" -n octelium get deploy -o name 2>/dev/null || true)" ]]; then
+  previous_upgrade_job="$(latest_upgrade_job)"
   action=(upgrade "$domain")
 else
   action=(init "$domain" --bootstrap "$bootstrap_file")
@@ -209,6 +254,7 @@ run_octops() {
 
 if [[ "${action[0]}" == "upgrade" ]]; then
   printf 'y\n' | run_octops "${action[@]}"
+  wait_for_upgrade_job "$previous_upgrade_job"
 else
   run_octops "${action[@]}"
 fi


### PR DESCRIPTION
## Summary

- teach the Octelium bootstrap wrapper to detect the newly-created octelium-genesis-upgrade Job after octops upgrade starts
- wait for that Job to complete before checking Deployment and DaemonSet rollouts
- update Octelium docs and the knowledge-base runbook with the real unattended upgrade sequence

## Validation

- bash -n scripts/octelium-cluster-bootstrap.sh
- kubectl kustomize clusters/homelab/apps/octelium-cluster
- git diff --check
- bash scripts/ci/static-checks.sh
- live wrapper run waited for octelium-genesis-upgrade-bhmrsf to complete, then all Octelium deployments and octelium-gwagent rolled out successfully

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `d3598c78ca5a18c99d47083b2a321241f9736095`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
