### PR TITLE
feat: enable octelium client connector

### DIFF
--- a/clusters/homelab/apps/octelium/README.md
+++ b/clusters/homelab/apps/octelium/README.md
@@ -29,10 +29,10 @@ The Octelium resource catalog for the external Octelium Cluster is
 - WEB Services for Argo CD, Compass, Deluge, Grafana, Kiali, LiteLLM, n8n,
   OctoBot, OpenClaw, Policy Bot, Prowlarr, Radarr, Sonarr, and the demo.
 
-`values.yaml` keeps the connector at `replicaCount: 0` until the Octelium
+`values.yaml` runs the connector at `replicaCount: 1` after the Octelium
 Cluster API, service catalog, and workload credential are verified. The
 prepared `--scope` entries keep the workload credential constrained to the same
-service names when the connector is activated.
+service names while the connector is active.
 
 ## Activation And Cutover
 
@@ -59,9 +59,10 @@ aws ssm put-parameter \
   --value '<authentication-token>'
 ```
 
-After the Octelium API is verified, change `replicaCount` to `1` in a follow-up
-PR and let Argo CD sync `octelium`. The connector then serves each configured
-Octelium Service from inside the homelab cluster.
+After the Octelium API is verified, store the credential in SSM, bump the
+`octelium-client-auth` ExternalSecret annotation when the SSM version changes,
+and let Argo CD sync `octelium`. The active connector then serves each
+configured Octelium Service from inside the homelab cluster.
 
 Then run:
 

--- a/clusters/homelab/apps/octelium/externalsecret.yaml
+++ b/clusters/homelab/apps/octelium/externalsecret.yaml
@@ -4,7 +4,7 @@ metadata:
   name: octelium-client-auth
   namespace: octelium-client
   annotations:
-    homelab.rst.io/octelium-credential-ssm-version: "1"
+    homelab.rst.io/octelium-credential-ssm-version: "2"
 spec:
   refreshPolicy: OnChange
   secretStoreRef:

--- a/clusters/homelab/apps/octelium/values.yaml
+++ b/clusters/homelab/apps/octelium/values.yaml
@@ -1,4 +1,4 @@
-replicaCount: 0
+replicaCount: 1
 
 image:
   repository: ghcr.io/octelium/octelium

--- a/docs/knowledge-base/runbooks/octelium.md
+++ b/docs/knowledge-base/runbooks/octelium.md
@@ -15,7 +15,7 @@ exceptions, until those are replaced in their own change.
 
 The Argo CD Application installs the official Octelium client Helm chart plus
 repo-owned support manifests. The connector is prepared for rootless gVisor
-mode, enrolled in Istio ambient mesh, and kept at `replicaCount: 0` until the
+mode, enrolled in Istio ambient mesh, and run at `replicaCount: 1` after the
 Octelium API, service catalog, and workload credential are verified.
 
 ## Service Catalog
@@ -182,10 +182,10 @@ scripts/octelium-e2e-check.sh --help
 ```
 
 After activation, confirm External Secrets, the service catalog, and the
-connector Deployment in `octelium-client`. Activate the connector only after
-`https://octelium-api.octelium.stinkyboi.com` serves the Octelium API, not a
-generic Istio `404` or gRPC `Unimplemented` response. Stop the connector by
-returning `replicaCount` to `0`.
+connector Deployment in `octelium-client`. Rotate the workload credential only
+after `https://octelium-api.octelium.stinkyboi.com` serves the Octelium API,
+not a generic Istio `404` or gRPC `Unimplemented` response. Stop the connector
+by returning `replicaCount` to `0`.
 
 Rollback for the Enterprise package is an Octelium package operation, not an
 Argo CD sync. Update the desired package version in this runbook first, then
@@ -200,13 +200,13 @@ execute the flag as the binary. The image's upstream Dockerfile sets
 `WORKDIR /home/app` and `CMD ["./podinfo"]`, so the explicit command must be
 `./podinfo` when passing custom args.
 
-The first rollout also started the connector before the external Octelium API
-was verified. The nested Octelium domain makes the client call
+An early rollout started the connector before the external Octelium API was
+verified. The nested Octelium domain makes the client call
 `octelium-api.octelium.stinkyboi.com`, so certificate coverage for
 `*.octelium.stinkyboi.com` must remain in place. The stable GitOps state keeps
