### PR TITLE
fix: authorize octelium workload connector

### DIFF
--- a/clusters/homelab/apps/octelium/README.md
+++ b/clusters/homelab/apps/octelium/README.md
@@ -12,7 +12,7 @@ The deployed Kubernetes pieces are:
   enrollment.
 - `octelium-client-auth`, an ExternalSecret sourced from
   `/homelab/octelium/client-auth-token` and currently rendering the versioned
-  target Secret `octelium-client-auth-v3`.
+  target Secret `octelium-client-auth-v5`.
 - The official Octelium client Helm chart, configured for rootless gVisor mode
   so it does not need `NET_ADMIN` or a privileged namespace.
 - `octelium-demo`, a tiny in-cluster HTTP service that remains available as a
@@ -26,14 +26,18 @@ The Octelium resource catalog for the external Octelium Cluster is
 - Octelium Namespace `homelab`.
 - Policy `homelab-human-web-access`, which allows authenticated human client
   sessions to WEB Services in the namespace.
+- Policy `homelab-workload-web-serve`, which allows only the
+  `homelab-octelium-client` workload User to serve the namespace's WEB
+  Services.
 - Workload User `homelab-octelium-client`.
 - WEB Services for Argo CD, Compass, Deluge, Grafana, Kiali, LiteLLM, n8n,
   OctoBot, OpenClaw, Policy Bot, Prowlarr, Radarr, Sonarr, and the demo.
 
 `values.yaml` runs the connector at `replicaCount: 1` after the Octelium
 Cluster API, service catalog, and workload credential are verified. The
-prepared `--scope=service:<name>` entries keep the workload credential
-constrained to the same service names while the connector is active.
+prepared `--scope=api:user.MainService/Connect` and
+`--scope=service:<name>` entries keep the workload credential constrained to
+the User API stream and same service names while the connector is active.
 
 ## Activation And Cutover
 
@@ -46,7 +50,10 @@ octeliumctl apply docs/examples/octelium/homelab-services.yaml
 Create an authentication token credential for the workload user:
 
 ```sh
-octeliumctl create cred --user homelab-octelium-client homelab-octelium-client
+octeliumctl create cred \
+  --user homelab-octelium-client \
+  --policy homelab-workload-web-serve \
+  homelab-octelium-client
 ```
 
 Do not attach `homelab-human-web-access` to this workload credential. That
@@ -118,7 +125,10 @@ Then authenticate and apply the catalog while the port-forward is running:
 ```sh
 octelium login --domain octelium.stinkyboi.com
 octeliumctl apply docs/examples/octelium/homelab-services.yaml
-octeliumctl create cred --user homelab-octelium-client homelab-octelium-client
+octeliumctl create cred \
+  --user homelab-octelium-client \
+  --policy homelab-workload-web-serve \
+  homelab-octelium-client
 ```
 
 Store the generated workload credential in SSM as shown above, sync the Argo CD
@@ -203,7 +213,9 @@ curl http://127.0.0.1:18081/version
 1. Add the Octelium `Service` to
    `docs/examples/octelium/homelab-services.yaml`.
 2. Add the service name to both `octelium.args` as a
-   `--scope=service:<name>` entry and `octelium.serve` in `values.yaml`.
+   `--scope=service:<name>` entry and `octelium.serve` in `values.yaml`. Keep
+   `--scope=api:user.MainService/Connect` present so the scoped token can open
+   the User API connection stream.
 3. If the destination workload has an Istio `AuthorizationPolicy`, add
    `cluster.local/ns/octelium-client/sa/octelium-client` as an allowed source.
 4. If the destination workload has a Kubernetes `NetworkPolicy`, add the

--- a/clusters/homelab/apps/octelium/externalsecret.yaml
+++ b/clusters/homelab/apps/octelium/externalsecret.yaml
@@ -4,7 +4,7 @@ metadata:
   name: octelium-client-auth
   namespace: octelium-client
   annotations:
-    homelab.rst.io/octelium-credential-ssm-version: "3"
+    homelab.rst.io/octelium-credential-ssm-version: "5"
 spec:
   refreshPolicy: OnChange
   secretStoreRef:
