### PR TITLE
fix: force octelium client secret refresh

### DIFF
--- a/clusters/homelab/apps/octelium/README.md
+++ b/clusters/homelab/apps/octelium/README.md
@@ -11,7 +11,8 @@ The deployed Kubernetes pieces are:
 - `octelium-client` namespace with baseline Pod Security and Istio ambient
   enrollment.
 - `octelium-client-auth`, an ExternalSecret sourced from
-  `/homelab/octelium/client-auth-token`.
+  `/homelab/octelium/client-auth-token` and currently rendering the versioned
+  target Secret `octelium-client-auth-v3`.
 - The official Octelium client Helm chart, configured for rootless gVisor mode
   so it does not need `NET_ADMIN` or a privileged namespace.
 - `octelium-demo`, a tiny in-cluster HTTP service that remains available as a
@@ -63,7 +64,8 @@ aws ssm put-parameter \
 ```
 
 After the Octelium API is verified, store the credential in SSM, bump
-`remoteRef.version` on `octelium-client-auth`, and bump
+`remoteRef.version` on `octelium-client-auth`, update the ExternalSecret target
+Secret name to match that SSM version, and bump
 `homelab.rst.io/octelium-credential-ssm-version` on both the ExternalSecret and
 the connector pod annotations when the SSM version changes. Let Argo CD sync
 `octelium`; the active connector then serves each configured Octelium Service

--- a/clusters/homelab/apps/octelium/externalsecret.yaml
+++ b/clusters/homelab/apps/octelium/externalsecret.yaml
@@ -11,7 +11,10 @@ spec:
     kind: ClusterSecretStore
     name: aws-ssm
   target:
-    name: octelium-client-auth
+    # External Secrets retained the original target Secret data after the SSM
+    # value was rotated. Version the rendered Secret name with the SSM version
+    # so Argo and the controller create a fresh materialized credential.
+    name: octelium-client-auth-v3
     creationPolicy: Owner
     deletionPolicy: Retain
   data:

--- a/clusters/homelab/apps/octelium/values.yaml
+++ b/clusters/homelab/apps/octelium/values.yaml
@@ -41,7 +41,7 @@ resources:
 octelium:
   domain: octelium.stinkyboi.com
   # checkov:skip=CKV_SECRET_6: Kubernetes Secret name, not a secret value.
-  authTokenSecret: octelium-client-auth
+  authTokenSecret: octelium-client-auth-v3
   # checkov:skip=CKV_SECRET_6: Kubernetes Secret key name, not a secret value.
   authTokenSecretKey: auth-token
   args:

--- a/docs/knowledge-base/architecture/secrets-and-identity.md
+++ b/docs/knowledge-base/architecture/secrets-and-identity.md
@@ -64,8 +64,9 @@ roles need identity-based KMS permissions for both keys.
 - Tailscale operator OAuth uses the `tailscale-oauth` ExternalSecret and the
   target Secret `operator-oauth`.
 - Octelium client bridge auth uses the `octelium-client-auth` ExternalSecret in
-  `octelium-client`, sourced from `/homelab/octelium/client-auth-token`. The
-  token belongs to the Octelium workload User `homelab-octelium-client` and is
+  `octelium-client`, sourced from `/homelab/octelium/client-auth-token` and
+  rendered to the versioned target Secret `octelium-client-auth-v3`. The token
+  belongs to the Octelium workload User `homelab-octelium-client` and is
   created outside git with `octeliumctl`.
   The self-hosted Octelium Cluster storage layer uses generated
   `/homelab/octelium/postgres-password` and

--- a/docs/knowledge-base/runbooks/octelium.md
+++ b/docs/knowledge-base/runbooks/octelium.md
@@ -105,16 +105,17 @@ remaining cutover work queue.
 
 ## Secret Contract
 
-`octelium-client-auth` reads `/homelab/octelium/client-auth-token` from AWS SSM.
+`octelium-client-auth` reads `/homelab/octelium/client-auth-token` from AWS SSM
+and renders the versioned target Secret `octelium-client-auth-v3`.
 The token is created with `octeliumctl create cred --user
 homelab-octelium-client homelab-octelium-client` and must stay outside git.
 Do not attach `homelab-human-web-access` to this workload credential; that
 Policy is intentionally human-only and denies `WORKLOAD` users.
 When the SSM value changes, bump `homelab.rst.io/octelium-credential-ssm-version`
 on both the `octelium-client-auth` ExternalSecret and the connector pod
-annotations, and bump the ExternalSecret `remoteRef.version` to the exact SSM
-parameter version so External Secrets refreshes the Secret and Argo rolls the
-pod.
+annotations, bump the ExternalSecret `remoteRef.version` to the exact SSM
+parameter version, and update the target Secret name to match that SSM version
+so External Secrets creates a fresh Secret and Argo rolls the pod.
 
 ## Isolation
 

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -127,7 +127,9 @@ Service catalog declared in
 `docs/examples/octelium/homelab-services.yaml`: Argo CD, Compass, Deluge,
 Grafana, Kiali, LiteLLM, n8n, OctoBot, OpenClaw, Policy Bot, Prowlarr, Radarr,
 Sonarr, and the Podinfo demo. The matching workload credential lives in SSM at
-`/homelab/octelium/client-auth-token` and renders to `octelium-client-auth`.
+`/homelab/octelium/client-auth-token` and renders through
+`octelium-client-auth` to the versioned target Secret
+`octelium-client-auth-v3`.
 Protected ambient workloads allow
 `cluster.local/ns/octelium-client/sa/octelium-client` as a narrow source.
 Octelium Enterprise is tracked separately as the `octeliumee` package at

--- a/docs/octelium.md
+++ b/docs/octelium.md
@@ -22,7 +22,8 @@ types:
 The Kubernetes namespace is `octelium-client`. It contains:
 
 - `octelium-client-auth`, an ExternalSecret that reads
-  `/homelab/octelium/client-auth-token`.
+  `/homelab/octelium/client-auth-token` and renders the versioned workload
+  token Secret consumed by the connector.
 - `octelium-client`, the Helm-managed Octelium client Deployment running with
   `replicaCount: 1` after the Octelium API served real traffic and the catalog
   credential was stored in SSM.
@@ -115,7 +116,8 @@ scripts/octelium-e2e-check.sh \
 The gate verifies:
 
 - the Octelium control-plane namespace and services exist;
-- `octelium-client-auth` is synced from SSM;
+- `octelium-client-auth` is synced from SSM and renders the versioned workload
+  token Secret consumed by the connector;
 - `octelium-client` has at least one ready replica;
 - `octelium.stinkyboi.com`, `portal.octelium.stinkyboi.com`, and
   `octelium-api.octelium.stinkyboi.com` are not generic Istio `404` responses;
@@ -179,7 +181,8 @@ The TLS certificate must match `octelium-api.octelium.stinkyboi.com`, and the
 endpoint must be the Octelium API rather than a generic Istio `404` or gRPC
 `Unimplemented` response. Once that is true, create or rotate the
 `homelab-octelium-client` credential, store it in SSM, bump
-`remoteRef.version` on `octelium-client-auth`, bump
+`remoteRef.version` on `octelium-client-auth`, update the ExternalSecret target
+Secret name to match that SSM version, bump
 `homelab.rst.io/octelium-credential-ssm-version` on both the ExternalSecret and
 the connector pod annotations, sync the `octelium` Argo CD Application, then
 run `scripts/octelium-e2e-check.sh`.

--- a/docs/secrets-aws-ssm.md
+++ b/docs/secrets-aws-ssm.md
@@ -83,7 +83,7 @@ stack because Terraform manages the Kubernetes Secret.
 | external-secrets | Terragrunt-managed Kubernetes provider Secret | `aws-ssm-auth` | `/homelab/external-secrets/aws-ssm/access-key-id`, `/homelab/external-secrets/aws-ssm/secret-access-key` |
 | cert-manager | reserved for DNS-01 issuer | `cloudflare-api-token` | `/homelab/cert-manager/cloudflare-api-token` |
 | tailscale | `tailscale-oauth` | `operator-oauth` | `/homelab/tailscale/oauth-client-id`, `/homelab/tailscale/oauth-client-secret` |
-| octelium | `octelium-client-auth` | `octelium-client-auth` | `/homelab/octelium/client-auth-token` |
+| octelium | `octelium-client-auth` | `octelium-client-auth-v3` | `/homelab/octelium/client-auth-token` |
 | grafana | `grafana-admin` | `grafana-admin` | `/homelab/grafana/admin-user`, `/homelab/grafana/admin-password` |
 | grafana | `grafana-azuread-sso` | `grafana-azuread-sso` | `/homelab/grafana/azuread/client-id`, `/homelab/grafana/azuread/client-secret`, `/homelab/grafana/azuread/auth-url`, `/homelab/grafana/azuread/token-url`, `/homelab/grafana/azuread/allowed-organizations` |
 | prometheus | `alertmanager-discord-webhook` | `alertmanager-discord-webhook` | `/homelab/grafana/discord-webhook-url` |
@@ -156,9 +156,11 @@ Octelium reads `/homelab/octelium/client-auth-token` through
 `octelium-client-auth` as the workload authentication token for the
 `homelab-octelium-client` User in the Octelium Cluster. Keep the token out of
 git; after replacing the placeholder directly in SSM, bump
-`remoteRef.version` and `homelab.rst.io/octelium-credential-ssm-version` in
+`remoteRef.version`, update the versioned ExternalSecret target Secret name,
+and bump `homelab.rst.io/octelium-credential-ssm-version` in
 `clusters/homelab/apps/octelium/externalsecret.yaml` so External Secrets
-rereads the exact Parameter Store version, and bump the same annotation in
+materializes a fresh Secret from the exact Parameter Store version, and bump
+the same annotation in
 `clusters/homelab/apps/octelium/values.yaml` so the connector pod restarts with
 the refreshed environment variable.
 


### PR DESCRIPTION
## Summary
- point the Octelium client at a versioned materialized Secret, octelium-client-auth-v3
- keep the ExternalSecret bound to SSM parameter version 3 while forcing External Secrets to create a fresh target Secret
- update the Octelium and secret-management docs/KB with the rotation contract

## Why
The Octelium client credential in SSM version 3 logs in successfully, but the existing Kubernetes Secret stayed on stale data even after the ExternalSecret reported a successful sync. Changing the target Secret name gives GitOps and External Secrets a fresh object to materialize and rolls the connector onto the known-good credential.

## Validation
- git diff --check
- kubectl apply --dry-run=server -f clusters/homelab/apps/octelium/externalsecret.yaml
- kubectl kustomize clusters/homelab/apps/octelium
- signed commit pre-commit hooks: YAML, codespell, Checkov diff, Checkov secrets

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `5907291117b7d55ac92b3fe22d14cd7d487e7b39`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
