### PR TITLE
fix: refresh octelium client credential

### DIFF
--- a/clusters/homelab/apps/octelium/README.md
+++ b/clusters/homelab/apps/octelium/README.md
@@ -48,6 +48,9 @@ Create an authentication token credential for the workload user:
 octeliumctl create cred --user homelab-octelium-client homelab-octelium-client
 ```
 
+Do not attach `homelab-human-web-access` to this workload credential. That
+Policy is intentionally human-only and denies `WORKLOAD` users.
+
 Store the printed token outside git:
 
 ```sh

--- a/clusters/homelab/apps/octelium/externalsecret.yaml
+++ b/clusters/homelab/apps/octelium/externalsecret.yaml
@@ -4,7 +4,7 @@ metadata:
   name: octelium-client-auth
   namespace: octelium-client
   annotations:
-    homelab.rst.io/octelium-credential-ssm-version: "2"
+    homelab.rst.io/octelium-credential-ssm-version: "3"
 spec:
   refreshPolicy: OnChange
   secretStoreRef:

--- a/docs/knowledge-base/runbooks/octelium.md
+++ b/docs/knowledge-base/runbooks/octelium.md
@@ -108,6 +108,8 @@ remaining cutover work queue.
 `octelium-client-auth` reads `/homelab/octelium/client-auth-token` from AWS SSM.
 The token is created with `octeliumctl create cred --user
 homelab-octelium-client homelab-octelium-client` and must stay outside git.
+Do not attach `homelab-human-web-access` to this workload credential; that
+Policy is intentionally human-only and denies `WORKLOAD` users.
 
 ## Isolation
 

--- a/docs/octelium.md
+++ b/docs/octelium.md
@@ -80,6 +80,9 @@ Create a workload authentication token:
 octeliumctl create cred --user homelab-octelium-client homelab-octelium-client
 ```
 
+Do not attach `homelab-human-web-access` to this workload credential. That
+Policy is intentionally human-only and denies `WORKLOAD` users.
+
 Store the printed token in SSM, not git:
 
 ```sh


### PR DESCRIPTION
## Summary
- bump octelium-client-auth ExternalSecret annotation to SSM version 3
- document that the workload credential must not attach the human-only access policy

## Live failure fixed
- the prior workload credential had homelab-human-web-access attached, but that Policy requires ctx.user.spec.type == "HUMAN" and denied the WORKLOAD connector user
- recreated the Octelium credential without that policy and stored the new token in /homelab/octelium/client-auth-token version 3

## Validation
- kubectl kustomize clusters/homelab/apps/octelium | rg 'octelium-credential-ssm-version|ExternalSecret'
- git diff --check
- bash scripts/ci/static-checks.sh

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `3988d7fd4f7fc950615ef198ddc8faf6d4c9b9fd`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