@@ -14,7 +14,7 @@ spec:
     # External Secrets retained the original target Secret data after the SSM
     # value was rotated. Version the rendered Secret name with the SSM version
     # so Argo and the controller create a fresh materialized credential.
-    name: octelium-client-auth-v3
+    name: octelium-client-auth-v5
     creationPolicy: Owner
     deletionPolicy: Retain
   data:
@@ -23,7 +23,7 @@ spec:
       remoteRef:
         # checkov:skip=CKV_SECRET_6: SSM parameter path, not a secret value.
         key: /homelab/octelium/client-auth-token
-        version: "3"
+        version: "5"
         conversionStrategy: Default
         decodingStrategy: None
         metadataPolicy: None

--- a/clusters/homelab/apps/octelium/values.yaml
+++ b/clusters/homelab/apps/octelium/values.yaml
@@ -14,7 +14,7 @@ serviceAccount:
   name: ""
 
 podAnnotations:
-  homelab.rst.io/octelium-credential-ssm-version: "3"
+  homelab.rst.io/octelium-credential-ssm-version: "5"
   homelab.rst.io/octelium-mode: client-connector
 
 podLabels:
@@ -41,12 +41,13 @@ resources:
 octelium:
   domain: octelium.stinkyboi.com
   # checkov:skip=CKV_SECRET_6: Kubernetes Secret name, not a secret value.
-  authTokenSecret: octelium-client-auth-v3
+  authTokenSecret: octelium-client-auth-v5
   # checkov:skip=CKV_SECRET_6: Kubernetes Secret key name, not a secret value.
   authTokenSecretKey: auth-token
   args:
     - --implementation=gvisor
     - --ip-mode=v4
+    - --scope=api:user.MainService/Connect
     - --scope=service:argocd.homelab
     - --scope=service:compass.homelab
     - --scope=service:deluge.homelab

--- a/docs/examples/octelium/homelab-services.yaml
+++ b/docs/examples/octelium/homelab-services.yaml
@@ -11,6 +11,20 @@ spec:
             - match: ctx.session.status.type == "CLIENT"
             - match: ctx.service.spec.mode == "WEB"
 ---
+kind: Policy
+metadata:
+  name: homelab-workload-web-serve
+spec:
+  rules:
+    - effect: ALLOW
+      condition:
+        all:
+          of:
+            - match: ctx.user.metadata.name == "homelab-octelium-client"
+            - match: ctx.user.spec.type == "WORKLOAD"
+            - match: ctx.session.status.type == "CLIENT"
+            - match: ctx.service.spec.mode == "WEB"
+---
 kind: Namespace
 metadata:
   name: homelab
@@ -18,6 +32,7 @@ spec:
   authorization:
     policies:
       - homelab-human-web-access
+      - homelab-workload-web-serve
 ---
 kind: User
 metadata:

--- a/docs/knowledge-base/architecture/secrets-and-identity.md
+++ b/docs/knowledge-base/architecture/secrets-and-identity.md
@@ -65,7 +65,7 @@ roles need identity-based KMS permissions for both keys.
   target Secret `operator-oauth`.
 - Octelium client bridge auth uses the `octelium-client-auth` ExternalSecret in
   `octelium-client`, sourced from `/homelab/octelium/client-auth-token` and
-  rendered to the versioned target Secret `octelium-client-auth-v3`. The token
+  rendered to the versioned target Secret `octelium-client-auth-v5`. The token
   belongs to the Octelium workload User `homelab-octelium-client` and is
   created outside git with `octeliumctl`.
   The self-hosted Octelium Cluster storage layer uses generated

--- a/docs/knowledge-base/runbooks/octelium.md
+++ b/docs/knowledge-base/runbooks/octelium.md
@@ -22,13 +22,17 @@ Octelium API, service catalog, and workload credential are verified.
 
 `docs/examples/octelium/homelab-services.yaml` is the Octelium Cluster resource
 catalog. It creates Namespace `homelab`, Policy `homelab-human-web-access`,
