### PR TITLE
fix(octelium): allow tun device creation

### DIFF
--- a/clusters/homelab/apps/octelium/README.md
+++ b/clusters/homelab/apps/octelium/README.md
@@ -9,13 +9,13 @@ existing app hostnames are all working through Octelium.
 The deployed Kubernetes pieces are:
 
 - `octelium-client` namespace with privileged Pod Security for the connector's
-  `NET_ADMIN` TUN requirement and Istio ambient enrollment.
+  `NET_ADMIN`/`MKNOD` TUN requirement and Istio ambient enrollment.
 - `octelium-client-auth`, an ExternalSecret sourced from
   `/homelab/octelium/client-auth-token` and currently rendering the versioned
   target Secret `octelium-client-auth-v5`.
 - The official Octelium client Helm chart, configured for TUN mode with
-  `NET_ADMIN` so generated Octelium service pods can reach the connector's
-  served app ports.
+  `NET_ADMIN` and `MKNOD` so generated Octelium service pods can reach the
+  connector's served app ports.
 - `octelium-demo`, a tiny in-cluster HTTP service that remains available as a
   harmless smoke-test target.
 - `octelium-demo-allow-client`, a NetworkPolicy limiting demo ingress to the

--- a/clusters/homelab/apps/octelium/namespace.yaml
+++ b/clusters/homelab/apps/octelium/namespace.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: octelium-client
   annotations:
-    homelab.rst.io/privileged-namespace-justification: Octelium connector Pods need NET_ADMIN to serve app Services over a real TUN interface.
+    homelab.rst.io/privileged-namespace-justification: Octelium connector Pods need NET_ADMIN and MKNOD to create /dev/net/tun and serve app Services over a real TUN interface.
   labels:
     istio.io/dataplane-mode: ambient
     pod-security.kubernetes.io/enforce: privileged

--- a/clusters/homelab/apps/octelium/values.yaml
+++ b/clusters/homelab/apps/octelium/values.yaml
@@ -28,6 +28,7 @@ securityContext:
   allowPrivilegeEscalation: false
   capabilities:
     add:
+      - MKNOD
       - NET_ADMIN
     drop:
       - ALL

--- a/docs/knowledge-base/runbooks/octelium.md
+++ b/docs/knowledge-base/runbooks/octelium.md
@@ -14,9 +14,9 @@ non-app duties, such as CI cluster reachability or reviewed public webhook
 exceptions, until those are replaced in their own change.
 
 The Argo CD Application installs the official Octelium client Helm chart plus
-repo-owned support manifests. The connector runs in TUN mode with `NET_ADMIN`,
-is enrolled in Istio ambient mesh, and runs at `replicaCount: 1` after the
-Octelium API, service catalog, and workload credential are verified.
+repo-owned support manifests. The connector runs in TUN mode with `NET_ADMIN`
+and `MKNOD`, is enrolled in Istio ambient mesh, and runs at `replicaCount: 1`
+after the Octelium API, service catalog, and workload credential are verified.
 
 ## Service Catalog
 

--- a/docs/knowledge-base/runbooks/runtime-isolation.md
+++ b/docs/knowledge-base/runbooks/runtime-isolation.md
@@ -24,7 +24,7 @@ Current enforced controls:
 | `media` | Deluge Gluetun needs `NET_ADMIN` and `/dev/net/tun` |
 | `istio-system` | Istio gateway and dataplane networking |
 | `octelium` | Octelium data-plane gateway pods need host networking, hostPath CNI access, and `NET_ADMIN`/`NET_RAW`; labels are applied by `scripts/octelium-cluster-bootstrap.sh` after `octops` creates the namespace |
-| `octelium-client` | Octelium connector pods need `NET_ADMIN` to serve app Services over a real TUN interface |
+| `octelium-client` | Octelium connector pods need `NET_ADMIN` and `MKNOD` to create `/dev/net/tun` and serve app Services over a real TUN interface |
 | `tailscale` | Tailscale operator proxy Pods need privileged networking |
 
 ## Baseline Namespaces

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -118,8 +118,9 @@ until `scripts/octelium-e2e-check.sh` passes.
 The Argo CD Application installs the official `ghcr.io/octelium/helm-charts`
 client chart plus repo-owned support manifests in
 `clusters/homelab/apps/octelium`. The Helm values pin the `0.35.0` Octelium
-image by digest and force `--implementation=tun` with `NET_ADMIN` so generated
-Octelium service pods can reach the connector's served app ports.
+image by digest and force `--implementation=tun` with `NET_ADMIN` and `MKNOD`
+so the connector can create `/dev/net/tun` and generated Octelium service pods
+can reach the connector's served app ports.
 
 The connector runs with `replicaCount: 1` after the Octelium API, service
 catalog, and workload credential are verified. It serves only the explicit app

--- a/docs/octelium.md
+++ b/docs/octelium.md
@@ -40,9 +40,10 @@ cluster.local/ns/octelium-client/sa/octelium-client
 ```
 
 The Octelium client is configured for `--implementation=tun` with `NET_ADMIN`
-so generated Octelium service pods can reach the connector's served app ports.
-The `octelium-client` namespace is therefore a narrow privileged namespace; it
-does not host the Octelium data plane.
+and `MKNOD` so it can create `/dev/net/tun` and generated Octelium service pods
+can reach the connector's served app ports. The `octelium-client` namespace is
+therefore a narrow privileged namespace; it does not host the Octelium data
+plane.
 
 ## Octelium Service Catalog
 


### PR DESCRIPTION
## Summary
- add MKNOD alongside NET_ADMIN for the Octelium client connector
- document why octelium-client needs privileged Pod Security for /dev/net/tun creation
- keep the TUN connector path needed for generated Octelium service pods to reach served app ports

## Validation
- bash -n scripts/octelium-e2e-check.sh scripts/octelium-gateway-dns.sh scripts/octelium-app-dns.sh
- git diff --check
- kubectl kustomize clusters/homelab/apps/octelium
- helm template octelium-client oci://ghcr.io/octelium/helm-charts/octelium --version 0.3.0 --namespace octelium-client -f clusters/homelab/apps/octelium/values.yaml
- conftest test --policy policy --output github <(kubectl kustomize clusters/homelab/apps/octelium)

## Live context
The previous deploy rolled the connector to TUN mode, but the pod crash-looped because Octelium could not create /dev/net/tun without MKNOD.

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `666c0a6d98caa8d36d8e8f38b019587b8d9e2294`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
