### PR TITLE
fix: roll octelium client on credential refresh

### DIFF
--- a/clusters/homelab/apps/octelium/README.md
+++ b/clusters/homelab/apps/octelium/README.md
@@ -62,9 +62,10 @@ aws ssm put-parameter \
   --value '<authentication-token>'
 ```
 
-After the Octelium API is verified, store the credential in SSM, bump the
-`octelium-client-auth` ExternalSecret annotation when the SSM version changes,
-and let Argo CD sync `octelium`. The active connector then serves each
+After the Octelium API is verified, store the credential in SSM, bump
+`homelab.rst.io/octelium-credential-ssm-version` on both
+`octelium-client-auth` and the connector pod annotations when the SSM version
+changes, and let Argo CD sync `octelium`. The active connector then serves each
 configured Octelium Service from inside the homelab cluster.
 
 Then run:

--- a/clusters/homelab/apps/octelium/values.yaml
+++ b/clusters/homelab/apps/octelium/values.yaml
@@ -14,6 +14,7 @@ serviceAccount:
   name: ""
 
 podAnnotations:
+  homelab.rst.io/octelium-credential-ssm-version: "3"
   homelab.rst.io/octelium-mode: client-connector
 
 podLabels:

--- a/docs/knowledge-base/runbooks/octelium.md
+++ b/docs/knowledge-base/runbooks/octelium.md
@@ -110,6 +110,9 @@ The token is created with `octeliumctl create cred --user
 homelab-octelium-client homelab-octelium-client` and must stay outside git.
 Do not attach `homelab-human-web-access` to this workload credential; that
 Policy is intentionally human-only and denies `WORKLOAD` users.
+When the SSM value changes, bump `homelab.rst.io/octelium-credential-ssm-version`
+on both the `octelium-client-auth` ExternalSecret and the connector pod
+annotations so External Secrets refreshes the Secret and Argo rolls the pod.
 
 ## Isolation
 

--- a/docs/octelium.md
+++ b/docs/octelium.md
@@ -179,8 +179,9 @@ The TLS certificate must match `octelium-api.octelium.stinkyboi.com`, and the
 endpoint must be the Octelium API rather than a generic Istio `404` or gRPC
 `Unimplemented` response. Once that is true, create or rotate the
 `homelab-octelium-client` credential, store it in SSM, bump
-`homelab.rst.io/octelium-credential-ssm-version`, sync the `octelium` Argo CD
-Application, then run `scripts/octelium-e2e-check.sh`.
+`homelab.rst.io/octelium-credential-ssm-version` on both the ExternalSecret and
+the connector pod annotations, sync the `octelium` Argo CD Application, then
+run `scripts/octelium-e2e-check.sh`.
 
 ## Octelium Enterprise Package
 

--- a/docs/secrets-aws-ssm.md
+++ b/docs/secrets-aws-ssm.md
@@ -157,8 +157,10 @@ Octelium reads `/homelab/octelium/client-auth-token` through
 `homelab-octelium-client` User in the Octelium Cluster. Keep the token out of
 git; after replacing the placeholder directly in SSM, bump
 `homelab.rst.io/octelium-credential-ssm-version` in
-`clusters/homelab/apps/octelium/externalsecret.yaml` if External Secrets needs
-to reread the value.
+`clusters/homelab/apps/octelium/externalsecret.yaml` so External Secrets
+rereads the value, and bump the same annotation in
+`clusters/homelab/apps/octelium/values.yaml` so the connector pod restarts with
+the refreshed environment variable.
 
 The cert-manager Cloudflare value should be a scoped API token with permission
 to read the zone and edit DNS records for `stinkyboi.com`; do not store the


### PR DESCRIPTION
## Summary
- add the Octelium credential SSM version annotation to the connector pod template
- document that credential rotations must bump both the ExternalSecret and pod annotations

## Live failure fixed
- ExternalSecret refreshed to SSM version 3, but the existing CrashLooping pod kept its old env var because Kubernetes Secret-backed env vars are resolved at pod creation
- this pod-template annotation forces Argo/Helm to create a fresh pod with the updated credential

## Validation
- helm template octelium-client oci://ghcr.io/octelium/helm-charts/octelium --version 0.3.0 --namespace octelium-client -f clusters/homelab/apps/octelium/values.yaml | rg 'octelium-credential-ssm-version|annotations:'
- kubectl kustomize clusters/homelab/apps/octelium | rg 'octelium-credential-ssm-version|ExternalSecret'
- git diff --check
- bash scripts/ci/static-checks.sh

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `0554238a17e1c80e2960a58fa8d188cb3b0d696b`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