-workload User `homelab-octelium-client`, and WEB Services for Argo CD, Compass,
-Deluge, Grafana, Kiali, LiteLLM, n8n, OctoBot, OpenClaw, Policy Bot, Prowlarr,
-Radarr, Sonarr, and `homelab-demo`.
+Policy `homelab-workload-web-serve`, workload User
+`homelab-octelium-client`, and WEB Services for Argo CD, Compass, Deluge,
+Grafana, Kiali, LiteLLM, n8n, OctoBot, OpenClaw, Policy Bot, Prowlarr, Radarr,
+Sonarr, and `homelab-demo`.
 
 The policy allows authenticated human client sessions to WEB Services in the
-`homelab` namespace. The Kubernetes connector serves the same service list with
-matching `--scope=service:<name>` flags.
+`homelab` namespace. The workload policy allows the single
+`homelab-octelium-client` workload User to serve those WEB Services. The
+Kubernetes connector serves the same service list with
+`--scope=api:user.MainService/Connect` and matching `--scope=service:<name>`
+flags.
 
 ## Enterprise Package
 
@@ -106,9 +110,10 @@ remaining cutover work queue.
 ## Secret Contract
 
 `octelium-client-auth` reads `/homelab/octelium/client-auth-token` from AWS SSM
-and renders the versioned target Secret `octelium-client-auth-v3`.
+and renders the versioned target Secret `octelium-client-auth-v5`.
 The token is created with `octeliumctl create cred --user
-homelab-octelium-client homelab-octelium-client` and must stay outside git.
+homelab-octelium-client --policy homelab-workload-web-serve
+homelab-octelium-client` and must stay outside git.
 Do not attach `homelab-human-web-access` to this workload credential; that
 Policy is intentionally human-only and denies `WORKLOAD` users.
 When the SSM value changes, bump `homelab.rst.io/octelium-credential-ssm-version`

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -126,10 +126,14 @@ catalog, and workload credential are verified. It serves only the explicit WEB
 Service catalog declared in
 `docs/examples/octelium/homelab-services.yaml`: Argo CD, Compass, Deluge,
 Grafana, Kiali, LiteLLM, n8n, OctoBot, OpenClaw, Policy Bot, Prowlarr, Radarr,
-Sonarr, and the Podinfo demo. The matching workload credential lives in SSM at
+Sonarr, and the Podinfo demo. The catalog keeps human WEB access separate from
+the workload WEB-serving rule for `homelab-octelium-client`. The matching
+workload credential lives in SSM at
 `/homelab/octelium/client-auth-token` and renders through
 `octelium-client-auth` to the versioned target Secret
-`octelium-client-auth-v3`.
+`octelium-client-auth-v5`. The connector scope list includes
+`api:user.MainService/Connect` plus one `service:<name>` entry per served WEB
+Service.
 Protected ambient workloads allow
 `cluster.local/ns/octelium-client/sa/octelium-client` as a narrow source.
 Octelium Enterprise is tracked separately as the `octeliumee` package at

--- a/docs/octelium.md
+++ b/docs/octelium.md
@@ -56,6 +56,9 @@ They create:
 - Octelium Namespace `homelab`.
 - Policy `homelab-human-web-access`, allowing authenticated human client
   sessions to WEB Services in that namespace.
+- Policy `homelab-workload-web-serve`, allowing only the
+  `homelab-octelium-client` workload User to serve WEB Services in that
+  namespace.
 - Workload User `homelab-octelium-client`.
 - WEB Services for the current homelab app routes:
   `argocd.homelab`, `compass.homelab`, `deluge.homelab`, `grafana.homelab`,
@@ -66,8 +69,9 @@ They create:
 Each Service upstream points at the Kubernetes Service DNS name reachable from
 inside this homelab cluster and is served by the workload user. The prepared
 Kubernetes Deployment serves the same explicit list through `octelium.serve`,
-and its workload credential is constrained with matching
-`--scope=service:<name>` flags.
+and its workload credential is constrained with
+`--scope=api:user.MainService/Connect` plus matching `--scope=service:<name>`
+flags.
 
 Apply the service catalog to the Octelium Cluster:
 
@@ -78,7 +82,10 @@ octeliumctl apply docs/examples/octelium/homelab-services.yaml
 Create a workload authentication token:
 
 ```sh
