### PR TITLE
fix: pin octelium client credential version

### DIFF
--- a/clusters/homelab/apps/octelium/README.md
+++ b/clusters/homelab/apps/octelium/README.md
@@ -63,10 +63,11 @@ aws ssm put-parameter \
 ```
 
 After the Octelium API is verified, store the credential in SSM, bump
-`homelab.rst.io/octelium-credential-ssm-version` on both
-`octelium-client-auth` and the connector pod annotations when the SSM version
-changes, and let Argo CD sync `octelium`. The active connector then serves each
-configured Octelium Service from inside the homelab cluster.
+`remoteRef.version` on `octelium-client-auth`, and bump
+`homelab.rst.io/octelium-credential-ssm-version` on both the ExternalSecret and
+the connector pod annotations when the SSM version changes. Let Argo CD sync
+`octelium`; the active connector then serves each configured Octelium Service
+from inside the homelab cluster.
 
 Then run:
 

--- a/clusters/homelab/apps/octelium/externalsecret.yaml
+++ b/clusters/homelab/apps/octelium/externalsecret.yaml
@@ -20,6 +20,7 @@ spec:
       remoteRef:
         # checkov:skip=CKV_SECRET_6: SSM parameter path, not a secret value.
         key: /homelab/octelium/client-auth-token
+        version: "3"
         conversionStrategy: Default
         decodingStrategy: None
         metadataPolicy: None

--- a/docs/knowledge-base/runbooks/octelium.md
+++ b/docs/knowledge-base/runbooks/octelium.md
@@ -112,7 +112,9 @@ Do not attach `homelab-human-web-access` to this workload credential; that
 Policy is intentionally human-only and denies `WORKLOAD` users.
 When the SSM value changes, bump `homelab.rst.io/octelium-credential-ssm-version`
 on both the `octelium-client-auth` ExternalSecret and the connector pod
-annotations so External Secrets refreshes the Secret and Argo rolls the pod.
+annotations, and bump the ExternalSecret `remoteRef.version` to the exact SSM
+parameter version so External Secrets refreshes the Secret and Argo rolls the
+pod.
 
 ## Isolation
 

--- a/docs/octelium.md
+++ b/docs/octelium.md
@@ -179,6 +179,7 @@ The TLS certificate must match `octelium-api.octelium.stinkyboi.com`, and the
 endpoint must be the Octelium API rather than a generic Istio `404` or gRPC
 `Unimplemented` response. Once that is true, create or rotate the
 `homelab-octelium-client` credential, store it in SSM, bump
+`remoteRef.version` on `octelium-client-auth`, bump
 `homelab.rst.io/octelium-credential-ssm-version` on both the ExternalSecret and
 the connector pod annotations, sync the `octelium` Argo CD Application, then
 run `scripts/octelium-e2e-check.sh`.

--- a/docs/secrets-aws-ssm.md
+++ b/docs/secrets-aws-ssm.md
@@ -156,9 +156,9 @@ Octelium reads `/homelab/octelium/client-auth-token` through
 `octelium-client-auth` as the workload authentication token for the
 `homelab-octelium-client` User in the Octelium Cluster. Keep the token out of
 git; after replacing the placeholder directly in SSM, bump
-`homelab.rst.io/octelium-credential-ssm-version` in
+`remoteRef.version` and `homelab.rst.io/octelium-credential-ssm-version` in
 `clusters/homelab/apps/octelium/externalsecret.yaml` so External Secrets
-rereads the value, and bump the same annotation in
+rereads the exact Parameter Store version, and bump the same annotation in
 `clusters/homelab/apps/octelium/values.yaml` so the connector pod restarts with
 the refreshed environment variable.
 


### PR DESCRIPTION
## Summary
- pin octelium-client-auth remoteRef.version to SSM version 3
- document that Octelium credential rotations must update the ExternalSecret version field and rollout annotations

## Live failure fixed
- SSM version 3 token authenticates successfully with Octelium CLI, but the Kubernetes Secret hash did not match SSM after metadata-only refresh
- pinning remoteRef.version changes ExternalSecret spec and forces External Secrets to read the exact Parameter Store version

## Validation
- kubectl kustomize clusters/homelab/apps/octelium | rg 'version: "3"|octelium-credential-ssm-version|ExternalSecret'
- kubectl kustomize clusters/homelab/apps/octelium | kubectl apply --dry-run=server -f -
- git diff --check
- bash scripts/ci/static-checks.sh

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `a78fa5f75137bc318ea304005657dff995e2aec0`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
