### PR TITLE
fix(octelium): require openid for entra setup

### DIFF
--- a/docs/knowledge-base/runbooks/octelium.md
+++ b/docs/knowledge-base/runbooks/octelium.md
@@ -54,9 +54,10 @@ native Secret `entra-oidc-client-secret`, and applies the IdentityProvider.
 Pass `--admin-user-name` and `--admin-email` only at runtime when adding the
 operator HUMAN user mapping; keep personal Entra identifiers out of git.
 
-The IdentityProvider uses Entra `preferred_username` as the login identifier
-and does not require `email_verified`, which Entra may omit. If the portal
-shows `No Available Identity Providers`, verify
+The IdentityProvider requests `openid`, `email`, and `profile`, uses Entra
+`preferred_username` as the login identifier, and does not require
+`email_verified`, which Entra may omit. If the portal shows
+`No Available Identity Providers`, verify
 `octeliumctl get identityprovider entra --domain octelium.stinkyboi.com`
 before changing the app service catalog.
 

--- a/docs/octelium.md
+++ b/docs/octelium.md
@@ -115,10 +115,11 @@ scripts/octelium-entra-oidc.sh \
   --admin-email '<entra-user-principal-name>'
 ```
 
-The script reads the generated SSM parameters, replaces the Octelium native
-Secret `entra-oidc-client-secret`, applies IdentityProvider `entra`, and, when
-both admin flags are supplied, applies a HUMAN user with an explicit Entra
-identity and the built-in `allow-all` policy. Octelium uses the Entra
+The script reads the generated SSM parameters, creates or updates the Octelium
+native Secret `entra-oidc-client-secret`, applies IdentityProvider `entra`, and,
+when both admin flags are supplied, applies a HUMAN user with an explicit Entra
+identity and the built-in `allow-all` policy. The IdentityProvider requests the
+`openid`, `email`, and `profile` OIDC scopes, and Octelium uses the Entra
 `preferred_username` claim as the login identifier. Microsoft Entra may omit
 `email_verified`, so the IdentityProvider intentionally does not require that
 claim.

--- a/scripts/octelium-entra-oidc.sh
+++ b/scripts/octelium-entra-oidc.sh
@@ -122,6 +122,22 @@ read_parameter() {
     --output text
 }
 
+apply_identity_resources() {
+  local apply_output
+
+  if ! apply_output="$(octeliumctl apply --domain "$domain" "$identity_file" 2>&1)"; then
+    printf '%s\n' "$apply_output" >&2
+    exit 1
+  fi
+
+  printf '%s\n' "$apply_output"
+
+  if grep -Eq '(^|[[:space:]])Could not (create|update|apply)|gRPC error' <<<"$apply_output"; then
+    echo "error: octeliumctl reported one or more failed resource changes" >&2
+    exit 1
+  fi
+}
+
 require_command aws
 require_command octeliumctl
 validate_name "$idp_name" "--idp-name"
@@ -178,6 +194,7 @@ spec:
       fromSecret: ${secret_name}
     identifierClaim: preferred_username
     scopes:
+      - openid
       - email
       - profile
 YAML
@@ -201,7 +218,7 @@ spec:
 YAML
 fi
 
-octeliumctl apply --domain "$domain" "$identity_file"
+apply_identity_resources
 
 echo "Configured Octelium IdentityProvider ${idp_name} for ${domain}."
 if [[ -n "$admin_user_name" ]]; then


### PR DESCRIPTION
## Summary
- request the required `openid` scope when applying the Octelium Entra IdentityProvider
- make `scripts/octelium-entra-oidc.sh` fail when `octeliumctl apply` reports per-resource errors
- update the Octelium docs/runbook to match the safer secret update and OIDC scope behavior

## Validation
- `bash -n scripts/octelium-entra-oidc.sh`
- `git diff --check`
- live rerun: `scripts/octelium-entra-oidc.sh --admin-user-name homelab-owner --admin-email <redacted>` created IdentityProvider `entra` and User `homelab-owner`
- live e2e: `scripts/octelium-e2e-check.sh` passed, including existing `*.stinkyboi.com` app hostnames through Octelium VPN

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `673594e7498bc98b552fe0f7f904ffc3a9240738`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.

> AzureAD application registration plans were skipped because the plan environment did not provide `ARM_CLIENT_ID`, `ARM_CLIENT_SECRET`, and `ARM_TENANT_ID`. Production apply still fails fast when `IaC/live/azuread-applications` changes and those credentials are absent.


<!-- terragrunt-plan:end -->
