### PR TITLE
fix(octelium): preserve forwarded app headers

### DIFF
--- a/docs/examples/octelium/homelab-services.yaml
+++ b/docs/examples/octelium/homelab-services.yaml
@@ -95,6 +95,7 @@ spec:
       url: http://istio-ingressgateway.istio-system.svc.cluster.local
     http:
       header:
+        forwardedMode: TRANSPARENT
         host:
           value: argocd.stinkyboi.com
         addRequestHeaders:
@@ -121,6 +122,7 @@ spec:
       url: http://istio-ingressgateway.istio-system.svc.cluster.local
     http:
       header:
+        forwardedMode: TRANSPARENT
         host:
           value: compass.stinkyboi.com
         addRequestHeaders:
@@ -147,6 +149,7 @@ spec:
       url: http://istio-ingressgateway.istio-system.svc.cluster.local
     http:
       header:
+        forwardedMode: TRANSPARENT
         host:
           value: deluge.stinkyboi.com
         addRequestHeaders:
@@ -173,6 +176,7 @@ spec:
       url: http://istio-ingressgateway.istio-system.svc.cluster.local
     http:
       header:
+        forwardedMode: TRANSPARENT
         host:
           value: grafana.stinkyboi.com
         addRequestHeaders:
@@ -210,6 +214,7 @@ spec:
       url: http://istio-ingressgateway.istio-system.svc.cluster.local
     http:
       header:
+        forwardedMode: TRANSPARENT
         host:
           value: kiali.stinkyboi.com
         addRequestHeaders:
@@ -246,6 +251,7 @@ spec:
       url: http://istio-ingressgateway.istio-system.svc.cluster.local
     http:
       header:
+        forwardedMode: TRANSPARENT
         host:
           value: litellm.stinkyboi.com
         addRequestHeaders:
@@ -272,6 +278,7 @@ spec:
       url: http://istio-ingressgateway.istio-system.svc.cluster.local
     http:
       header:
+        forwardedMode: TRANSPARENT
         host:
           value: n8n.stinkyboi.com
         addRequestHeaders:
@@ -298,6 +305,7 @@ spec:
       url: http://istio-ingressgateway.istio-system.svc.cluster.local
     http:
       header:
+        forwardedMode: TRANSPARENT
         host:
           value: octobot.stinkyboi.com
         addRequestHeaders:
@@ -324,6 +332,7 @@ spec:
       url: http://istio-ingressgateway.istio-system.svc.cluster.local
     http:
       header:
+        forwardedMode: TRANSPARENT
         host:
           value: openclaw.stinkyboi.com
         addRequestHeaders:
@@ -350,6 +359,7 @@ spec:
       url: http://istio-ingressgateway.istio-system.svc.cluster.local
     http:
       header:
+        forwardedMode: TRANSPARENT
         host:
           value: policy-bot.stinkyboi.com
         addRequestHeaders:
@@ -376,6 +386,7 @@ spec:
       url: http://istio-ingressgateway.istio-system.svc.cluster.local
     http:
       header:
+        forwardedMode: TRANSPARENT
         host:
           value: prowlarr.stinkyboi.com
         addRequestHeaders:
@@ -402,6 +413,7 @@ spec:
       url: http://istio-ingressgateway.istio-system.svc.cluster.local
     http:
       header:
+        forwardedMode: TRANSPARENT
         host:
           value: radarr.stinkyboi.com
         addRequestHeaders:
@@ -428,6 +440,7 @@ spec:
       url: http://istio-ingressgateway.istio-system.svc.cluster.local
     http:
       header:
+        forwardedMode: TRANSPARENT
         host:
           value: sonarr.stinkyboi.com
         addRequestHeaders:

--- a/docs/knowledge-base/runbooks/octelium.md
+++ b/docs/knowledge-base/runbooks/octelium.md
@@ -41,7 +41,10 @@ a separate workload User `homelab-ci`, Policy
 Service as the transport path for live Terragrunt plan/apply and diagnostics.
 The app Services forward HTTP to the in-cluster Istio gateway while setting the
 original app hostname headers, preserving existing `https://*.stinkyboi.com`
-URLs and Istio routing while moving browser authentication to Octelium. The
+URLs and Istio routing while moving browser authentication to Octelium. Keep
+`forwardedMode: TRANSPARENT` on these `WEB` Services whenever they set
+`X-Forwarded-*` headers; otherwise Octelium can derive forwarded values from
+the internal upstream and confuse apps that build absolute HTTPS URLs. The
 Kubernetes connector scope list is limited to `homelab-demo.homelab`; app
 traffic uses Cloudflare Tunnel to Octelium public ingress instead of a local
 VPN command.

--- a/docs/octelium.md
+++ b/docs/octelium.md
@@ -76,9 +76,11 @@ They create:
 
 Each app `WEB` Service forwards HTTP to the in-cluster Istio gateway while
 setting `Host`, `X-Forwarded-Host`, `X-Forwarded-Port`, and
-`X-Forwarded-Proto` for the original app hostname. That keeps each app's
-existing Istio `VirtualService` and base URL intact while moving the user-facing
-authentication layer to Octelium clientless access.
+`X-Forwarded-Proto` for the original app hostname. The header block also sets
+`forwardedMode: TRANSPARENT` so Octelium preserves those explicit forwarded
+headers instead of deriving them from the internal upstream. That keeps each
+app's existing Istio `VirtualService` and base URL intact while moving the
+user-facing authentication layer to Octelium clientless access.
 
 Apply the service catalog to the Octelium Cluster:
 


### PR DESCRIPTION
## Summary
- set Octelium app WEB services to forwardedMode: TRANSPARENT so explicit Host and X-Forwarded-* headers are preserved
- document the forwarded-header requirement for clientless app access

## Validation
- ruby -e 'require "yaml"; YAML.load_stream(File.read("docs/examples/octelium/homelab-services.yaml")); puts "ok"'
- octeliumctl --domain stinkyboi.com apply docs/examples/octelium/homelab-services.yaml
- octeliumctl --domain stinkyboi.com get service grafana -o yaml
- curl -sSIL --max-redirs 12 https://grafana.stinkyboi.com/
- scripts/octelium-e2e-check.sh