### PR TITLE
fix: reconcile octelium public tunnel dns

### DIFF
--- a/clusters/homelab/apps/octelium-public/README.md
+++ b/clusters/homelab/apps/octelium-public/README.md
@@ -28,8 +28,16 @@ the matching origin SNI and Host header. Istio then uses the existing
 `octelium-cluster` `VirtualService` to route to
 `octelium-ingress-dataplane.octelium.svc.cluster.local:8080`.
 
-The Cloudflare DNS records for the three public hostnames must be CNAMEs to the
-named tunnel target, `<tunnel-uuid>.cfargotunnel.com`.
+The Cloudflare DNS records for the three public hostnames must be exact proxied
+CNAMEs to the named tunnel target, `<tunnel-uuid>.cfargotunnel.com`. Reconcile
+them with `scripts/octelium-public-dns.sh` after the tunnel UUID is stored in
+SSM. Public resolvers should return Cloudflare anycast A/AAAA records, not the
+old tailnet `100.64.0.0/10` address.
+
+Cloudflare edge TLS also needs coverage for `octelium.stinkyboi.com` and
+`*.octelium.stinkyboi.com`. Istio's `stinkyboi-com-tls` origin certificate
+covers those names, but proxied Cloudflare records require Cloudflare to present
+a matching edge certificate before traffic reaches this connector.
 
 ## Validation
 
@@ -37,7 +45,8 @@ named tunnel target, `<tunnel-uuid>.cfargotunnel.com`.
 kubectl kustomize clusters/homelab/apps/octelium-public
 kubectl -n octelium-public get externalsecret,secret,deploy,pod
 kubectl -n octelium-public logs deploy/cloudflared
