### PR TITLE
fix(octelium): route app fqdn access through octelium

### DIFF
--- a/IaC/live/argocd-apps/compass/terragrunt.hcl
+++ b/IaC/live/argocd-apps/compass/terragrunt.hcl
@@ -10,7 +10,6 @@ dependencies {
   paths = [
     "../cert-manager",
     "../istio",
-    "../tailscale",
     "../prometheus"
   ]
 }
@@ -85,7 +84,7 @@ inputs = {
   info = [
     {
       name  = "ingress"
-      value = "Octelium target compass.homelab; tailnet stinkyboi.com route remains fallback until octelium e2e passes"
+      value = "Octelium target compass.homelab with private Istio SNI backend routing"
     },
     {
       name  = "state"

--- a/IaC/live/argocd-apps/deluge/terragrunt.hcl
+++ b/IaC/live/argocd-apps/deluge/terragrunt.hcl
@@ -11,7 +11,6 @@ dependencies {
     "../external-secrets",
     "../cert-manager",
     "../istio",
-    "../tailscale",
     "../platform-storage"
   ]
 }

--- a/IaC/live/argocd-apps/grafana/terragrunt.hcl
+++ b/IaC/live/argocd-apps/grafana/terragrunt.hcl
@@ -11,7 +11,6 @@ dependencies {
     "../external-secrets",
     "../cert-manager",
     "../istio",
-    "../tailscale",
     "../prometheus",
     "../platform-storage"
   ]
@@ -98,7 +97,7 @@ inputs = {
     },
     {
       name  = "ingress"
-      value = "docs/networking-tailnet-ingress.md"
+      value = "private app access is through the Octelium service catalog with Istio SNI backend routing"
     }
   ]
 }