-octeliumctl create cred --user homelab-octelium-client homelab-octelium-client
+octeliumctl create cred \
+  --user homelab-octelium-client \
+  --policy homelab-workload-web-serve \
+  homelab-octelium-client
 ```
 
 Do not attach `homelab-human-web-access` to this workload credential. That
@@ -163,7 +170,10 @@ Then authenticate and set up the cluster resources:
 ```sh
 octelium login --domain octelium.stinkyboi.com
 octeliumctl apply docs/examples/octelium/homelab-services.yaml
-octeliumctl create cred --user homelab-octelium-client homelab-octelium-client
+octeliumctl create cred \
+  --user homelab-octelium-client \
+  --policy homelab-workload-web-serve \
+  homelab-octelium-client
 ```
 
 Keep the port-forward and temporary host entries in place until the first VPN
@@ -283,7 +293,10 @@ credential:
 
 ```sh
 octeliumctl apply docs/examples/octelium/homelab-services.yaml
-octeliumctl create cred --user homelab-octelium-client homelab-octelium-client
+octeliumctl create cred \
+  --user homelab-octelium-client \
+  --policy homelab-workload-web-serve \
+  homelab-octelium-client
 ```
 
 Store the printed credential in `/homelab/octelium/client-auth-token`, then set

--- a/docs/secrets-aws-ssm.md
+++ b/docs/secrets-aws-ssm.md
@@ -83,7 +83,7 @@ stack because Terraform manages the Kubernetes Secret.
 | external-secrets | Terragrunt-managed Kubernetes provider Secret | `aws-ssm-auth` | `/homelab/external-secrets/aws-ssm/access-key-id`, `/homelab/external-secrets/aws-ssm/secret-access-key` |
 | cert-manager | reserved for DNS-01 issuer | `cloudflare-api-token` | `/homelab/cert-manager/cloudflare-api-token` |
 | tailscale | `tailscale-oauth` | `operator-oauth` | `/homelab/tailscale/oauth-client-id`, `/homelab/tailscale/oauth-client-secret` |
-| octelium | `octelium-client-auth` | `octelium-client-auth-v3` | `/homelab/octelium/client-auth-token` |
+| octelium | `octelium-client-auth` | `octelium-client-auth-v5` | `/homelab/octelium/client-auth-token` |
 | grafana | `grafana-admin` | `grafana-admin` | `/homelab/grafana/admin-user`, `/homelab/grafana/admin-password` |
 | grafana | `grafana-azuread-sso` | `grafana-azuread-sso` | `/homelab/grafana/azuread/client-id`, `/homelab/grafana/azuread/client-secret`, `/homelab/grafana/azuread/auth-url`, `/homelab/grafana/azuread/token-url`, `/homelab/grafana/azuread/allowed-organizations` |
 | prometheus | `alertmanager-discord-webhook` | `alertmanager-discord-webhook` | `/homelab/grafana/discord-webhook-url` |


### PR DESCRIPTION
## Summary
- add the Octelium workload-serving Policy and attach it to the homelab namespace catalog
- rotate the connector to SSM parameter version 5 and materialize octelium-client-auth-v5
- add the required api:user.MainService/Connect scope alongside the per-service scopes
- update Octelium and secret-management docs/KB with the credential policy and scope requirements

## Why
The connector was receiving the correct token from SSM, but octelium connect --serve still failed with PermissionDenied. The token could login, which narrowed the issue to the serving session authorization and the scoped User API Connect stream. The credential has now been recreated with homelab-workload-web-serve attached, and the v5 token authenticates. A local connect test with the User API Connect scope stayed alive instead of failing immediately.

## Validation
- git diff --check
- YAML parse of docs/examples/octelium/homelab-services.yaml
- kubectl apply --dry-run=server -f clusters/homelab/apps/octelium/externalsecret.yaml
- kubectl kustomize clusters/homelab/apps/octelium
- octeliumctl apply docs/examples/octelium/homelab-services.yaml --domain octelium.stinkyboi.com
- SSM v5 token login test passed
- SSM v5 token connect test passed the immediate authorization check when api:user.MainService/Connect scope was included
- signed commit pre-commit hooks: YAML, codespell, Checkov diff, Checkov secrets

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `1c4600fda667550b5be0b138359cc3c7a519427d`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
