### PR TITLE
fix: pass octelium tunnel id explicitly

### DIFF
--- a/IaC/live/aws-ssm-parameters/terragrunt.hcl
+++ b/IaC/live/aws-ssm-parameters/terragrunt.hcl
@@ -90,6 +90,10 @@ inputs = {
       description   = "Cloudflare Tunnel credentials JSON for the public Octelium control-plane connector."
       initial_value = local.placeholder
     }
+    "/homelab/octelium/cloudflare-tunnel-id" = {
+      description   = "Cloudflare Tunnel UUID for the public Octelium control-plane connector."
+      initial_value = local.placeholder
+    }
     "/homelab/octelium/postgres-password" = {
       description = "Octelium Cluster PostgreSQL password."
       generated = {

--- a/clusters/homelab/apps/octelium-public/README.md
+++ b/clusters/homelab/apps/octelium-public/README.md
@@ -14,10 +14,11 @@ are reached through an authenticated Octelium client session.
 ## Secret Contract
 
 `octelium-public-cloudflared-credentials` reads
-`/homelab/octelium/cloudflare-tunnel-credentials-json` from AWS SSM. Store the
-credentials JSON created by `cloudflared tunnel create
-homelab-octelium-public` at that path. Do not commit the JSON file, tunnel
-secret, or Cloudflare API tokens.
+`/homelab/octelium/cloudflare-tunnel-credentials-json` and
+`/homelab/octelium/cloudflare-tunnel-id` from AWS SSM. Store the credentials
+JSON and UUID created by `cloudflared tunnel create homelab-octelium-public`
+at those paths. Do not commit the JSON file, tunnel secret, or Cloudflare API
+tokens.
 
 ## Routing
 

--- a/clusters/homelab/apps/octelium-public/configmap.yaml
+++ b/clusters/homelab/apps/octelium-public/configmap.yaml
@@ -9,8 +9,6 @@ metadata:
     app.kubernetes.io/part-of: octelium-public
 data:
   config.yaml: |
-    tunnel: homelab-octelium-public
-    credentials-file: /etc/cloudflared/creds/credentials.json
     no-autoupdate: true
     metrics: 0.0.0.0:2000
     protocol: http2

--- a/clusters/homelab/apps/octelium-public/deployment.yaml
+++ b/clusters/homelab/apps/octelium-public/deployment.yaml
@@ -4,6 +4,9 @@ kind: Deployment
 metadata:
   name: cloudflared
   namespace: octelium-public
+  annotations:
+    checkov.io/skip1: CKV_K8S_35=The tunnel UUID is non-secret routing metadata; the Cloudflare credentials JSON remains file-mounted.
+    checkov.io/skip2: CKV2_K8S_6=cloudflared-egress NetworkPolicy exists in this Kustomize app; the diff-only hook scans this Deployment without the unchanged policy.
   labels:
     app.kubernetes.io/name: cloudflared
     app.kubernetes.io/part-of: octelium-public
@@ -37,7 +40,16 @@ spec:
             - tunnel
             - --config
             - /etc/cloudflared/config/config.yaml
+            - --credentials-file
+            - /etc/cloudflared/creds/credentials.json
             - run
+            - $(TUNNEL_ID)
+          env:
+            - name: TUNNEL_ID
+              valueFrom:
+                secretKeyRef:
+                  name: octelium-public-cloudflared-credentials
+                  key: tunnel-id
           ports:
             - name: metrics
               containerPort: 2000

--- a/clusters/homelab/apps/octelium-public/externalsecret.yaml
+++ b/clusters/homelab/apps/octelium-public/externalsecret.yaml
@@ -25,3 +25,6 @@ spec:
     - secretKey: credentials.json
       remoteRef:
         key: /homelab/octelium/cloudflare-tunnel-credentials-json
+    - secretKey: tunnel-id
+      remoteRef:
+        key: /homelab/octelium/cloudflare-tunnel-id

--- a/docs/knowledge-base/architecture/secrets-and-identity.md
+++ b/docs/knowledge-base/architecture/secrets-and-identity.md
@@ -71,8 +71,9 @@ roles need identity-based KMS permissions for both keys.
   Public Octelium control-plane access uses the
   `octelium-public-cloudflared-credentials` ExternalSecret in
   `octelium-public`, sourced from
-  `/homelab/octelium/cloudflare-tunnel-credentials-json`. The Cloudflare Tunnel
-  credential JSON is created outside git with `cloudflared tunnel create
+  `/homelab/octelium/cloudflare-tunnel-credentials-json` and
+  `/homelab/octelium/cloudflare-tunnel-id`. The Cloudflare Tunnel credential
+  JSON and UUID are created outside git with `cloudflared tunnel create
   homelab-octelium-public`.
   Octelium portal login uses Microsoft Entra OIDC. The Entra application is
   managed by `IaC/live/azuread-applications/octelium` and writes generated

--- a/docs/knowledge-base/runbooks/octelium.md
+++ b/docs/knowledge-base/runbooks/octelium.md
@@ -100,8 +100,9 @@ The steady-state bootstrap path for users outside the tailnet is the
 `octelium.stinkyboi.com`, `portal.octelium.stinkyboi.com`, and
 `octelium-api.octelium.stinkyboi.com` to the public Internet and forwards those
 hostnames to the existing Istio `octelium-cluster` route. The Cloudflare Tunnel
-credentials JSON lives outside git in
-`/homelab/octelium/cloudflare-tunnel-credentials-json` and is rendered by the
+credentials JSON and UUID live outside git in
+`/homelab/octelium/cloudflare-tunnel-credentials-json` and
+`/homelab/octelium/cloudflare-tunnel-id`; both are rendered by the
 `octelium-public-cloudflared-credentials` ExternalSecret.
 
 If public DNS or VPN access to the Octelium Cluster is not available yet,

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -142,8 +142,9 @@ Service.
 
 The public Octelium control-plane path is a separate `octelium-public`
 Application. It runs two `cloudflared` replicas in `octelium-public`, reads the
-named tunnel credentials JSON from
-`/homelab/octelium/cloudflare-tunnel-credentials-json`, and forwards only
+named tunnel credentials JSON and UUID from
+`/homelab/octelium/cloudflare-tunnel-credentials-json` and
+`/homelab/octelium/cloudflare-tunnel-id`, and forwards only
 `octelium.stinkyboi.com`, `portal.octelium.stinkyboi.com`, and
 `octelium-api.octelium.stinkyboi.com` to the in-cluster Istio gateway. App
 hostnames such as `grafana.stinkyboi.com` remain Octelium private Service

--- a/docs/secrets-aws-ssm.md
+++ b/docs/secrets-aws-ssm.md
@@ -85,7 +85,7 @@ stack because Terraform manages the Kubernetes Secret.
 | cert-manager | reserved for DNS-01 issuer | `cloudflare-api-token` | `/homelab/cert-manager/cloudflare-api-token` |
 | tailscale | `tailscale-oauth` | `operator-oauth` | `/homelab/tailscale/oauth-client-id`, `/homelab/tailscale/oauth-client-secret` |
 | octelium | `octelium-client-auth` | `octelium-client-auth-v5` | `/homelab/octelium/client-auth-token` |
-| octelium-public | `octelium-public-cloudflared-credentials` | `octelium-public-cloudflared-credentials` | `/homelab/octelium/cloudflare-tunnel-credentials-json` |
+| octelium-public | `octelium-public-cloudflared-credentials` | `octelium-public-cloudflared-credentials` | `/homelab/octelium/cloudflare-tunnel-credentials-json`, `/homelab/octelium/cloudflare-tunnel-id` |
 | octelium | Octelium native Secret `entra-oidc-client-secret` | Octelium IdentityProvider `entra` | `/homelab/octelium/entra/client-id`, `/homelab/octelium/entra/client-secret`, `/homelab/octelium/entra/issuer-url`, `/homelab/octelium/entra/tenant-id` |
 | grafana | `grafana-admin` | `grafana-admin` | `/homelab/grafana/admin-user`, `/homelab/grafana/admin-password` |
 | grafana | `grafana-azuread-sso` | `grafana-azuread-sso` | `/homelab/grafana/azuread/client-id`, `/homelab/grafana/azuread/client-secret`, `/homelab/grafana/azuread/auth-url`, `/homelab/grafana/azuread/token-url`, `/homelab/grafana/azuread/allowed-organizations` |
@@ -179,11 +179,11 @@ admin mapping; do not commit personal Entra identifiers into this public repo.
 The public Octelium control plane uses a Cloudflare Tunnel connector in
 `octelium-public`. Store the credentials JSON created by
 `cloudflared tunnel create homelab-octelium-public` in
-`/homelab/octelium/cloudflare-tunnel-credentials-json`, then route
-`octelium.stinkyboi.com`, `portal.octelium.stinkyboi.com`, and
-`octelium-api.octelium.stinkyboi.com` to the tunnel target
-`<tunnel-uuid>.cfargotunnel.com`. Keep the credentials JSON and any Cloudflare
-API token outside git.
+`/homelab/octelium/cloudflare-tunnel-credentials-json` and the tunnel UUID in
+`/homelab/octelium/cloudflare-tunnel-id`, then route `octelium.stinkyboi.com`,
+`portal.octelium.stinkyboi.com`, and `octelium-api.octelium.stinkyboi.com` to
+the tunnel target `<tunnel-uuid>.cfargotunnel.com`. Keep the credentials JSON
+and any Cloudflare API token outside git.
 
 The cert-manager Cloudflare value should be a scoped API token with permission
 to read the zone and edit DNS records for `stinkyboi.com`; do not store the


### PR DESCRIPTION
## Summary

- pass the Cloudflare Tunnel UUID explicitly to `cloudflared run` instead of relying on the tunnel name in config
- add `/homelab/octelium/cloudflare-tunnel-id` to the SSM contract and ExternalSecret
- keep the tunnel credentials JSON file-mounted while using the UUID as non-secret runtime metadata

## Why

After PR #454 deployed, `octelium-public` created the namespace and pods, but `cloudflared` crashed with `Cannot determine default origin certificate path` because name-based tunnel lookup requires a Cloudflare origin cert in the pod. Passing the UUID with `--credentials-file` lets the pod authenticate using the mounted credentials JSON only.

## Validation

- `cloudflared tunnel --config /private/tmp/octelium-public-cloudflared-config.yaml ingress validate` returned OK
- `kubectl kustomize clusters/homelab/apps/octelium-public`
- `bash scripts/ci/static-checks.sh` passed; local Checkov warned that it could not resolve Prisma guideline metadata, but reported 0 failed Terraform, Kubernetes, and secret checks
- `terragrunt hcl fmt --check`
- `terragrunt hcl validate`
- `terragrunt --log-disable plan -no-color` in `IaC/live/aws-ssm-parameters` planned one SSM parameter create and one IAM reader policy update


<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `f29d7514a20ceb382b3a257b5a18f399e16b7c9b`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.

> AzureAD application registration plans were skipped because the plan environment did not provide `ARM_CLIENT_ID`, `ARM_CLIENT_SECRET`, and `ARM_TENANT_ID`. Production apply still fails fast when `IaC/live/azuread-applications` changes and those credentials are absent.


<!-- terragrunt-plan:end -->
