### PR TITLE
fix: route openclaw default model through codex

### DIFF
--- a/clusters/homelab/apps/openclaw/README.md
+++ b/clusters/homelab/apps/openclaw/README.md
@@ -178,9 +178,10 @@ billing, but OpenAI Codex can sign in with a ChatGPT plan and store local
 credentials on the OpenClaw PVC.
 
 The pod startup bootstrap enables the bundled `codex` plugin and sets the
-default agent model to the canonical Codex-backed OpenAI route,
-`openai/gpt-5.5`. The older `openai-codex/gpt-*` model refs are legacy routes
-and should not be used for new default config.
+default agent model to the authenticated Codex route, `codex/gpt-5.5`. The
+older `openai-codex/gpt-*` model refs are legacy routes, and
+`openai/gpt-*` routes require a separate OpenAI auth surface that this
+deployment does not manage.
 
 The bootstrap also enables the bundled `memory-wiki` plugin. OpenClaw uses that
 plugin for Imported Insights and Memory Palace, so reload the Control UI tab
@@ -222,7 +223,7 @@ kubectl -n ai exec deploy/openclaw -c app -- \
   openclaw models status --plain
 
 kubectl -n ai exec deploy/openclaw -c app -- \
-  openclaw models list --provider openai-codex
+  openclaw models list --provider codex
 ```
 
 Those OAuth credentials persist on the `/data/openclaw` volume and should not be

--- a/clusters/homelab/apps/openclaw/values.yaml
+++ b/clusters/homelab/apps/openclaw/values.yaml
@@ -181,7 +181,7 @@ controllers:
 
             openclaw config set --strict-json \
               agents.defaults.model \
-              '{"primary":"openai/gpt-5.5"}'
+              '{"primary":"codex/gpt-5.5"}'
 
             openclaw config set --strict-json \
               agents.defaults.sandbox.mode \

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -197,8 +197,10 @@ are `emptyDir` mounts at `/data/openclaw/npm` and
 OpenClaw blocks code plugins with suspicious ownership. ChatGPT Pro access uses
 interactive OpenAI Codex OAuth stored on the PVC; do not model that as an SSM
 secret or committed API key. The bootstrap also enables the bundled `codex`
-plugin and sets the default agent model to `openai/gpt-5.5`, which is the
-canonical Codex-backed OpenAI model route for new OpenClaw config. The
+plugin and sets the default agent model to `codex/gpt-5.5`, which is the
+authenticated Codex route exposed by the current OpenClaw runtime. The older
+`openai-codex/gpt-*` model refs are legacy routes, and `openai/gpt-*` routes
+require a separate OpenAI auth surface that this deployment does not manage. The
 bootstrap enables the bundled `memory-wiki` plugin so Imported Insights and
 Memory Palace are available after the Control UI tab is reloaded. The
 bootstrap pins `agents.defaults.sandbox.mode` to `off` because the Codex


### PR DESCRIPTION
## Issue

OpenClaw was healthy at the Kubernetes and Argo CD layers, and the Discord channel probe reported that Discord was enabled, configured, running, connected, and working. However, Discord-triggered agent runs were returning the generic OpenClaw error: "Something went wrong while processing your request."

Recent OpenClaw app logs showed the real failure after Discord handed the request to the agent: the embedded run attempted to use `openai/gpt-5.5` and failed against the OpenAI Responses API with `401 Unauthorized: Missing bearer or basic authentication`.

## Root Cause

The OpenClaw bootstrap still configured the default agent model as `openai/gpt-5.5`. In the current OpenClaw runtime, the pod's subscription-backed Codex OAuth profile exposes authenticated model routes under the `codex/*` provider namespace, including `codex/gpt-5.5`.

The `openai/gpt-*` route now requires a separate OpenAI auth surface that this deployment does not manage. As a result, Discord was not the broken leg; the agent failed at model authentication after receiving the Discord request.

## Fix

This updates the OpenClaw desired-state bootstrap to set `agents.defaults.model` to `codex/gpt-5.5`.

It also updates the OpenClaw README and homelab knowledge-base note so future operators verify the runtime with `openclaw models list --provider codex` and do not chase the older `openai/gpt-*` or `openai-codex/gpt-*` routes for this deployment.

## Validation

Live read-only checks before the fix:

- `kubectl -n ai get pods -l app.kubernetes.io/name=openclaw -o wide` showed the OpenClaw pod `2/2 Running`.
- `kubectl -n argocd get application openclaw -o wide` showed OpenClaw `Synced` and `Healthy`.
- `kubectl -n ai get externalsecret openclaw-secrets openclaw-github-app-private-key` showed both ExternalSecrets `SecretSynced` and ready.
- `kubectl -n ai exec deploy/openclaw -c app -- openclaw channels status --probe` showed Discord enabled, configured, running, connected, and working.
- `kubectl -n ai exec deploy/openclaw -c app -- openclaw models auth list` showed the OpenAI Codex OAuth profile present and not expired.
- `kubectl -n ai exec deploy/openclaw -c app -- openclaw models list --provider codex` showed `codex/gpt-5.5` with auth available.

Repository checks:

- `git diff --check`
- `bash scripts/ci/static-checks.sh`
- Commit pre-commit hooks passed, including formatting checks, YAML validation, codespell, Checkov Diff, and Checkov Secrets.

`bash scripts/ci/static-checks.sh` completed with zero failed Checkov checks. The local Checkov run emitted the usual Prisma guideline metadata DNS warning, but the Terraform, Kubernetes, and secrets scans all completed cleanly.


<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `cbe3c5600e17440cec89b45a14b39e0595e9d4f3`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->