-`replicaCount: 0` until the real Octelium API/package path is ready and the
-nested API hostname serves Octelium instead of a generic Istio `404` or gRPC
-`Unimplemented` response.
+the connector active only after the real Octelium API/package path is ready and
+the nested API hostname serves Octelium instead of a generic Istio `404` or
+gRPC `Unimplemented` response.
 
 During full Cluster bootstrap, Multus must stay ready on every node that can
 host Octelium service pods. A 50Mi daemon limit OOMKilled Multus on

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -121,9 +121,9 @@ client chart plus repo-owned support manifests in
 image by digest and force `--implementation=gvisor` so the namespace can keep
 baseline Pod Security.
 
-The connector is prepared with `replicaCount: 0` until the Octelium API,
-service catalog, and workload credential are verified.
-When activated, it serves only the explicit WEB Service catalog declared in
+The connector runs with `replicaCount: 1` after the Octelium API, service
+catalog, and workload credential are verified. It serves only the explicit WEB
+Service catalog declared in
 `docs/examples/octelium/homelab-services.yaml`: Argo CD, Compass, Deluge,
 Grafana, Kiali, LiteLLM, n8n, OctoBot, OpenClaw, Policy Bot, Prowlarr, Radarr,
 Sonarr, and the Podinfo demo. The matching workload credential lives in SSM at

--- a/docs/octelium.md
+++ b/docs/octelium.md
@@ -23,9 +23,9 @@ The Kubernetes namespace is `octelium-client`. It contains:
 
 - `octelium-client-auth`, an ExternalSecret that reads
   `/homelab/octelium/client-auth-token`.
-- `octelium-client`, the Helm-managed Octelium client Deployment prepared with
-  `replicaCount: 0` until the Octelium API serves real traffic and the catalog
-  credential has been stored in SSM.
+- `octelium-client`, the Helm-managed Octelium client Deployment running with
+  `replicaCount: 1` after the Octelium API served real traffic and the catalog
+  credential was stored in SSM.
 - `octelium-demo`, a small Podinfo HTTP service exposed only as a ClusterIP.
 - `octelium-demo-allow-client`, a NetworkPolicy that allows only the Octelium
   client pod to call the demo service once a policy-enforcing CNI exists.
@@ -165,8 +165,8 @@ Keep the port-forward and temporary host entries in place until the first VPN
 or other private access path is working. Remove the temporary host entries once
 real DNS can resolve the same names to the Octelium ingress.
 
-Verify that the external Octelium API is actually serving before enabling the
-connector replica:
+Verify that the external Octelium API is actually serving before rotating the
+workload credential or rolling the connector:
 
 ```sh
 curl -vI https://octelium-api.octelium.stinkyboi.com
@@ -174,10 +174,10 @@ curl -vI https://octelium-api.octelium.stinkyboi.com
 
 The TLS certificate must match `octelium-api.octelium.stinkyboi.com`, and the
 endpoint must be the Octelium API rather than a generic Istio `404` or gRPC
-`Unimplemented` response. Once that is true and the
-`homelab-octelium-client` credential is stored in SSM, set `replicaCount` to
-`1` in `clusters/homelab/apps/octelium/values.yaml`, sync the `octelium` Argo
-CD Application, then run `scripts/octelium-e2e-check.sh`.
+`Unimplemented` response. Once that is true, create or rotate the
+`homelab-octelium-client` credential, store it in SSM, bump
+`homelab.rst.io/octelium-credential-ssm-version`, sync the `octelium` Argo CD
+Application, then run `scripts/octelium-e2e-check.sh`.
 
 ## Octelium Enterprise Package
 


### PR DESCRIPTION
## Summary
- enable the Octelium client connector replica after storing the workload credential in SSM
- bump the ExternalSecret SSM version annotation to refresh the credential
- update Octelium docs and knowledge-base notes for active connector state

## Validation
- kubectl kustomize clusters/homelab/apps/octelium
- helm template octelium-client oci://ghcr.io/octelium/helm-charts/octelium --version 0.3.0 --namespace octelium-client -f clusters/homelab/apps/octelium/values.yaml
- git diff --check
- bash scripts/ci/static-checks.sh

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `4c5158408ae9ca5e1bacbe4c5156ae8d7f08c2bb`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
