### PR TITLE
fix: format octelium client service scopes

### DIFF
--- a/clusters/homelab/apps/octelium/README.md
+++ b/clusters/homelab/apps/octelium/README.md
@@ -31,8 +31,8 @@ The Octelium resource catalog for the external Octelium Cluster is
 
 `values.yaml` runs the connector at `replicaCount: 1` after the Octelium
 Cluster API, service catalog, and workload credential are verified. The
-prepared `--scope` entries keep the workload credential constrained to the same
-service names while the connector is active.
+prepared `--scope=service:<name>` entries keep the workload credential
+constrained to the same service names while the connector is active.
 
 ## Activation And Cutover
 
@@ -195,8 +195,8 @@ curl http://127.0.0.1:18081/version
 
 1. Add the Octelium `Service` to
    `docs/examples/octelium/homelab-services.yaml`.
-2. Add the service name to both `octelium.args` as a `--scope=...` entry and
-   `octelium.serve` in `values.yaml`.
+2. Add the service name to both `octelium.args` as a
+   `--scope=service:<name>` entry and `octelium.serve` in `values.yaml`.
 3. If the destination workload has an Istio `AuthorizationPolicy`, add
    `cluster.local/ns/octelium-client/sa/octelium-client` as an allowed source.
 4. If the destination workload has a Kubernetes `NetworkPolicy`, add the

--- a/clusters/homelab/apps/octelium/values.yaml
+++ b/clusters/homelab/apps/octelium/values.yaml
@@ -46,20 +46,20 @@ octelium:
   args:
     - --implementation=gvisor
     - --ip-mode=v4
-    - --scope=argocd.homelab
-    - --scope=compass.homelab
-    - --scope=deluge.homelab
-    - --scope=grafana.homelab
-    - --scope=homelab-demo.homelab
-    - --scope=kiali.homelab
-    - --scope=litellm.homelab
-    - --scope=n8n.homelab
-    - --scope=octobot.homelab
-    - --scope=openclaw.homelab
-    - --scope=policy-bot.homelab
-    - --scope=prowlarr.homelab
-    - --scope=radarr.homelab
-    - --scope=sonarr.homelab
+    - --scope=service:argocd.homelab
+    - --scope=service:compass.homelab
+    - --scope=service:deluge.homelab
+    - --scope=service:grafana.homelab
+    - --scope=service:homelab-demo.homelab
+    - --scope=service:kiali.homelab
+    - --scope=service:litellm.homelab
+    - --scope=service:n8n.homelab
+    - --scope=service:octobot.homelab
+    - --scope=service:openclaw.homelab
+    - --scope=service:policy-bot.homelab
+    - --scope=service:prowlarr.homelab
+    - --scope=service:radarr.homelab
+    - --scope=service:sonarr.homelab
   serve:
     - argocd.homelab
     - compass.homelab

--- a/docs/knowledge-base/runbooks/octelium.md
+++ b/docs/knowledge-base/runbooks/octelium.md
@@ -28,7 +28,7 @@ Radarr, Sonarr, and `homelab-demo`.
 
 The policy allows authenticated human client sessions to WEB Services in the
 `homelab` namespace. The Kubernetes connector serves the same service list with
-matching `--scope` flags.
+matching `--scope=service:<name>` flags.
 
 ## Enterprise Package
 

--- a/docs/octelium.md
+++ b/docs/octelium.md
@@ -65,8 +65,8 @@ They create:
 Each Service upstream points at the Kubernetes Service DNS name reachable from
 inside this homelab cluster and is served by the workload user. The prepared
 Kubernetes Deployment serves the same explicit list through `octelium.serve`,
-and its workload credential is constrained with matching `--scope` flags when
-the connector is activated.
+and its workload credential is constrained with matching
+`--scope=service:<name>` flags.
 
 Apply the service catalog to the Octelium Cluster:
 


### PR DESCRIPTION
## Summary
- prefix Octelium client auth-token scopes with service: so the connector accepts them
- update Octelium docs and knowledge-base scope guidance

## Live failure fixed
- octelium-client crashed with Octelium InvalidArgument usage output because bare --scope=<service> values are invalid for auth-token sessions

## Validation
- helm template octelium-client oci://ghcr.io/octelium/helm-charts/octelium --version 0.3.0 --namespace octelium-client -f clusters/homelab/apps/octelium/values.yaml | rg -- '--scope'
- kubectl kustomize clusters/homelab/apps/octelium
- git diff --check
- bash scripts/ci/static-checks.sh

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `529baa241590c2cab71285c2ff97bb8776778036`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