-dig +short octelium.stinkyboi.com CNAME
+scripts/octelium-public-dns.sh --dry-run
+dig +short octelium.stinkyboi.com
 curl -fsS -o /dev/null -w '%{http_code}\n' https://octelium.stinkyboi.com/
 curl -fsS -o /dev/null -w '%{http_code}\n' https://portal.octelium.stinkyboi.com/
 ```

--- a/docs/knowledge-base/runbooks/octelium.md
+++ b/docs/knowledge-base/runbooks/octelium.md
@@ -103,7 +103,12 @@ hostnames to the existing Istio `octelium-cluster` route. The Cloudflare Tunnel
 credentials JSON and UUID live outside git in
 `/homelab/octelium/cloudflare-tunnel-credentials-json` and
 `/homelab/octelium/cloudflare-tunnel-id`; both are rendered by the
-`octelium-public-cloudflared-credentials` ExternalSecret.
+`octelium-public-cloudflared-credentials` ExternalSecret. After those SSM values
+exist, run `scripts/octelium-public-dns.sh` to replace the old tailnet DNS
+answers with exact proxied CNAMEs to the Cloudflare Tunnel target. Cloudflare
+edge TLS must cover `octelium.stinkyboi.com` and `*.octelium.stinkyboi.com`;
+the Istio origin certificate alone does not satisfy TLS at Cloudflare's edge
+for nested portal/API hostnames.
 
 If public DNS or VPN access to the Octelium Cluster is not available yet,
 bootstrap the UI and API through a local port-forward to the Octelium Cluster

--- a/docs/knowledge-base/runbooks/tailnet-ingress.md
+++ b/docs/knowledge-base/runbooks/tailnet-ingress.md
@@ -15,10 +15,12 @@ reach.
 The Octelium control-plane names are the narrow public exception and do not use
 Tailscale Funnel. `octelium.stinkyboi.com`,
 `portal.octelium.stinkyboi.com`, and
-`octelium-api.octelium.stinkyboi.com` are CNAMEs to the
-`homelab-octelium-public` Cloudflare Tunnel target. The in-cluster
-`octelium-public` app runs `cloudflared` and forwards those hostnames to the
-Istio gateway, which preserves the existing Octelium Cluster `VirtualService`.
+`octelium-api.octelium.stinkyboi.com` are proxied Cloudflare CNAMEs to the
+`homelab-octelium-public` Cloudflare Tunnel target. Public DNS returns
+Cloudflare anycast addresses, while the Cloudflare zone metadata keeps the
+`<tunnel-uuid>.cfargotunnel.com` target. The in-cluster `octelium-public` app
+runs `cloudflared` and forwards those hostnames to the Istio gateway, which
+preserves the existing Octelium Cluster `VirtualService`.
 
 The Octelium service catalog in `docs/examples/octelium/homelab-services.yaml`
 keeps the existing app URLs by storing each `*.stinkyboi.com` hostname as a

--- a/docs/networking-tailnet-ingress.md
+++ b/docs/networking-tailnet-ingress.md
@@ -17,10 +17,19 @@ are the public bootstrap and control-plane exception: Cloudflare Tunnel routes
 those names from the public Internet to the in-cluster Istio gateway, and Istio
 then routes to the Octelium dataplane.
 
-The public control-plane DNS records must be exact CNAMEs to the
+The public control-plane DNS records must be exact proxied CNAMEs to the
 `homelab-octelium-public` Cloudflare Tunnel target,
-`<tunnel-uuid>.cfargotunnel.com`. They must not point at the old tailnet
-LoadBalancer IP.
+`<tunnel-uuid>.cfargotunnel.com`. Public DNS answers should be Cloudflare
+anycast addresses, not the old tailnet LoadBalancer IP. Use
+`scripts/octelium-public-dns.sh` to reconcile those exact records from the
+SSM-backed tunnel UUID.
+
+Cloudflare edge TLS must cover the same names as the origin certificate:
+`octelium.stinkyboi.com` and `*.octelium.stinkyboi.com`. The in-cluster
+cert-manager certificate can satisfy Istio origin TLS, but Cloudflare still
+needs edge coverage for the nested `portal.octelium.stinkyboi.com` and
+`octelium-api.octelium.stinkyboi.com` hostnames when the DNS records are
+proxied.
 
 ## Route Inventory
 

--- a/docs/secrets-aws-ssm.md
+++ b/docs/secrets-aws-ssm.md
@@ -180,10 +180,15 @@ The public Octelium control plane uses a Cloudflare Tunnel connector in
 `octelium-public`. Store the credentials JSON created by
 `cloudflared tunnel create homelab-octelium-public` in
 `/homelab/octelium/cloudflare-tunnel-credentials-json` and the tunnel UUID in
-`/homelab/octelium/cloudflare-tunnel-id`, then route `octelium.stinkyboi.com`,
-`portal.octelium.stinkyboi.com`, and `octelium-api.octelium.stinkyboi.com` to
-the tunnel target `<tunnel-uuid>.cfargotunnel.com`. Keep the credentials JSON
-and any Cloudflare API token outside git.
+`/homelab/octelium/cloudflare-tunnel-id`, then run
+`scripts/octelium-public-dns.sh` to route `octelium.stinkyboi.com`,
+`portal.octelium.stinkyboi.com`, and `octelium-api.octelium.stinkyboi.com`
+through proxied CNAME records to the tunnel target
+`<tunnel-uuid>.cfargotunnel.com`. Keep the credentials JSON and any Cloudflare
+API token outside git. Cloudflare edge TLS must cover both
+`octelium.stinkyboi.com` and `*.octelium.stinkyboi.com`; otherwise the nested
+portal and API names reach Cloudflare but fail before the tunnel with an edge
+TLS handshake error.
 
 The cert-manager Cloudflare value should be a scoped API token with permission
 to read the zone and edit DNS records for `stinkyboi.com`; do not store the

--- a/scripts/octelium-public-dns.sh
+++ b/scripts/octelium-public-dns.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+domain="octelium.stinkyboi.com"
+zone_name="stinkyboi.com"
+aws_region="us-west-2"
+token_parameter="/homelab/cert-manager/cloudflare-api-token"
+tunnel_id_parameter="/homelab/octelium/cloudflare-tunnel-id"
+dry_run="false"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/octelium-public-dns.sh [options]
+
+Reconcile Cloudflare DNS records for the public Octelium control plane.
+
+The script reads the Cloudflare API token and Cloudflare Tunnel UUID from AWS
+SSM Parameter Store, removes exact A/AAAA records for the Octelium control-plane
+hostnames, and creates exact proxied CNAME records pointing at the named tunnel
+target. It does not touch wildcard records or app hostnames such as
+grafana.stinkyboi.com.
+
+Options:
+  --domain DOMAIN                 Octelium Cluster domain. Default: octelium.stinkyboi.com
+  --zone NAME                     Cloudflare zone name. Default: stinkyboi.com
+  --aws-region REGION             AWS region for SSM. Default: us-west-2
+  --token-parameter NAME          SSM parameter containing the Cloudflare API token.
+                                  Default: /homelab/cert-manager/cloudflare-api-token
+  --tunnel-id-parameter NAME      SSM parameter containing the Cloudflare Tunnel UUID.
+                                  Default: /homelab/octelium/cloudflare-tunnel-id
+  --dry-run                       Print intended changes without writing Cloudflare DNS.
+  -h, --help                      Show this help.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --domain)
+      domain="$2"
+      shift 2
+      ;;
+    --zone)
+      zone_name="$2"
+      shift 2
+      ;;
+    --aws-region)
+      aws_region="$2"
+      shift 2
+      ;;
+    --token-parameter)
+      token_parameter="$2"
+      shift 2
+      ;;
+    --tunnel-id-parameter)
+      tunnel_id_parameter="$2"
+      shift 2
+      ;;
+    --dry-run)
+      dry_run="true"
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "error: $1 is required" >&2
+    exit 127
+  fi
+}
+
+require_command aws
+require_command curl
+require_command jq
+
+cloudflare_token="$(
+  aws ssm get-parameter \
+    --region "$aws_region" \
+    --name "$token_parameter" \
+    --with-decryption \
+    --query Parameter.Value \
+    --output text
+)"
+
+tunnel_id="$(
+  aws ssm get-parameter \
+    --region "$aws_region" \
+    --name "$tunnel_id_parameter" \
+    --with-decryption \
+    --query Parameter.Value \
+    --output text
+)"
+
+if ! [[ "$tunnel_id" =~ ^[0-9a-fA-F-]{36}$ ]]; then
+  echo "error: ${tunnel_id_parameter} does not look like a Cloudflare Tunnel UUID" >&2
+  exit 1
+fi
+
+cf_api() {
+  local method="$1"
+  local path="$2"
+  local data="${3:-}"
+
+  if [[ -n "$data" ]]; then
+    curl -fsS \
+      -X "$method" \
+      -H "Authorization: Bearer ${cloudflare_token}" \
+      -H "Content-Type: application/json" \
+      --data "$data" \
+      "https://api.cloudflare.com/client/v4${path}"
+  else
+    curl -fsS \
+      -X "$method" \
+      -H "Authorization: Bearer ${cloudflare_token}" \
+      -H "Content-Type: application/json" \
+      "https://api.cloudflare.com/client/v4${path}"
+  fi
+}
+
+zone_id="$(
+  cf_api GET "/zones?name=${zone_name}" |
+    jq -er '.result[0].id'
+)"
+
+tunnel_target="${tunnel_id}.cfargotunnel.com"
+hostnames=(
+  "$domain"
+  "portal.${domain}"
+  "octelium-api.${domain}"
+)
+
+delete_exact_records() {
+  local hostname="$1"
+  local record_type="$2"
+  local records
+
+  records="$(
+    cf_api GET "/zones/${zone_id}/dns_records?type=${record_type}&name=${hostname}" |
+      jq -c '.result[]'
+  )"
+
+  if [[ -z "$records" ]]; then
+    return 0
+  fi
+
+  while IFS= read -r record; do
+    [[ -n "$record" ]] || continue
+    local id content
+    id="$(jq -r '.id' <<<"$record")"
+    content="$(jq -r '.content' <<<"$record")"
+    if [[ "$dry_run" == "true" ]]; then
+      echo "DRY-RUN delete ${record_type} ${hostname} ${content}"
+    else
+      cf_api DELETE "/zones/${zone_id}/dns_records/${id}" >/dev/null
+      echo "Deleted ${record_type} ${hostname} ${content}"
+    fi
+  done <<<"$records"
+}
+
+upsert_cname_record() {
+  local hostname="$1"
+  local payload records record_id
+
+  payload="$(
+    jq -cn \
+      --arg type "CNAME" \
+      --arg name "$hostname" \
+      --arg content "$tunnel_target" \
+      '{type: $type, name: $name, content: $content, ttl: 1, proxied: true}'
+  )"
+
+  records="$(
+    cf_api GET "/zones/${zone_id}/dns_records?type=CNAME&name=${hostname}" |
+      jq -c '.result[]'
+  )"
+
+  if [[ -z "$records" ]]; then
+    if [[ "$dry_run" == "true" ]]; then
+      echo "DRY-RUN create CNAME ${hostname} ${tunnel_target}"
+    else
+      cf_api POST "/zones/${zone_id}/dns_records" "$payload" >/dev/null
+      echo "Created CNAME ${hostname} ${tunnel_target}"
+    fi
+    return 0
+  fi
+
+  record_id="$(jq -r '.id' <<<"$(head -n 1 <<<"$records")")"
+  if [[ "$dry_run" == "true" ]]; then
+    echo "DRY-RUN update CNAME ${hostname} ${tunnel_target}"
+  else
+    cf_api PUT "/zones/${zone_id}/dns_records/${record_id}" "$payload" >/dev/null
+    echo "Updated CNAME ${hostname} ${tunnel_target}"
+  fi
+
+  tail -n +2 <<<"$records" | while IFS= read -r extra_record; do
+    [[ -n "$extra_record" ]] || continue
+    local extra_id extra_content
+    extra_id="$(jq -r '.id' <<<"$extra_record")"
+    extra_content="$(jq -r '.content' <<<"$extra_record")"
+    if [[ "$dry_run" == "true" ]]; then
+      echo "DRY-RUN delete extra CNAME ${hostname} ${extra_content}"
+    else
+      cf_api DELETE "/zones/${zone_id}/dns_records/${extra_id}" >/dev/null
+      echo "Deleted extra CNAME ${hostname} ${extra_content}"
+    fi
+  done
+}
+
+for hostname in "${hostnames[@]}"; do
+  delete_exact_records "$hostname" A
+  delete_exact_records "$hostname" AAAA
+  upsert_cname_record "$hostname"
+done


### PR DESCRIPTION
## Summary
- add a repo-owned Cloudflare DNS reconciler for the Octelium public control-plane hostnames
- make the three Octelium public hostnames exact proxied CNAMEs to the SSM-backed Cloudflare Tunnel UUID
- document that Cloudflare edge TLS must cover octelium.stinkyboi.com and *.octelium.stinkyboi.com for nested portal/API hosts

## Validation
- bash -n scripts/octelium-public-dns.sh
- AWS_PROFILE=SubAccountAdmin-716182248480 scripts/octelium-public-dns.sh --dry-run
- AWS_PROFILE=SubAccountAdmin-716182248480 scripts/octelium-public-dns.sh
- dig +short @1.1.1.1 octelium.stinkyboi.com
- dig +short @1.1.1.1 portal.octelium.stinkyboi.com A / AAAA
- dig +short @1.1.1.1 octelium-api.octelium.stinkyboi.com A / AAAA
- curl -fsS -I --resolve octelium.stinkyboi.com:443:104.21.93.45 https://octelium.stinkyboi.com/
- bash scripts/ci/static-checks.sh

## Live result
- cloudflared is healthy at 2/2 replicas and registered with Cloudflare edge
- octelium.stinkyboi.com works through Cloudflare with server: cloudflare and HTTP/2 200
- portal.octelium.stinkyboi.com and octelium-api.octelium.stinkyboi.com now resolve to Cloudflare anycast, but Cloudflare edge TLS still needs nested hostname coverage before those two can complete TLS

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `949ff344fa5b89f2accdf49af575dc865aa04234`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.

> AzureAD application registration plans were skipped because the plan environment did not provide `ARM_CLIENT_ID`, `ARM_CLIENT_SECRET`, and `ARM_TENANT_ID`. Production apply still fails fast when `IaC/live/azuread-applications` changes and those credentials are absent.


<!-- terragrunt-plan:end -->