--- a/IaC/live/argocd-apps/kiali/terragrunt.hcl
+++ b/IaC/live/argocd-apps/kiali/terragrunt.hcl
@@ -9,7 +9,6 @@ terraform {
 dependencies {
   paths = [
     "../istio",
-    "../tailscale",
     "../prometheus",
     "../grafana"
   ]
@@ -85,11 +84,11 @@ inputs = {
   info = [
     {
       name  = "ingress"
-      value = "docs/networking-tailnet-ingress.md"
+      value = "private app access is through the Octelium service catalog"
     },
     {
       name  = "auth"
-      value = "anonymous read-only; Octelium connector and fallback tailnet gateway allowlisted"
+      value = "anonymous read-only; Octelium service-proxy access through Istio is allowlisted"
     }
   ]
 }

--- a/IaC/live/argocd-apps/litellm/terragrunt.hcl
+++ b/IaC/live/argocd-apps/litellm/terragrunt.hcl
@@ -11,7 +11,6 @@ dependencies {
     "../external-secrets",
     "../cert-manager",
     "../istio",
-    "../tailscale",
     "../platform-storage"
   ]
 }

--- a/IaC/live/argocd-apps/octelium/terragrunt.hcl
+++ b/IaC/live/argocd-apps/octelium/terragrunt.hcl
@@ -83,7 +83,7 @@ inputs = {
   info = [
     {
       name  = "mode"
-      value = "Octelium client connector target for homelab app access; Tailscale app routes remain fallback until e2e passes"
+      value = "Octelium service catalog is the homelab app access path; app FQDNs use private Istio SNI backend routes"
     },
     {
       name  = "services"

--- a/IaC/live/argocd-apps/octobot/terragrunt.hcl
+++ b/IaC/live/argocd-apps/octobot/terragrunt.hcl
@@ -10,7 +10,6 @@ dependencies {
   paths = [
     "../cert-manager",
     "../istio",
-    "../tailscale",
     "../platform-storage"
   ]
 }
@@ -85,7 +84,7 @@ inputs = {
   info = [
     {
       name  = "rollout"
-      value = "OctoBot UI targets octobot.homelab via Octelium; tailnet route remains fallback until octelium e2e passes; no exchange credentials, real-trading strategy, or autostart configuration are committed"
+      value = "OctoBot UI targets octobot.homelab via Octelium; no exchange credentials, real-trading strategy, or autostart configuration are committed"
     }
   ]
 }

--- a/IaC/live/argocd-apps/openclaw/terragrunt.hcl
+++ b/IaC/live/argocd-apps/openclaw/terragrunt.hcl
@@ -11,7 +11,6 @@ dependencies {
     "../external-secrets",
     "../cert-manager",
     "../istio",
-    "../tailscale",
     "../litellm",
     "../platform-storage"
   ]

--- a/IaC/live/argocd-apps/prowlarr/terragrunt.hcl
+++ b/IaC/live/argocd-apps/prowlarr/terragrunt.hcl
@@ -11,7 +11,6 @@ dependencies {
     "../cert-manager",
     "../istio",
     "../media-postgres",
-    "../tailscale",
     "../platform-storage"
   ]
 }

--- a/IaC/live/argocd-apps/radarr/terragrunt.hcl
+++ b/IaC/live/argocd-apps/radarr/terragrunt.hcl
@@ -10,7 +10,6 @@ dependencies {
   paths = [
     "../cert-manager",
     "../istio",
-    "../tailscale",
     "../deluge",
     "../media-postgres",
     "../prowlarr",

--- a/IaC/live/argocd-apps/sonarr/terragrunt.hcl
+++ b/IaC/live/argocd-apps/sonarr/terragrunt.hcl
@@ -10,7 +10,6 @@ dependencies {
   paths = [
     "../cert-manager",
     "../istio",
-    "../tailscale",
     "../deluge",
     "../media-postgres",
     "../prowlarr",

--- a/clusters/homelab/apps/README.md
+++ b/clusters/homelab/apps/README.md
@@ -7,8 +7,9 @@ Typical files:
 
 - `values.yaml`: Helm values or app-template values with non-secret defaults.
 - `externalsecret.yaml`: AWS SSM Parameter Store references only.
-- `virtualservice.yaml`: Istio fallback route for app UI access while the
-  Octelium cutover gate is still failing.
+- `virtualservice.yaml`: Istio SNI routing for an app hostname that is published
+  through Octelium, or a separately reviewed non-app exception such as a webhook
+  Funnel route.
 - `kustomization.yaml`: Raw resources included by Argo CD alongside Helm
   sources.
 - `README.md`: Storage, backup, restore, rollback, and app-specific notes.
@@ -22,11 +23,13 @@ in `clusters/homelab/apps/argocd-image-updater/imageupdater.yaml`; Image Updater
 opens pull requests for those values instead of relying on live-only overrides.
 
 Human app access targets the Octelium `.homelab` service catalog in
-`docs/examples/octelium/homelab-services.yaml`. Existing tailnet app routes stay
-as fallback only until `scripts/octelium-e2e-check.sh` passes. Public Tailscale
-Funnel routes must stay limited to reviewed webhook exceptions such as n8n's
-webhook prefixes and Policy Bot's `/api/github/hook` route, and every exception
-must be documented in `docs/networking-tailnet-ingress.md`.
+`docs/examples/octelium/homelab-services.yaml`. App `VirtualService` objects are
+the private Istio backend routing layer for Octelium TCP/443 Services; they must
+stay annotated with `homelab.rst.io/access-plane: octelium` and
+`homelab.rst.io/public-funnel: "false"`. Public Tailscale Funnel routes must
+stay limited to reviewed webhook exceptions such as n8n's webhook prefixes and
+Policy Bot's `/api/github/hook` route, and every exception must be documented in
+`docs/networking-tailnet-ingress.md`.
 
 Do not add a route just because an upstream chart exposes a web UI. Prefer the
 least direct reviewed access path. For example, Grafana is the operator-facing

--- a/clusters/homelab/apps/compass/virtualservice.yaml
+++ b/clusters/homelab/apps/compass/virtualservice.yaml
@@ -1,9 +1,10 @@
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
-  name: compass-tailnet
+  name: compass-octelium
   namespace: monitoring
   annotations:
+    homelab.rst.io/access-plane: octelium
     homelab.rst.io/public-funnel: "false"
 spec:
   hosts:

--- a/clusters/homelab/apps/deluge/README.md
+++ b/clusters/homelab/apps/deluge/README.md
@@ -96,15 +96,15 @@ same restored config volume at the same time.
 ## Mesh Policy
 
 The `media` namespace is intentionally not enrolled in Istio ambient mode while
-the operator web UIs are exposed through the shared tailnet ingress gateway.
-The tailnet gateway must be able to proxy to Deluge, Radarr, Sonarr, and
-Prowlarr services without ambient HBONE resets, and the Deluge Pod cannot use
-sidecar injection because Gluetun owns the VPN network setup.
+the operator web UIs are exposed through the shared Istio ingress path published
+by Octelium. The Istio gateway must be able to proxy to Deluge, Radarr, Sonarr,
+and Prowlarr services without ambient HBONE resets, and the Deluge Pod cannot
+use sidecar injection because Gluetun owns the VPN network setup.
 
-Keep media UI access on the Istio reverse proxy ingress path with
-`public-funnel=false` Tailscale annotations. Reintroduce ambient mesh only with a
-repo-owned waypoint or equivalent gateway policy that preserves HTTPS access to
-the `*.stinkyboi.com` operator addresses.
+Keep media UI access on the Octelium service catalog path that forwards TCP/443
+to the Istio reverse proxy. Reintroduce ambient mesh only with a repo-owned
+waypoint or equivalent gateway policy that preserves HTTPS access to the
+`*.stinkyboi.com` operator addresses.
 
 ## Verification
 

--- a/clusters/homelab/apps/deluge/virtualservice.yaml
+++ b/clusters/homelab/apps/deluge/virtualservice.yaml
@@ -1,9 +1,10 @@
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
-  name: deluge-tailnet
+  name: deluge-octelium
   namespace: media
   annotations:
+    homelab.rst.io/access-plane: octelium
     homelab.rst.io/public-funnel: "false"
 spec:
   hosts:

--- a/clusters/homelab/apps/grafana/virtualservice.yaml
+++ b/clusters/homelab/apps/grafana/virtualservice.yaml
@@ -1,9 +1,10 @@
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
-  name: grafana-tailnet
+  name: grafana-octelium
   namespace: monitoring
   annotations:
+    homelab.rst.io/access-plane: octelium
     homelab.rst.io/public-funnel: "false"
 spec:
   hosts:

--- a/clusters/homelab/apps/kiali/README.md
+++ b/clusters/homelab/apps/kiali/README.md
@@ -18,32 +18,29 @@ kiali.homelab
 ```
 
 The Octelium service is the target human access path. The existing
-`https://kiali.stinkyboi.com` route through the shared
-`istio-system/tailnet-gateway` remains fallback until
-`scripts/octelium-e2e-check.sh` passes and is annotated with
-`homelab.rst.io/public-funnel: "false"`. Do not add a public Funnel route for
-Kiali.
+`https://kiali.stinkyboi.com` hostname resolves to the Octelium service address
+and reaches Kiali through the published `kiali.homelab` Service. Do not add a
+public Funnel route for Kiali.
 
 Kiali uses `auth.strategy: anonymous` and `deployment.view_only_mode: true`,
-with an Istio `AuthorizationPolicy` that allows Octelium, the fallback tailnet
-gateway, and Prometheus to reach the Kiali workload. This keeps the UI
-immediately usable without granting write operations through Kiali. If this
-becomes a broader operator surface, replace anonymous access with OIDC-backed
-authentication in a separate change.
+with an Istio `AuthorizationPolicy` that allows Octelium service-proxy traffic
+through the Istio gateway and Prometheus to reach the Kiali workload. This keeps
+the UI immediately usable without granting write operations through Kiali. If
+this becomes a broader operator surface, replace anonymous access with
+OIDC-backed authentication in a separate change.
 
 ## Dependencies
 
 Kiali depends on:
 
 - Istio for mesh resources and status.
-- Octelium for target app access, with Tailscale as fallback until the cutover
-  gate passes.
+- Octelium for app access.
 - Prometheus for graph and health metrics.
 - Grafana for dashboard links.
 
 The monitoring AuthorizationPolicies allow the Kiali service account to query
-Prometheus and Grafana, and allow Prometheus plus Octelium and the fallback
-tailnet gateway to reach Kiali. Kiali has no persistent storage requirement.
+Prometheus and Grafana, and allow Prometheus plus the Octelium service-proxy path
+to reach Kiali. Kiali has no persistent storage requirement.
 
 ## Validation
 
@@ -56,10 +53,10 @@ kubectl -n monitoring get deploy,svc kiali
 curl -I https://kiali.stinkyboi.com
 ```
 
-Expected result before the Octelium cutover gate passes: the Argo CD
-Application is `Synced` and `Healthy`, the Kiali custom resource reports a
-successful reconciliation, the Deployment and Service exist in `monitoring`,
-and the fallback tailnet HTTPS route returns a Kiali response.
+Expected result: the Argo CD Application is `Synced` and `Healthy`, the Kiali
+custom resource reports a successful reconciliation, the Deployment and Service
+exist in `monitoring`, and the `kiali.stinkyboi.com` hostname responds through
+Octelium.
 
 Rollback by reverting the `kiali` Application registration and this desired
 state path, then syncing Argo CD. Let the Kiali CR delete cleanly before

--- a/clusters/homelab/apps/kiali/virtualservice.yaml
+++ b/clusters/homelab/apps/kiali/virtualservice.yaml
@@ -1,9 +1,10 @@
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
-  name: kiali-tailnet
+  name: kiali-octelium
   namespace: monitoring
   annotations:
+    homelab.rst.io/access-plane: octelium
     homelab.rst.io/public-funnel: "false"
 spec:
   hosts:

--- a/clusters/homelab/apps/n8n/README.md
+++ b/clusters/homelab/apps/n8n/README.md
@@ -1,9 +1,8 @@
 # n8n Desired State
 
 n8n runs as a self-hosted automation service. Human editor/UI access targets
-Octelium as `n8n.homelab`; the existing tailnet Istio route at
-`https://n8n.stinkyboi.com` remains fallback until
-`scripts/octelium-e2e-check.sh` passes.
+Octelium as `n8n.homelab`, while the stable editor URL remains
+`https://n8n.stinkyboi.com` and resolves to the Octelium service address.
 
 n8n uses the dedicated `n8n-postgres` support app for workflows, credential
 metadata, user records, and execution history. It still persists
@@ -28,19 +27,18 @@ persisted settings file instead of crashlooping on an accidental mismatch.
 
 ## Access Contract
 
-- Editor/UI target: `n8n.homelab` through Octelium after cutover
-- Editor/UI fallback: `https://n8n.stinkyboi.com` through
-  `istio-system/tailnet-gateway` until the Octelium gate passes
+- Editor/UI target: `https://n8n.stinkyboi.com` through Octelium service
+  `n8n.homelab`
 - Public webhook Funnel host: `https://n8n-webhook.tail67beb.ts.net`
 - Public webhook paths: `/webhook`, `/webhook-test`, and `/webhook-waiting`
 
 `WEBHOOK_URL` is set to the public Funnel host so n8n advertises externally
-reachable webhook URLs. The editor base URL stays on the fallback
-`n8n.stinkyboi.com` host until the Octelium e2e gate passes and the app base
-URL can move to the Octelium service name. The Funnel route is declared as a
-Tailscale Ingress in `istio-system` and forwards only the webhook path prefixes
-to the Istio gateway, which then routes to the n8n service. Do not add the root
-path, editor routes, static assets, or API routes to the Funnel Ingress.
+reachable webhook URLs. The editor base URL stays on `n8n.stinkyboi.com`, but
+that app hostname is reached through Octelium rather than the public webhook
+Funnel. The Funnel route is declared as a Tailscale Ingress in `istio-system`
+and forwards only the webhook path prefixes to the Istio gateway, which then
+routes to the n8n service. Do not add the root path, editor routes, static
+assets, or API routes to the Funnel Ingress.
 
 The Tailscale tailnet policy must allow the operator proxy tag, currently
 `tag:k8s`, to use Funnel:
@@ -80,15 +78,15 @@ curl -I https://n8n.stinkyboi.com/
 curl -sS -o /dev/null -w '%{http_code}\n' https://n8n-webhook.tail67beb.ts.net/webhook/__missing__
 ```
 
-Expected route behavior before the Octelium cutover gate passes: the fallback
-editor host serves n8n through the tailnet, the Funnel host reaches n8n only
-under the webhook prefixes, and an unknown webhook path returns an n8n
-not-found response until a workflow registers that webhook.
+Expected route behavior: the editor host serves n8n through Octelium, the
+Funnel host reaches n8n only under the webhook prefixes, and an unknown webhook
+path returns an n8n not-found response until a workflow registers that webhook.
 
 ## Rollback
 
 Rollback removes public webhook exposure first by removing
 `ingress-funnel.yaml` and `gateway-funnel.yaml` from the kustomization and
-restoring `WEBHOOK_URL` to the tailnet editor host. Then sync the n8n Argo CD
-Application. Preserve both the n8n PVC and `n8n-postgres` PVC unless the
-operator explicitly chooses to rebuild from exports.
+restoring `WEBHOOK_URL` to the editor host if webhook publishing is no longer
+desired. Then sync the n8n Argo CD Application. Preserve both the n8n PVC and
+`n8n-postgres` PVC unless the operator explicitly chooses to rebuild from
+exports.

--- a/clusters/homelab/apps/n8n/authorizationpolicy.yaml
+++ b/clusters/homelab/apps/n8n/authorizationpolicy.yaml
@@ -1,7 +1,7 @@
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
-  name: n8n-allow-tailnet-gateway
+  name: n8n-allow-istio-gateway
   namespace: automation
 spec:
   selector:

--- a/clusters/homelab/apps/n8n/kustomization.yaml
+++ b/clusters/homelab/apps/n8n/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
   - authorizationpolicy.yaml
   - gateway-funnel.yaml
   - ingress-funnel.yaml
+  - virtualservice-app.yaml
   - virtualservice.yaml

--- a/clusters/homelab/apps/n8n/virtualservice-app.yaml
+++ b/clusters/homelab/apps/n8n/virtualservice-app.yaml
@@ -1,19 +1,19 @@
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
-  name: litellm-octelium
-  namespace: ai
+  name: n8n-octelium
+  namespace: automation
   annotations:
     homelab.rst.io/access-plane: octelium
     homelab.rst.io/public-funnel: "false"
 spec:
   hosts:
-    - litellm.stinkyboi.com
+    - n8n.stinkyboi.com
   gateways:
     - istio-system/tailnet-gateway
   http:
     - route:
         - destination:
-            host: litellm.ai.svc.cluster.local
+            host: n8n.automation.svc.cluster.local
             port:
-              number: 4000
+              number: 5678

--- a/clusters/homelab/apps/n8n/virtualservice.yaml
+++ b/clusters/homelab/apps/n8n/virtualservice.yaml
@@ -1,16 +1,16 @@
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
-  name: n8n-tailnet
+  name: n8n-webhook-funnel
   namespace: automation
   annotations:
-    homelab.rst.io/public-funnel: "false"
+    homelab.rst.io/public-funnel: "true"
+    homelab.rst.io/public-funnel-reviewed: "true"
+    homelab.rst.io/public-funnel-purpose: "n8n external webhook deliveries only."
 spec:
   hosts:
-    - n8n.stinkyboi.com
     - n8n-webhook.tail67beb.ts.net
   gateways:
-    - istio-system/tailnet-gateway
     - istio-system/n8n-webhook-funnel
   http:
     - name: public-webhooks
@@ -39,15 +39,6 @@ spec:
             - istio-system/n8n-webhook-funnel
           uri:
             prefix: /webhook-waiting/
-      route:
-        - destination:
-            host: n8n.automation.svc.cluster.local
-            port:
-              number: 5678
-    - name: tailnet-ui
-      match:
-        - gateways:
-            - istio-system/tailnet-gateway
       route:
         - destination:
             host: n8n.automation.svc.cluster.local

--- a/clusters/homelab/apps/octelium/README.md
+++ b/clusters/homelab/apps/octelium/README.md
@@ -1,10 +1,10 @@
 # Octelium Client Desired State
 
 This app prepares a repo-owned Octelium client connector in the homelab.
-Octelium is the replacement target for human app access. Tailscale remains the
-temporary fallback for app routes until `scripts/octelium-e2e-check.sh` proves
-the Octelium Cluster, service catalog, workload credential, connector, and
-existing app hostnames are all working through Octelium.
+Octelium is the replacement path for human app access. App hostnames keep their
+existing `*.stinkyboi.com` names, exact DNS points those names at Octelium
+private service IPs, and per-app Istio `VirtualService` objects provide only the
+backend SNI routing layer for Octelium TCP/443 Services.
 
 The deployed Kubernetes pieces are:
 
@@ -131,7 +131,7 @@ scripts/octelium-e2e-check.sh \
   --homelab-context <homelab-context>
 ```
 
-Only remove the old Tailscale-backed app UI routes after this e2e gate passes.
+Only publish app UI routes after this e2e gate passes.
 
 ## Bootstrap UI Access
 
@@ -292,7 +292,9 @@ octeliumctl delete policy homelab-human-web-access
 
 Do not delete or change Tailscale resources as part of Octelium rollback unless
 a later migration PR explicitly replaces the tailnet ingress and exit-node
-model.
+model. The app VirtualServices are retained as private Istio backend routing for
+Octelium Services; the remaining Tailscale resources are non-app paths such as
+CI/LAN reachability and reviewed webhook Funnel exceptions.
 
 Remove or downgrade the Enterprise package through an Octelium-supported
 package operation. Update the desired package version in this README and the

--- a/clusters/homelab/apps/octobot/README.md
+++ b/clusters/homelab/apps/octobot/README.md
@@ -2,9 +2,8 @@
 
 OctoBot runs as the finance namespace trading bot with a real web UI. The app
 uses the upstream `drakkarsoftware/octobot` Docker image. Human UI access
-targets Octelium as `octobot.homelab`; the existing tailnet Istio route at
-`https://octobot.stinkyboi.com` remains fallback until
-`scripts/octelium-e2e-check.sh` passes.
+targets Octelium as `octobot.homelab`, while the stable UI URL remains
+`https://octobot.stinkyboi.com` and resolves to the Octelium service address.
 
 This repository intentionally does not commit exchange API keys, trading
 profiles, Telegram tokens, or live-trading startup configuration. Use the web
@@ -18,9 +17,8 @@ to trading only with withdrawals disabled before enabling live execution.
 - Web UI port: `5001`
 - Persistent state: `octobot-user`, `octobot-tentacles`, and `octobot-logs`
   PVCs on `nfs-default`
-- Route target: `octobot.homelab` through Octelium; fallback
-  `https://octobot.stinkyboi.com` until the cutover gate passes; no public
-  Funnel route
+- Route target: `https://octobot.stinkyboi.com` through Octelium service
+  `octobot.homelab`; no public Funnel route
 - Secret source: none committed; OctoBot setup and exchange credentials are
   stored by the application on its persistent volumes
 
@@ -42,7 +40,7 @@ helm template octobot app-template \
   --values clusters/homelab/apps/octobot/values.yaml
 ```
 
-After Argo CD applies the Application, verify the workload and current fallback
+After Argo CD applies the Application, verify the workload and Octelium-backed
 route:
 
 ```sh
@@ -51,9 +49,9 @@ kubectl -n finance get deploy,pod,pvc,svc -l app.kubernetes.io/instance=octobot
 curl -I https://octobot.stinkyboi.com
 ```
 
-Expected result before the Octelium cutover gate passes: one OctoBot pod is
-ready, the UI service listens on port `5001`, the three NFS-backed PVCs are
-bound, and the fallback FQDN is reachable only from the tailnet.
+Expected result: one OctoBot pod is ready, the UI service listens on port
+`5001`, the three NFS-backed PVCs are bound, and the stable FQDN is reachable
+through Octelium.
 
 ## Operations
 

--- a/clusters/homelab/apps/octobot/virtualservice.yaml
+++ b/clusters/homelab/apps/octobot/virtualservice.yaml
@@ -1,9 +1,10 @@
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
-  name: octobot-tailnet
+  name: octobot-octelium
   namespace: finance
   annotations:
+    homelab.rst.io/access-plane: octelium
     homelab.rst.io/public-funnel: "false"
 spec:
   hosts:

--- a/clusters/homelab/apps/openclaw/README.md
+++ b/clusters/homelab/apps/openclaw/README.md
@@ -1,9 +1,9 @@
 # OpenClaw
 
-OpenClaw targets Octelium app access as `openclaw.homelab`. The existing
-tailnet Istio route at `https://openclaw.stinkyboi.com` remains fallback until
-`scripts/octelium-e2e-check.sh` passes. Runtime config and agent state persist
-on the `openclaw` PVC under `/data/openclaw`.
+OpenClaw targets Octelium app access as `openclaw.homelab`, while the stable UI
+URL remains `https://openclaw.stinkyboi.com` and resolves to the Octelium
+service address. Runtime config and agent state persist on the `openclaw` PVC
+under `/data/openclaw`.
 
 ## Resource Profile
 
@@ -57,11 +57,10 @@ kubectl -n ai exec deploy/openclaw -c app -- openclaw gateway health
 kubectl -n ai exec deploy/openclaw -c app -- openclaw devices list --json
 ```
 
-If the gateway is healthy, refresh the browser's site data for the host in use:
-`openclaw.homelab` through Octelium after cutover or the fallback
-`https://openclaw.stinkyboi.com` route before the gate passes. Reconnect through
-the current shared gateway-auth flow. To reissue a server-side token for a
-paired Control UI device, identify the `clientId: openclaw-control-ui` record
+If the gateway is healthy, refresh the browser's site data for the stable
+`https://openclaw.stinkyboi.com` host reached through Octelium. Reconnect
+through the current shared gateway-auth flow. To reissue a server-side token for
+a paired Control UI device, identify the `clientId: openclaw-control-ui` record
 and rotate its operator token:
 
 ```sh

--- a/clusters/homelab/apps/openclaw/virtualservice.yaml
+++ b/clusters/homelab/apps/openclaw/virtualservice.yaml
@@ -1,9 +1,10 @@
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
-  name: openclaw-tailnet
+  name: openclaw-octelium
   namespace: ai
   annotations:
+    homelab.rst.io/access-plane: octelium
     homelab.rst.io/public-funnel: "false"
 spec:
   hosts:

--- a/clusters/homelab/apps/policy-bot/virtualservice.yaml
+++ b/clusters/homelab/apps/policy-bot/virtualservice.yaml
@@ -1,9 +1,10 @@
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
-  name: policy-bot-tailnet
+  name: policy-bot-octelium
   namespace: automation
   annotations:
+    homelab.rst.io/access-plane: octelium
     homelab.rst.io/public-funnel: "false"
 spec:
   hosts:

--- a/clusters/homelab/apps/prowlarr/values.yaml
+++ b/clusters/homelab/apps/prowlarr/values.yaml
@@ -7,7 +7,7 @@ controllers:
     pod:
       automountServiceAccountToken: false
       annotations:
-        homelab.rst.io/mesh-mode: "tailnet-ingress"
+        homelab.rst.io/access-mode: "octelium"
     initContainers:
       configure-postgres:
         image:

--- a/clusters/homelab/apps/prowlarr/virtualservice.yaml
+++ b/clusters/homelab/apps/prowlarr/virtualservice.yaml
@@ -1,9 +1,10 @@
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
-  name: prowlarr-tailnet
+  name: prowlarr-octelium
   namespace: media
   annotations:
+    homelab.rst.io/access-plane: octelium
     homelab.rst.io/public-funnel: "false"
 spec:
   hosts:

--- a/clusters/homelab/apps/radarr/README.md
+++ b/clusters/homelab/apps/radarr/README.md
@@ -38,9 +38,10 @@ The Radarr app container also sets `RADARR__AUTH__METHOD=External` and
 variables override persisted `config.xml` entries at startup and keep the
 running process aligned if the PVC copy drifts back to Forms authentication or
 password-required mode.
-Radarr targets Octelium as the external access boundary, with the tailnet Istio
-route retained as fallback until `scripts/octelium-e2e-check.sh` passes. Funnel
-stays disabled, and Radarr's own password prompt is intentionally disabled.
+Radarr targets Octelium as the external access boundary. The stable
+`https://radarr.stinkyboi.com` hostname resolves to the Octelium service
+address, Funnel stays disabled, and Radarr's own password prompt is
+intentionally disabled.
 
 This avoids recurring lockouts when the internal Radarr username/password state
 drifts or is reset during config/database migrations. If Radarr is ever exposed

--- a/clusters/homelab/apps/radarr/values.yaml
+++ b/clusters/homelab/apps/radarr/values.yaml
@@ -7,7 +7,7 @@ controllers:
     pod:
       automountServiceAccountToken: false
       annotations:
-        homelab.rst.io/mesh-mode: "tailnet-ingress"
+        homelab.rst.io/access-mode: "octelium"
     initContainers:
       configure-postgres:
         image:

--- a/clusters/homelab/apps/radarr/virtualservice.yaml
+++ b/clusters/homelab/apps/radarr/virtualservice.yaml
@@ -1,9 +1,10 @@
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
-  name: radarr-tailnet
+  name: radarr-octelium
   namespace: media
   annotations:
+    homelab.rst.io/access-plane: octelium
     homelab.rst.io/public-funnel: "false"
 spec:
   hosts:

--- a/clusters/homelab/apps/sonarr/values.yaml
+++ b/clusters/homelab/apps/sonarr/values.yaml
@@ -7,7 +7,7 @@ controllers:
     pod:
       automountServiceAccountToken: false
       annotations:
-        homelab.rst.io/mesh-mode: "tailnet-ingress"
+        homelab.rst.io/access-mode: "octelium"
     initContainers:
       configure-postgres:
         image:

--- a/clusters/homelab/apps/sonarr/virtualservice.yaml
+++ b/clusters/homelab/apps/sonarr/virtualservice.yaml
@@ -1,9 +1,10 @@
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
-  name: sonarr-tailnet
+  name: sonarr-octelium
   namespace: media
   annotations:
+    homelab.rst.io/access-plane: octelium
     homelab.rst.io/public-funnel: "false"
 spec:
   hosts:

--- a/clusters/homelab/argocd/self-management/virtualservice.yaml
+++ b/clusters/homelab/argocd/self-management/virtualservice.yaml
@@ -1,9 +1,10 @@
 apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
-  name: argocd-tailnet
+  name: argocd-octelium
   namespace: argocd
   annotations:
+    homelab.rst.io/access-plane: octelium
     homelab.rst.io/public-funnel: "false"
 spec:
   hosts:

--- a/docs/argocd-app-onboarding.md
+++ b/docs/argocd-app-onboarding.md
@@ -23,19 +23,19 @@ requested workloads.
 | tailscale | requested | `tailscale` | `clusters/homelab/apps/tailscale` | `IaC/live/argocd-apps/tailscale` | Yes | external-secrets, istio |
 | octelium | requested | `octelium-client` | `clusters/homelab/apps/octelium` | `IaC/live/argocd-apps/octelium` | Yes | external-secrets, istio |
 | prometheus | requested | `monitoring` | `clusters/homelab/apps/prometheus` | `IaC/live/argocd-apps/prometheus` | Yes | external-secrets, platform-storage |
-| grafana | requested | `monitoring` | `clusters/homelab/apps/grafana` | `IaC/live/argocd-apps/grafana` | Yes | external-secrets, cert-manager, istio, tailscale, prometheus, platform-storage |
-| kiali | requested | `monitoring` | `clusters/homelab/apps/kiali` | `IaC/live/argocd-apps/kiali` | Yes | istio, tailscale, prometheus, grafana |
-| compass | requested | `monitoring` | `clusters/homelab/apps/compass` | `IaC/live/argocd-apps/compass` | Yes | cert-manager, istio, tailscale, prometheus |
+| grafana | requested | `monitoring` | `clusters/homelab/apps/grafana` | `IaC/live/argocd-apps/grafana` | Yes | external-secrets, cert-manager, istio, prometheus, platform-storage |
+| kiali | requested | `monitoring` | `clusters/homelab/apps/kiali` | `IaC/live/argocd-apps/kiali` | Yes | istio, prometheus, grafana |
+| compass | requested | `monitoring` | `clusters/homelab/apps/compass` | `IaC/live/argocd-apps/compass` | Yes | cert-manager, istio, prometheus |
 | descheduler | requested | `kube-system` | `clusters/homelab/apps/descheduler` | `IaC/live/argocd-apps/descheduler` | Yes | prometheus |
-| deluge | requested | `media` | `clusters/homelab/apps/deluge` | `IaC/live/argocd-apps/deluge` | Yes | cert-manager, istio, tailscale, platform-storage |
-| prowlarr | requested | `media` | `clusters/homelab/apps/prowlarr` | `IaC/live/argocd-apps/prowlarr` | Yes | cert-manager, istio, media-postgres, tailscale, platform-storage |
-| radarr | requested | `media` | `clusters/homelab/apps/radarr` | `IaC/live/argocd-apps/radarr` | Yes | cert-manager, istio, tailscale, deluge, media-postgres, prowlarr, platform-storage |
-| sonarr | requested | `media` | `clusters/homelab/apps/sonarr` | `IaC/live/argocd-apps/sonarr` | Yes | cert-manager, istio, tailscale, deluge, media-postgres, prowlarr, platform-storage |
-| litellm | requested | `ai` | `clusters/homelab/apps/litellm` | `IaC/live/argocd-apps/litellm` | Yes | external-secrets, cert-manager, istio, tailscale, platform-storage |
-| openclaw | requested | `ai` | `clusters/homelab/apps/openclaw` | `IaC/live/argocd-apps/openclaw` | Yes | external-secrets, cert-manager, istio, tailscale, litellm, platform-storage |
+| deluge | requested | `media` | `clusters/homelab/apps/deluge` | `IaC/live/argocd-apps/deluge` | Yes | cert-manager, istio, platform-storage |
+| prowlarr | requested | `media` | `clusters/homelab/apps/prowlarr` | `IaC/live/argocd-apps/prowlarr` | Yes | cert-manager, istio, media-postgres, platform-storage |
+| radarr | requested | `media` | `clusters/homelab/apps/radarr` | `IaC/live/argocd-apps/radarr` | Yes | cert-manager, istio, deluge, media-postgres, prowlarr, platform-storage |
+| sonarr | requested | `media` | `clusters/homelab/apps/sonarr` | `IaC/live/argocd-apps/sonarr` | Yes | cert-manager, istio, deluge, media-postgres, prowlarr, platform-storage |
+| litellm | requested | `ai` | `clusters/homelab/apps/litellm` | `IaC/live/argocd-apps/litellm` | Yes | external-secrets, cert-manager, istio, platform-storage |
+| openclaw | requested | `ai` | `clusters/homelab/apps/openclaw` | `IaC/live/argocd-apps/openclaw` | Yes | external-secrets, cert-manager, istio, litellm, platform-storage |
 | n8n | requested | `automation` | `clusters/homelab/apps/n8n` | `IaC/live/argocd-apps/n8n` | Yes | external-secrets, cert-manager, istio, tailscale, platform-storage, n8n-postgres |
 | policy-bot | requested | `automation` | `clusters/homelab/apps/policy-bot` | `IaC/live/argocd-apps/policy-bot` | Yes | external-secrets, cert-manager, istio, tailscale |
-| octobot | requested | `finance` | `clusters/homelab/apps/octobot` | `IaC/live/argocd-apps/octobot` | Yes | cert-manager, istio, tailscale, platform-storage |
+| octobot | requested | `finance` | `clusters/homelab/apps/octobot` | `IaC/live/argocd-apps/octobot` | Yes | cert-manager, istio, platform-storage |
 
 ## Dependency Readiness
 

--- a/docs/knowledge-base/operations/validation-gates.md
+++ b/docs/knowledge-base/operations/validation-gates.md
@@ -65,7 +65,7 @@ HTTP/2 upstream `DestinationRule` in `istio-system`; it must not create the
 bootstrap. The bootstrap wrapper applies the required privileged Pod Security
 labels to the namespace after `octops` creates it.
 
-Before removing any Tailscale-backed app route, the Octelium replacement path
+Before declaring Octelium-backed app UI access healthy, the replacement path
 must pass:
 
 ```sh

--- a/docs/knowledge-base/runbooks/octelium.md
+++ b/docs/knowledge-base/runbooks/octelium.md
@@ -8,10 +8,10 @@ Source: `docs/octelium.md`
 
 Octelium is the replacement target for human access to homelab applications.
 The current app registration is `octelium`, the Kubernetes namespace is
-`octelium-client`, and Tailscale remains only the temporary fallback for app
-routes until the Octelium e2e gate passes. Tailscale can still have separate
-non-app duties, such as CI cluster reachability or reviewed public webhook
-exceptions, until those are replaced in their own change.
+`octelium-client`, and app UI routes now use Octelium-backed
+`*.stinkyboi.com` hostnames. Tailscale can still have separate non-app duties,
+such as CI cluster reachability or reviewed public webhook exceptions, until
+those are replaced in their own change.
 
 The Argo CD Application installs the official Octelium client Helm chart plus
 repo-owned support manifests. The connector runs in TUN mode with `NET_ADMIN`
@@ -38,7 +38,9 @@ Services forward TCP/443 to the in-cluster Istio gateway, preserving existing
 moving the network path onto Octelium. The Kubernetes connector serves the same
 service list with
 `--scope=api:user.MainService/Connect` and matching `--scope=service:<name>`
-flags.
+flags. The per-app Istio `VirtualService` objects remain as private backend SNI
+routes for these TCP Services and are annotated with
+`homelab.rst.io/access-plane: octelium`.
 
 ## Enterprise Package
 
@@ -98,8 +100,8 @@ path reaches the same Octelium ingress.
 
 ## Cutover Gate
 
-`scripts/octelium-e2e-check.sh` is the required gate before removing old
-Tailscale-backed app routes. It checks the Octelium control-plane namespace,
+`scripts/octelium-e2e-check.sh` is the required gate for Octelium app access.
+It checks the Octelium control-plane namespace,
 the synced workload credential, a ready `octelium-client` replica, non-Istio
 responses from the Cluster/API/portal hostnames, every homelab app Service in
 the Octelium catalog, exact `AAAA` DNS for each existing app hostname, and
@@ -117,9 +119,8 @@ separate `--octelium-context` and `--homelab-context` values so the
 control-plane namespace checks and connector checks target the correct
 clusters.
 
-If the gate fails, keep the app `VirtualService` objects and the Tailscale
-Istio `LoadBalancer` fallback in place. Treat the failure output as the
-remaining cutover work queue.
+If the gate fails, treat the failure output as the remaining repair queue before
+declaring app access healthy.
 
 ## Secret Contract
 

--- a/docs/knowledge-base/runbooks/runtime-isolation.md
+++ b/docs/knowledge-base/runbooks/runtime-isolation.md
@@ -12,8 +12,7 @@ documentation placeholders until an enforcing CNI or policy engine exists.
 
 Current enforced controls:
 
-- fallback Istio ingress routes while the Octelium cutover gate is still
-  failing;
+- Octelium service-proxy access to app UIs through the Istio gateway;
 - workload-scoped Istio policy only where namespace mesh enrollment is proven;
 - explicit namespace Pod Security labels.
 
@@ -34,8 +33,8 @@ Current enforced controls:
 repo-owned namespace manifests. `octelium-client` is ambient-enrolled so the
 Octelium connector can be allowed as
 `cluster.local/ns/octelium-client/sa/octelium-client` by protected workloads.
-`finance` is not mesh-enrolled; OctoBot's current fallback route is a tailnet UI
-path, not a service-to-service or trading API path.
+`finance` is not mesh-enrolled; OctoBot's UI is reached through the Octelium
+service-proxy path and does not expose trading API access directly.
 
 ## Network Policy Gate
 

--- a/docs/knowledge-base/runbooks/tailnet-ingress.md
+++ b/docs/knowledge-base/runbooks/tailnet-ingress.md
@@ -6,26 +6,27 @@ Source: `docs/networking-tailnet-ingress.md`
 
 ## Model
 
-Octelium is the target access plane for human app access. Istio plus Tailscale
-remain the fallback app route until `scripts/octelium-e2e-check.sh` proves the
-Octelium Cluster, service catalog, connector, and client tunnel work end to
-end. Public Tailscale Funnel is reserved for reviewed webhook paths that
-external SaaS systems must reach.
+Octelium is the access plane for human app access. App hostnames stay on
+`*.stinkyboi.com`, but exact DNS records resolve them to Octelium private
+service addresses instead of the old Tailscale wildcard route. Public Tailscale
+Funnel is reserved for reviewed webhook paths that external SaaS systems must
+reach.
 
-`*.stinkyboi.com` is expected to resolve to the Tailscale-exposed Istio ingress
-address from tailnet clients while those fallback routes remain. DNS is not
-managed by this repo yet.
+The Octelium service catalog in `docs/examples/octelium/homelab-services.yaml`
+keeps the existing app URLs by storing each `*.stinkyboi.com` hostname as a
+service attribute and forwarding TCP/443 to the in-cluster Istio gateway. The
+per-app Istio `VirtualService` objects are private backend routes for that
+Octelium path, not public Funnel routes.
 
-Octelium is documented under [[octelium]] for the same private homelab service
-set. It replaces app access only after the e2e gate passes; it does not
-automatically replace the Tailscale exit node, CI route, or reviewed public
-webhook exceptions.
+Octelium is documented under [[octelium]]. It replaces app access only; it does
+not replace the Tailscale exit node, CI route, or reviewed public webhook
+exceptions.
 
 ## Current Route Rules
 
 - Argo CD, Grafana, Kiali, Deluge, Prowlarr, Radarr, Sonarr, LiteLLM,
-  OpenClaw, n8n editor/UI, Policy Bot UI and normal routes, and OctoBot UI
-  still have tailnet-only fallback routes.
+  OpenClaw, n8n editor/UI, Policy Bot UI and normal routes, and OctoBot UI use
+  Octelium-backed `*.stinkyboi.com` app hostnames.
 - n8n webhooks are a reviewed public Funnel exception:
   `https://n8n-webhook.tail67beb.ts.net` for `/webhook`, `/webhook-test`, and
   `/webhook-waiting` only.
@@ -33,8 +34,8 @@ webhook exceptions.
   `https://policy-bot-hook.<tailnet-name>.ts.net/api/github/hook`.
 - Prometheus is intentionally not exposed; Grafana is the metrics UI and Kiali
   is the read-only mesh UI.
-- OctoBot uses `https://octobot.stinkyboi.com` through Octelium after cutover.
-  Its exchange credentials and strategy state live on PVC-backed runtime
+- OctoBot uses `https://octobot.stinkyboi.com` through Octelium. Its exchange
+  credentials and strategy state live on PVC-backed runtime
   configuration, not in public repository files.
 - Octelium serves private app Services from
   `docs/examples/octelium/homelab-services.yaml`; public webhook callbacks stay

--- a/docs/knowledge-base/runbooks/validation.md
+++ b/docs/knowledge-base/runbooks/validation.md
@@ -53,10 +53,11 @@ considered available. Check `external-secrets`, `cert-manager`, `istio`,
 `platform-storage`.
 
 Octelium app access has a dedicated gate in `scripts/octelium-e2e-check.sh`.
-Keep fallback tailnet app UI routes in place until that gate passes. Policy Bot
-has extra route checks: the fallback tailnet UI should redirect to auth, the
-public webhook should return `400` for an unsigned empty request, and the
-Funnel root should not route.
+The gate must prove each existing `*.stinkyboi.com` app hostname resolves to an
+Octelium private service address and responds through the matching Octelium
+published Service. Policy Bot has extra route checks: the Octelium-backed UI
+should redirect to auth, the public webhook should return `400` for an unsigned
+empty request, and the Funnel root should not route.
 
 Stateful apps wait for `platform-storage`, `nfs-default`, and backup coverage.
 Sonarr, Radarr, and Prowlarr also wait for `media-postgres` and Servarr

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -11,15 +11,14 @@ Sources:
 ## Shared App Rules
 
 App desired state lives under `clusters/homelab/apps/<app>`. Typical files are
-Helm values, ExternalSecret references, VirtualServices, Kustomize resources,
-and app-specific README notes. No file in this tree may contain secret values,
-private keys, raw certificate material, private kubeconfigs, or private
-hostnames.
+Helm values, ExternalSecret references, Kustomize resources, and app-specific
+README notes. No file in this tree may contain secret values, private keys, raw
+certificate material, private kubeconfigs, or private hostnames.
 
 Human app access targets the Octelium `.homelab` service catalog. Existing
-tailnet app routes are fallback until `scripts/octelium-e2e-check.sh` passes.
-Public Funnel is limited to reviewed webhook exceptions such as n8n's webhook
-prefixes and Policy Bot's `/api/github/hook`.
+`*.stinkyboi.com` app hostnames resolve to Octelium private service IPs instead
+of the old tailnet wildcard. Public Funnel is limited to reviewed webhook
+exceptions such as n8n's webhook prefixes and Policy Bot's `/api/github/hook`.
 
 ## Platform DNS
 
@@ -112,9 +111,10 @@ allow `kiali-service-account` to query Grafana and Prometheus.
 ## Octelium
 
 Octelium runs as a TUN-mode client connector in the `octelium-client`
-namespace and is the target replacement path for human app access. It is not a
-full Octelium Cluster; the old Tailscale-backed app routes stay as fallback
-until `scripts/octelium-e2e-check.sh` passes.
+namespace and is the replacement path for human app access. App hostnames keep
+their existing `*.stinkyboi.com` names, exact DNS points those names at
+Octelium private service IPs, and per-app Istio `VirtualService` objects provide
+only the backend SNI routing layer for Octelium TCP/443 Services.
 The Argo CD Application installs the official `ghcr.io/octelium/helm-charts`
 client chart plus repo-owned support manifests in
 `clusters/homelab/apps/octelium`. The Helm values pin the `0.35.0` Octelium
@@ -149,11 +149,11 @@ domain is `octelium.stinkyboi.com`, so clients contact
 keep the Cluster domain covered by `*.stinkyboi.com` and the API/portal names
 covered by `*.octelium.stinkyboi.com`.
 
-Before removing any old app transport fallback, run
-`scripts/octelium-e2e-check.sh` and confirm the service catalog plus direct
-HTTPS probes for the existing `*.stinkyboi.com` app hostnames succeed through
-Octelium private IPv6 service addresses. The `homelab-demo.homelab` service is
-only a smoke-test target for the connector bridge.
+Before changing app transport, run `scripts/octelium-e2e-check.sh` and confirm
+the service catalog plus direct HTTPS probes for the existing
+`*.stinkyboi.com` app hostnames succeed through Octelium private IPv6 service
+addresses. The `homelab-demo.homelab` service is only a smoke-test target for
+the service-proxy path.
 
 ## OctoBot
 
@@ -284,8 +284,8 @@ not automatically import rows from it. Export workflows and credentials before
 rollout when existing SQLite contents must be preserved.
 
 n8n targets editor and API access through Octelium as `n8n.homelab`, while the
-fallback editor route stays on `https://n8n.stinkyboi.com` until the cutover
-gate passes. It advertises workflow webhook URLs through
+stable editor URL remains `https://n8n.stinkyboi.com`. It advertises workflow
+webhook URLs through
 `https://n8n-webhook.tail67beb.ts.net`. The Funnel route is limited to
 `/webhook`, `/webhook-test`, and
 `/webhook-waiting`, and forwards through the Istio ingress gateway so the n8n
@@ -295,9 +295,9 @@ account.
 ## Policy Bot
 
 Policy Bot is an in-flight stateless automation workload. Human UI access
-targets Octelium as `policy-bot.homelab`; the fallback tailnet UI lives at
+targets Octelium as `policy-bot.homelab`; the stable UI URL remains
 `https://policy-bot.stinkyboi.com`, including the root page, details pages,
-static assets, and OAuth callback, until the cutover gate passes.
+static assets, and OAuth callback.
 The public GitHub webhook is:
 
 ```text
@@ -357,10 +357,9 @@ migration sources until the `/media` copy is verified.
 
 Radarr uses `AuthenticationMethod=External` in `/config/config.xml`, managed by
 the startup init container in `clusters/homelab/apps/radarr/values.yaml`.
-Octelium is the target access boundary, and the tailnet gateway remains fallback
-with Funnel disabled until the cutover gate passes. This avoids recurring Radarr
-password lockouts from internal auth drift while keeping browser access behind a
-reviewed private access layer.
+Octelium is the target access boundary, with Funnel disabled. This avoids
+recurring Radarr password lockouts from internal auth drift while keeping
+browser access behind a reviewed private access layer.
 
 ## Tailscale
 

--- a/docs/knowledge-base/workloads/inventory.md
+++ b/docs/knowledge-base/workloads/inventory.md
@@ -8,9 +8,10 @@ units as the source of truth when they disagree with this note.
 
 ## Import Note
 
-This note reflects the current working tree. OctoBot is the finance namespace
-trading workload with Octelium-targeted UI access and tailnet fallback until the
-Octelium e2e gate passes.
+This note reflects the current working tree. Human app access for the
+`*.stinkyboi.com` app hostnames is through Octelium; Tailscale remains only for
+separately reviewed non-app paths such as CI/LAN reachability and webhook
+Funnel exceptions.
 
 ## Platform And Support Applications
 
@@ -35,19 +36,19 @@ Octelium e2e gate passes.
 | `octelium-cluster` | `istio-system` | `clusters/homelab/apps/octelium-cluster` | `IaC/live/argocd-apps/octelium-cluster` | Istio front-proxy route for the self-hosted Octelium Cluster domain, portal, and API hostnames, plus an HTTP/2 upstream `DestinationRule` so Octelium CLI gRPC calls keep response trailers; the Octelium runtime namespace and workloads are installed by `scripts/octelium-cluster-bootstrap.sh` through `octops`, and the wrapper labels that namespace for privileged data-plane pods | istio, platform-multus, octelium-storage |
 | `octelium` | `octelium-client` | `clusters/homelab/apps/octelium` | `IaC/live/argocd-apps/octelium` | stateless TUN-mode Octelium client bridge pinned to Octelium dataplane nodes and target human app access plane for Cluster domain `octelium.stinkyboi.com`; the explicit homelab app Service catalog maps existing `*.stinkyboi.com` app hostnames to TCP/443 Octelium services whose generated service pods forward directly to the Istio gateway while keeping Podinfo as a demo service; auth token is `/homelab/octelium/client-auth-token`; cutover is gated by `scripts/octelium-e2e-check.sh`; Enterprise package `octeliumee` desired version `0.22.0` is installed with `scripts/octelium-enterprise-package.sh` | external-secrets, istio |
 | `prometheus` | `monitoring` | `clusters/homelab/apps/prometheus` | `IaC/live/argocd-apps/prometheus` | persistent metrics, Alertmanager state, Argo CD scrape config, and Alertmanager Discord/OpenClaw notification secrets | external-secrets, platform-storage |
-| `grafana` | `monitoring` | `clusters/homelab/apps/grafana` | `IaC/live/argocd-apps/grafana` | persistent config, dashboards, platform/workload alert rules, expected hardware-node and Kubernetes-node alerting, public GitHub API PR/status polling, and stale direct receiver cleanup | external-secrets, cert-manager, istio, tailscale, prometheus, platform-storage |
-| `kiali` | `monitoring` | `clusters/homelab/apps/kiali` | `IaC/live/argocd-apps/kiali` | controller state only; read-only mesh UI | istio, tailscale, prometheus, grafana |
-| `compass` | `monitoring` | `clusters/homelab/apps/compass` | `IaC/live/argocd-apps/compass` | stateless Kubernetes service discovery dashboard with Octelium service-name launch links and fallback tailnet UI from the `ghcr.io/adinhodovic/charts` OCI Helm source | cert-manager, istio, tailscale, prometheus |
+| `grafana` | `monitoring` | `clusters/homelab/apps/grafana` | `IaC/live/argocd-apps/grafana` | persistent config, dashboards, platform/workload alert rules, expected hardware-node and Kubernetes-node alerting, public GitHub API PR/status polling, and stale direct receiver cleanup | external-secrets, cert-manager, istio, prometheus, platform-storage |
+| `kiali` | `monitoring` | `clusters/homelab/apps/kiali` | `IaC/live/argocd-apps/kiali` | controller state only; read-only mesh UI through Octelium app access | istio, prometheus, grafana |
+| `compass` | `monitoring` | `clusters/homelab/apps/compass` | `IaC/live/argocd-apps/compass` | stateless Kubernetes service discovery dashboard with Octelium service-name launch links from the `ghcr.io/adinhodovic/charts` OCI Helm source | cert-manager, istio, prometheus |
 | `descheduler` | `kube-system` | `clusters/homelab/apps/descheduler` | `IaC/live/argocd-apps/descheduler` | controller state only | prometheus |
-| `deluge` | `media` | `clusters/homelab/apps/deluge` | `IaC/live/argocd-apps/deluge` | persistent config on `nfs-default`; shared downloads on QNAP `/media`; SSM-backed WireGuard profile via `deluge-vpn` | cert-manager, istio, tailscale, platform-storage |
-| `prowlarr` | `media` | `clusters/homelab/apps/prowlarr` | `IaC/live/argocd-apps/prowlarr` | persistent config and PostgreSQL databases | cert-manager, istio, media-postgres, tailscale, platform-storage |
-| `radarr` | `media` | `clusters/homelab/apps/radarr` | `IaC/live/argocd-apps/radarr` | persistent config and PostgreSQL databases on `nfs-default`; movies and downloads on QNAP `/media` | cert-manager, istio, tailscale, deluge, media-postgres, prowlarr, platform-storage |
-| `sonarr` | `media` | `clusters/homelab/apps/sonarr` | `IaC/live/argocd-apps/sonarr` | persistent config and PostgreSQL databases on `nfs-default`; TV and downloads on QNAP `/media` | cert-manager, istio, tailscale, deluge, media-postgres, prowlarr, platform-storage |
-| `litellm` | `ai` | `clusters/homelab/apps/litellm` | `IaC/live/argocd-apps/litellm` | optional persistent config or DB state | external-secrets, cert-manager, istio, tailscale, platform-storage |
-| `openclaw` | `ai` | `clusters/homelab/apps/openclaw` | `IaC/live/argocd-apps/openclaw` | persistent runtime state, SSM-backed gateway auth, Discord channel config, SSM-backed GitHub App credentials, Codex OAuth credentials on PVC, and explicit agent resource profile | external-secrets, cert-manager, istio, tailscale, litellm, platform-storage |
+| `deluge` | `media` | `clusters/homelab/apps/deluge` | `IaC/live/argocd-apps/deluge` | persistent config on `nfs-default`; shared downloads on QNAP `/media`; SSM-backed WireGuard profile via `deluge-vpn` | cert-manager, istio, platform-storage |
+| `prowlarr` | `media` | `clusters/homelab/apps/prowlarr` | `IaC/live/argocd-apps/prowlarr` | persistent config and PostgreSQL databases | cert-manager, istio, media-postgres, platform-storage |
+| `radarr` | `media` | `clusters/homelab/apps/radarr` | `IaC/live/argocd-apps/radarr` | persistent config and PostgreSQL databases on `nfs-default`; movies and downloads on QNAP `/media` | cert-manager, istio, deluge, media-postgres, prowlarr, platform-storage |
+| `sonarr` | `media` | `clusters/homelab/apps/sonarr` | `IaC/live/argocd-apps/sonarr` | persistent config and PostgreSQL databases on `nfs-default`; TV and downloads on QNAP `/media` | cert-manager, istio, deluge, media-postgres, prowlarr, platform-storage |
+| `litellm` | `ai` | `clusters/homelab/apps/litellm` | `IaC/live/argocd-apps/litellm` | optional persistent config or DB state | external-secrets, cert-manager, istio, platform-storage |
+| `openclaw` | `ai` | `clusters/homelab/apps/openclaw` | `IaC/live/argocd-apps/openclaw` | persistent runtime state, SSM-backed gateway auth, Discord channel config, SSM-backed GitHub App credentials, Codex OAuth credentials on PVC, and explicit agent resource profile | external-secrets, cert-manager, istio, litellm, platform-storage |
 | `n8n` | `automation` | `clusters/homelab/apps/n8n` | `IaC/live/argocd-apps/n8n` | persistent workflows, credential metadata, users, and execution history in n8n-postgres; instance settings and file-backed runtime data on PVC; SSM key bootstraps fresh PVCs only; public Funnel is limited to webhook prefixes | external-secrets, cert-manager, istio, tailscale, platform-storage, n8n-postgres |
 | `policy-bot` | `automation` | `clusters/homelab/apps/policy-bot` | `IaC/live/argocd-apps/policy-bot` | stateless GitHub App policy evaluator; one replica after SSM placeholders are replaced | external-secrets, cert-manager, istio, tailscale |
-| `octobot` | `finance` | `clusters/homelab/apps/octobot` | `IaC/live/argocd-apps/octobot` | UI-configured bot state, tentacles, exchange credentials after operator setup, logs, and Octelium-targeted UI access with tailnet fallback until the e2e gate passes | cert-manager, istio, tailscale, platform-storage |
+| `octobot` | `finance` | `clusters/homelab/apps/octobot` | `IaC/live/argocd-apps/octobot` | UI-configured bot state, tentacles, exchange credentials after operator setup, logs, and Octelium-targeted UI access | cert-manager, istio, platform-storage |
 
 ## Mesh Policy Summary
 
@@ -56,9 +57,9 @@ namespaces. The source of truth is `docs/runtime-isolation.md` plus the
 `authorizationpolicy.yaml` files in the affected app overlays.
 
 - `ai` uses a namespace default-deny policy and explicit inbound allows for the
-  tailnet gateway and Octelium connector to `litellm` and `openclaw`, for
-  Alertmanager to reach OpenClaw `/hooks/agent`, and for OpenClaw to reach
-  LiteLLM.
+  Istio gateway path used by Octelium service proxies, the Octelium connector
+  principal reserved for future served upstreams, Alertmanager to reach
+  OpenClaw `/hooks/agent`, and OpenClaw to reach LiteLLM.
 - `automation` currently restricts `n8n` workload access to the Istio gateway;
   the reviewed public n8n webhook Funnel forwards into that gateway instead of
   directly to the workload. `n8n-postgres` has a NetworkPolicy that documents
@@ -67,15 +68,16 @@ namespaces. The source of truth is `docs/runtime-isolation.md` plus the
   Funnel traffic and database source-identity validation still need live
   validation after rollout.
 - `monitoring` restricts Grafana, Prometheus, Alertmanager, and
-  kube-state-metrics by service account. Compass allows only the tailnet gateway,
-  Prometheus scraper, and Octelium connector. Compass also owns
+  kube-state-metrics by service account. Compass allows only the Istio gateway
+  path used by Octelium service proxies, Prometheus scraper, and Octelium
+  connector. Compass also owns
   discovery-only `Ingress` resources with an inert `compass-discovery` class;
   those resources intentionally ignore Argo CD health checks because no
   controller populates their load balancer status. The Prometheus operator
   remains unselected until its webhook/control-plane paths are modeled.
-- `octelium-client` is ambient-enrolled so the connector has a stable workload
-  principal when it calls protected `ai`, `automation`, and `monitoring`
-  services.
+- `octelium-client` is ambient-enrolled so future connector-served upstreams
+  have a stable workload principal when they call protected `ai`, `automation`,
+  and `monitoring` services.
 - `media` stays out of ambient while Deluge Gluetun/WireGuard and the media app
   ingress model need a repo-owned waypoint or equivalent policy design.
 

--- a/docs/networking-tailnet-ingress.md
+++ b/docs/networking-tailnet-ingress.md
@@ -1,42 +1,30 @@
 # Tailnet Ingress
 
-Octelium is the target access plane for human access to homelab apps. The
-Tailscale-backed Istio gateway remains the fallback route until
+Octelium is the access plane for human access to homelab apps. Existing
+`*.stinkyboi.com` app hostnames resolve to Octelium private service IPs after
 `scripts/octelium-e2e-check.sh` proves that the Octelium Cluster, service
 catalog, connector, and client tunnel all work end to end. Public Tailscale
 Funnel remains reserved for reviewed webhook paths that must be reachable by
 external SaaS systems until those callbacks are explicitly redesigned.
 
-## Initial DNS Assumption
+## DNS Model
 
-The repository still has one fallback DNS or tailnet naming setup that covers
-the old internal app routes. For this homelab, `*.stinkyboi.com` resolves to
-the Tailscale-exposed Istio ingress address from tailnet clients until Octelium
-passes the cutover gate. This feature does not add or edit public DNS records
-after that initial setup.
+Exact app records such as `grafana.stinkyboi.com` and `argocd.stinkyboi.com`
+point at Octelium private service IPs, not the old Tailscale wildcard. The
+Octelium Cluster names `octelium.stinkyboi.com`,
+`portal.octelium.stinkyboi.com`, and `octelium-api.octelium.stinkyboi.com`
+continue to route through the Istio gateway to the Octelium dataplane.
 
 Because no DNS provider resources are added in this repository, external DNS
 infrastructure is unaffected by this change. If DNS becomes repo-managed later,
 that must be added through a separate Terragrunt/OpenTofu entry point.
 
-## Fallback Route Inventory
+## Route Inventory
 
 | App | HTTPS host | Public Funnel |
 |-----|------------------|---------------|
-| argocd | `https://argocd.stinkyboi.com` | disabled |
-| grafana | `https://grafana.stinkyboi.com` | disabled |
-| kiali | `https://kiali.stinkyboi.com` | disabled |
-| compass | `https://compass.stinkyboi.com` | disabled |
-| deluge | `https://deluge.stinkyboi.com` | disabled |
-| prowlarr | `https://prowlarr.stinkyboi.com` | disabled |
-| radarr | `https://radarr.stinkyboi.com` | disabled |
-| sonarr | `https://sonarr.stinkyboi.com` | disabled |
-| litellm | `https://litellm.stinkyboi.com` | disabled |
-| openclaw | `https://openclaw.stinkyboi.com` | disabled |
-| n8n editor/UI | `https://n8n.stinkyboi.com` | disabled |
+| app UIs | existing `https://*.stinkyboi.com` app hostnames | disabled; app access is through Octelium private Services |
 | n8n webhooks | `https://n8n-webhook.tail67beb.ts.net/webhook...` | enabled for `/webhook`, `/webhook-test`, and `/webhook-waiting` only |
-| policy-bot UI and normal routes | `https://policy-bot.stinkyboi.com` | disabled |
-| octobot UI | `https://octobot.stinkyboi.com` | disabled |
 | policy-bot GitHub webhook | `https://policy-bot-hook.<tailnet-name>.ts.net/api/github/hook` | enabled for `/api/github/hook` only |
 
 Istio terminates HTTPS with the `stinkyboi-com-tls` certificate in
@@ -56,9 +44,10 @@ n8n now adds a reviewed Funnel exception for workflow webhook delivery. The
 `policy-bot-hook-funnel` and `n8n-webhook-funnel` Tailscale Ingresses are
 annotated with `homelab.rst.io/public-funnel: "true"` and
 `homelab.rst.io/public-funnel-reviewed: "true"`; the Policy Bot UI and n8n
-editor routes remain private. Every other Istio gateway and VirtualService
-route manifest is fallback app access only until Octelium e2e validation
-passes.
+editor routes remain private through Octelium. Other app `VirtualService`
+objects are retained only as private Istio backend routes for Octelium TCP/443
+Services, with `homelab.rst.io/access-plane: octelium` and public Funnel
+disabled.
 
 The Istio ingressgateway Service is a Tailscale `LoadBalancer` and sets
 `allocateLoadBalancerNodePorts: false` so the gateway is not exposed through
@@ -74,34 +63,28 @@ and rollback path.
 
 Octelium serves the private app set through
 `docs/examples/octelium/homelab-services.yaml` with service names in the
-`homelab` Octelium namespace. The old app `VirtualService` objects and the
-Tailscale-backed Istio `LoadBalancer` are removable only after
-`scripts/octelium-e2e-check.sh` passes. Keep public Funnel exceptions and
-Octelium Services separate: the n8n and Policy Bot webhook paths remain
-Tailscale Funnel exceptions unless a later PR explicitly redesigns those
-callbacks through Octelium.
+`homelab` Octelium namespace. Keep public Funnel exceptions and Octelium
+Services separate: the n8n and Policy Bot webhook paths remain Tailscale
+Funnel exceptions unless a later PR explicitly redesigns those callbacks
+through Octelium.
 
-OctoBot currently has a fallback UI route at `https://octobot.stinkyboi.com`.
-After Octelium cutover, use `octobot.homelab` through Octelium for private setup,
-paper trading, and operator-reviewed live trading; exchange credentials and
-strategy state are configured through OctoBot and persist on its NFS-backed
-volumes, not in public repository files.
+Use `octobot.homelab` through Octelium for private setup, paper trading, and
+operator-reviewed live trading; exchange credentials and strategy state are
+configured through OctoBot and persist on its NFS-backed volumes, not in public
+repository files.
 
-Compass currently has a fallback route at `https://compass.stinkyboi.com`, but
-its launch links and discovery-only entries point at Octelium service names. It
-discovers Kubernetes ingress and Gateway API routes with read-only RBAC,
+Compass launch links and discovery-only entries point at Octelium service names.
+It discovers Kubernetes ingress and Gateway API routes with read-only RBAC,
 disables operator debug routes, and does not persist application state.
 
 Because the homelab's reviewed ingress path is still Istio `VirtualService`,
 Compass also owns discovery-only `Ingress` resources in the `monitoring`
 namespace. Those resources use the inert `compass-discovery` IngressClass and
 carry the same hostnames and Compass metadata for catalog discovery, but they
-do not replace the Istio `VirtualService` resources that route traffic through
-`tailnet-gateway`. They are annotated with
+do not route traffic. They are annotated with
 `argocd.argoproj.io/ignore-healthcheck: "true"` because no ingress controller
-is expected to populate `status.loadBalancer` for the inert class; the
-tailnet-only `VirtualService` and Compass Deployment remain the operational
-health signals.
+is expected to populate `status.loadBalancer` for the inert class; the Compass
+Deployment remains the operational health signal.
 
 ## Homelab VPN Exit Node And LAN Route
 
@@ -159,9 +142,8 @@ Data exposed: webhook request body and headers sent by GitHub.
 ```
 
 The Policy Bot UI, details routes, static assets, OAuth callback, and root path
-target `policy-bot.homelab` through Octelium after cutover. The
-`https://policy-bot.stinkyboi.com` tailnet Istio route remains fallback until
-the Octelium gate passes. Only `/api/github/hook` is exposed through Funnel.
+target `policy-bot.homelab` through Octelium. Only `/api/github/hook` is
+exposed through Funnel.
 
 ## n8n Webhook Funnel Exception
 
@@ -180,10 +162,9 @@ Data exposed: request bodies and headers sent to active n8n webhook workflows.
 ```
 
 The n8n editor, REST API, static assets, and root path target `n8n.homelab`
-through Octelium after cutover. The `https://n8n.stinkyboi.com` tailnet Istio
-route remains fallback until the Octelium gate passes. The Funnel Ingress
-forwards only webhook path prefixes to the Istio gateway, and the n8n
-VirtualService only routes those prefixes on the public webhook gateway.
+through Octelium. The Funnel Ingress forwards only webhook path prefixes to the
+Istio gateway, and the n8n VirtualService only routes those prefixes on the
+public webhook gateway.
 
 ## Future Funnel Webhook Exception Template
 

--- a/docs/octelium.md
+++ b/docs/octelium.md
@@ -1,15 +1,14 @@
 # Octelium Client Bridge
 
-This repository prepares Octelium to replace Tailscale for human access to
-homelab applications. Tailscale remains the temporary fallback for app routes
-until the Octelium Cluster, service catalog, workload credential, connector, and
-existing app hostnames all pass the e2e gate in
-`scripts/octelium-e2e-check.sh`.
+This repository uses Octelium for human access to homelab applications. App
+hostnames keep their existing `*.stinkyboi.com` names, exact DNS points those
+names at Octelium private service IPs, and per-app Istio `VirtualService`
+objects provide only the backend SNI routing layer for Octelium TCP/443
+Services.
 
 The Tailscale operator can still have non-app responsibilities, such as CI
 cluster reachability or reviewed public webhook exceptions, until those are
-separately replaced. Do not remove the current tailnet app routes before the
-Octelium e2e check passes.
+separately replaced.
 
 ## Current Model
 
@@ -110,7 +109,7 @@ aws ssm put-parameter \
 
 ## Cutover Gate
 
-Run the e2e gate before removing any old Tailscale-backed app route:
+Run the e2e gate before declaring any Octelium app route ready:
 
 ```sh
 scripts/octelium-e2e-check.sh
@@ -155,11 +154,10 @@ The gate verifies:
 - each existing app hostname resolves to an Octelium private service IP and
   responds over HTTPS through the VPN.
 
-When it passes, remove the old application `VirtualService` objects that point
-at `istio-system/tailnet-gateway`, remove the Tailscale-backed Istio
-`LoadBalancer` path for app UI access, and keep only separately reviewed
-non-app exceptions such as webhooks or CI cluster access. If it fails, treat the
-failure output as the cutover work queue.
+Keep per-app `VirtualService` objects as private Istio backend routes for the
+Octelium TCP Services. Keep only separately reviewed Tailscale-specific non-app
+exceptions such as webhooks or CI cluster access. If the gate fails, treat the
+failure output as the repair work queue.
 
 ## Bootstrap UI Access
 
@@ -406,7 +404,7 @@ If the external resources are no longer wanted, delete the homelab Services,
 the `homelab-octelium-client` User, and the `homelab-human-web-access` Policy
 from the Octelium Cluster with `octeliumctl`. Do not delete or change Tailscale
 resources as part of Octelium rollback unless a later migration PR explicitly
-replaces the tailnet ingress and exit-node model.
+replaces the remaining webhook, CI, and LAN tailnet model.
 
 Remove or downgrade the Enterprise package through an Octelium-supported
 package operation. Record the target package version in this document before

--- a/docs/runtime-isolation.md
+++ b/docs/runtime-isolation.md
@@ -14,8 +14,8 @@ than a reliable isolation control.
 
 Current enforced controls are therefore:
 
-- fallback Istio ingress routes reviewed in `docs/networking-tailnet-ingress.md`
-  while the Octelium cutover gate is still failing;
+- Octelium app access through the Istio ingress gateway and reviewed webhook
+  Funnel exceptions in `docs/networking-tailnet-ingress.md`;
 - workload-scoped Istio policy only where the namespace is explicitly
   mesh-enrolled and the gateway path is proven to keep working;
 - namespace Pod Security labels that are explicit in repo-owned namespace
@@ -40,29 +40,30 @@ is known well enough to enforce with Layer 4 identity policy:
   Bot Funnel traffic, monitoring operator webhooks, and other controller paths
   need live source-identity validation before those namespaces move to full
   default-deny.
-- `octelium-client` is ambient-enrolled so the Octelium connector has a stable
-  service-account principal when it serves protected homelab apps.
+- `octelium-client` is ambient-enrolled so future connector-served upstreams
+  have a stable service-account principal. Current app Services forward through
+  generated Octelium service proxies into the Istio ingress gateway.
 
 The current service access contract is:
 
 | Destination workload | Namespace | Allowed source principal | Reason |
 |----------------------|-----------|--------------------------|--------|
-| `litellm` | `ai` | `cluster.local/ns/istio-system/sa/istio-ingressgateway` | Fallback tailnet UI/API ingress. |
+| `litellm` | `ai` | `cluster.local/ns/istio-system/sa/istio-ingressgateway` | Octelium service-proxy app access through the Istio gateway. |
 | `litellm` | `ai` | `cluster.local/ns/ai/sa/openclaw` | OpenClaw model gateway calls. |
 | `litellm` | `ai` | `cluster.local/ns/octelium-client/sa/octelium-client` | Octelium private service bridge. |
-| `openclaw` | `ai` | `cluster.local/ns/istio-system/sa/istio-ingressgateway` | Fallback tailnet UI ingress. |
+| `openclaw` | `ai` | `cluster.local/ns/istio-system/sa/istio-ingressgateway` | Octelium service-proxy app access through the Istio gateway. |
 | `openclaw` | `ai` | `cluster.local/ns/octelium-client/sa/octelium-client` | Octelium private service bridge. |
 | `openclaw` | `ai` | `cluster.local/ns/monitoring/sa/prometheus-kube-prometheus-alertmanager` | Alertmanager direct `/hooks/agent` delivery. |
-| `n8n` | `automation` | `cluster.local/ns/istio-system/sa/istio-ingressgateway` | Fallback tailnet UI ingress and reviewed n8n webhook Funnel traffic forwarded through the Istio gateway. |
+| `n8n` | `automation` | `cluster.local/ns/istio-system/sa/istio-ingressgateway` | Octelium service-proxy app access and reviewed n8n webhook Funnel traffic forwarded through the Istio gateway. |
 | `n8n` | `automation` | `cluster.local/ns/octelium-client/sa/octelium-client` | Octelium private service bridge. |
-| `grafana` | `monitoring` | `cluster.local/ns/istio-system/sa/istio-ingressgateway` | Fallback tailnet UI ingress. |
+| `grafana` | `monitoring` | `cluster.local/ns/istio-system/sa/istio-ingressgateway` | Octelium service-proxy app access through the Istio gateway. |
 | `grafana` | `monitoring` | `cluster.local/ns/monitoring/sa/kiali-service-account` | Kiali dashboard links and health checks. |
 | `grafana` | `monitoring` | `cluster.local/ns/monitoring/sa/prometheus-kube-prometheus-prometheus` | Prometheus scrapes Grafana metrics. |
 | `grafana` | `monitoring` | `cluster.local/ns/octelium-client/sa/octelium-client` | Octelium private service bridge. |
-| `kiali` | `monitoring` | `cluster.local/ns/istio-system/sa/istio-ingressgateway` | Fallback tailnet UI ingress. |
+| `kiali` | `monitoring` | `cluster.local/ns/istio-system/sa/istio-ingressgateway` | Octelium service-proxy app access through the Istio gateway. |
 | `kiali` | `monitoring` | `cluster.local/ns/monitoring/sa/prometheus-kube-prometheus-prometheus` | Prometheus scrape or health access. |
 | `kiali` | `monitoring` | `cluster.local/ns/octelium-client/sa/octelium-client` | Octelium private service bridge. |
-| `compass` | `monitoring` | `cluster.local/ns/istio-system/sa/istio-ingressgateway` | Fallback tailnet UI ingress. |
+| `compass` | `monitoring` | `cluster.local/ns/istio-system/sa/istio-ingressgateway` | Octelium service-proxy app access through the Istio gateway. |
 | `compass` | `monitoring` | `cluster.local/ns/monitoring/sa/prometheus-kube-prometheus-prometheus` | Prometheus scrape access. |
 | `compass` | `monitoring` | `cluster.local/ns/octelium-client/sa/octelium-client` | Octelium private service bridge. |
 | `prometheus` | `monitoring` | `cluster.local/ns/monitoring/sa/grafana` | Grafana Prometheus datasource queries. |
@@ -90,8 +91,7 @@ Ambient is intentionally not enabled for:
 - `media`, because Deluge Gluetun/WireGuard and the current media app traffic
   model still need a repo-owned waypoint or equivalent policy design before
   re-enrollment;
-- `finance`, because OctoBot has only a fallback tailnet UI route until the
-  Octelium gate passes and needs a separate identity-policy design before any
+- `finance`, because OctoBot needs a separate identity-policy design before any
   service-to-service or trading API control path is mesh-enrolled;
 - `argocd`, `cert-manager`, `external-secrets`, and `storage`, because their
   API server, webhook, NFS, and controller paths need separate validation;

--- a/docs/validation-runbook.md
+++ b/docs/validation-runbook.md
@@ -67,7 +67,7 @@ argocd app get platform-dns
 argocd app get platform-storage
 ```
 
-For Kiali, verify the operator-created custom resource and current fallback UI:
+For Kiali, verify the operator-created custom resource and Octelium-backed UI:
 
 ```sh
 kubectl -n monitoring get kiali kiali
@@ -75,12 +75,12 @@ kubectl -n monitoring get deploy,svc kiali
 curl -I https://kiali.stinkyboi.com
 ```
 
-Expected result before the Octelium cutover gate passes: the Kiali Application
-is synced and healthy, the Kiali custom resource is successfully reconciled,
-and the fallback tailnet HTTPS route reaches the read-only UI.
+Expected result: the Kiali Application is synced and healthy, the Kiali custom
+resource is successfully reconciled, and the `kiali.stinkyboi.com` hostname
+reaches the read-only UI through Octelium.
 
-For Octelium app-access cutover, run the e2e gate before removing any
-Tailscale-backed app route:
+For Octelium app-access readiness, run the e2e gate before declaring app UI
+access healthy:
 
 ```sh
 scripts/octelium-e2e-check.sh
@@ -152,9 +152,8 @@ to PostgreSQL.
 
 n8n webhooks use the reviewed Tailscale Funnel route at
 `https://n8n-webhook.tail67beb.ts.net`. After sync, verify the Tailscale
-Ingress and operator proxy exist, then check that the fallback editor host still
-works until the Octelium gate passes and the public host only reaches n8n under
-webhook path prefixes:
+Ingress and operator proxy exist, then check that the Octelium-backed editor
+host works and the public host only reaches n8n under webhook path prefixes:
 
 ```sh
 kubectl -n istio-system get gateway,ingress n8n-webhook-funnel
@@ -237,7 +236,7 @@ curl -sS -o /dev/null -w '%{http_code}\n' https://n8n-webhook.tail67beb.ts.net/w
 | External Secrets unavailable | Hold dependent apps until `external-secrets` is synced and healthy. |
 | NFS provisioner missing | Restore `platform-storage` readiness first; do not rely on stateful apps until PVC validation passes. |
 | Media PostgreSQL unavailable | Hold Sonarr, Radarr, and Prowlarr; verify `media-postgres-auth`, `media-postgres-arr-env`, the StatefulSet, and the six logical databases before app sync. |
-| Tailscale unavailable | Do not expose tailnet VirtualServices as ready, even if workloads are healthy. |
+| Tailscale unavailable | Do not mark Funnel webhook exceptions or LAN/CI tailnet routes as ready, even if workloads are healthy. |
 | Policy Bot webhook unreachable | Confirm the Tailscale `funnel` node attribute for `tag:k8s`, then inspect the `policy-bot-hook-funnel` Ingress and the operator-managed proxy Pod; do not expose additional Funnel routes. |
 | n8n webhook unreachable | Confirm the Tailscale `funnel` node attribute for `tag:k8s`, then inspect the `n8n-webhook-funnel` Ingress, Gateway, VirtualService, and operator-managed proxy Pod; keep editor/API routes off Funnel. |
 | Image updater misconfiguration | Remove the affected `applicationRefs` image entry or write-back target from `clusters/homelab/apps/argocd-image-updater/imageupdater.yaml`, then fix the repository desired state. |


### PR DESCRIPTION
## Summary
- marks app FQDN routes as Octelium-backed Istio SNI backend routes instead of tailnet fallback routes
- keeps existing *.stinkyboi.com app hostnames and splits n8n editor access from the webhook-only Funnel route
- updates Terragrunt metadata, workload docs, KB notes, and validation runbooks for the Octelium access model

## Validation
- terragrunt hcl fmt
- terragrunt hcl validate
- git diff --check
- kubectl kustomize for argocd self-management plus affected app overlays
- conftest test --policy policy on combined rendered manifests: 1720 passed

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `e0afbe1eb9875b6405f9a33d8e4f86e341193c2f`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.


<!-- terragrunt-plan:end -->
