### PR TITLE
fix(octelium): use non-redirecting app upstreams

### DIFF
--- a/clusters/homelab/apps/istio/tailnet-gateway.yaml
+++ b/clusters/homelab/apps/istio/tailnet-gateway.yaml
@@ -25,6 +25,7 @@ spec:
       hosts:
         - stinkyboi.com
         - "*.stinkyboi.com"
+        - istio-ingressgateway.istio-system.svc.cluster.local
       tls:
         mode: SIMPLE
         credentialName: stinkyboi-com-tls

--- a/clusters/homelab/apps/octelium/README.md
+++ b/clusters/homelab/apps/octelium/README.md
@@ -48,9 +48,11 @@ The Octelium resource catalog for the external Octelium Cluster is
   `https://grafana.stinkyboi.com`.
 - WEB Service `homelab-demo.homelab` for service-proxy smoke tests.
 
-Each app `WEB` Service forwards to the in-cluster Istio gateway while setting
-the original app hostname in the HTTP headers. Exact Cloudflare app records are
-proxied CNAMEs to the public tunnel, so users can open the existing
+Each app `WEB` Service forwards over HTTPS to the in-cluster Istio gateway
+while setting the original app hostname in the HTTP headers. This internal
+HTTPS hop avoids the gateway's HTTP-to-HTTPS redirect while preserving the
+existing app `VirtualService` routes. Exact Cloudflare app records are proxied
+CNAMEs to the public tunnel, so users can open the existing
 `https://*.stinkyboi.com` URLs without running `octelium connect`.
 
 The connector manifest runs at one replica after the Octelium Cluster API,

--- a/docs/examples/octelium/homelab-services.yaml
+++ b/docs/examples/octelium/homelab-services.yaml
@@ -92,7 +92,9 @@ spec:
       - homelab-human-web-access
   config:
     upstream:
-      url: http://istio-ingressgateway.istio-system.svc.cluster.local
+      url: https://istio-ingressgateway.istio-system.svc.cluster.local:443
+    tls:
+      insecureSkipVerify: true
     http:
       header:
         forwardedMode: TRANSPARENT
@@ -119,7 +121,9 @@ spec:
       - homelab-human-web-access
   config:
     upstream:
-      url: http://istio-ingressgateway.istio-system.svc.cluster.local
+      url: https://istio-ingressgateway.istio-system.svc.cluster.local:443
+    tls:
+      insecureSkipVerify: true
     http:
       header:
         forwardedMode: TRANSPARENT
@@ -146,7 +150,9 @@ spec:
       - homelab-human-web-access
   config:
     upstream:
-      url: http://istio-ingressgateway.istio-system.svc.cluster.local
+      url: https://istio-ingressgateway.istio-system.svc.cluster.local:443
+    tls:
+      insecureSkipVerify: true
     http:
       header:
         forwardedMode: TRANSPARENT
@@ -173,7 +179,9 @@ spec:
       - homelab-human-web-access
   config:
     upstream:
-      url: http://istio-ingressgateway.istio-system.svc.cluster.local
+      url: https://istio-ingressgateway.istio-system.svc.cluster.local:443
+    tls:
+      insecureSkipVerify: true
     http:
       header:
         forwardedMode: TRANSPARENT
@@ -211,7 +219,9 @@ spec:
       - homelab-human-web-access
   config:
     upstream:
-      url: http://istio-ingressgateway.istio-system.svc.cluster.local
+      url: https://istio-ingressgateway.istio-system.svc.cluster.local:443
+    tls:
+      insecureSkipVerify: true
     http:
       header:
         forwardedMode: TRANSPARENT
@@ -248,7 +258,9 @@ spec:
       - homelab-human-web-access
   config:
     upstream:
-      url: http://istio-ingressgateway.istio-system.svc.cluster.local
+      url: https://istio-ingressgateway.istio-system.svc.cluster.local:443
+    tls:
+      insecureSkipVerify: true
     http:
       header:
         forwardedMode: TRANSPARENT
@@ -275,7 +287,9 @@ spec:
       - homelab-human-web-access
   config:
     upstream:
-      url: http://istio-ingressgateway.istio-system.svc.cluster.local
+      url: https://istio-ingressgateway.istio-system.svc.cluster.local:443
+    tls:
+      insecureSkipVerify: true
     http:
       header:
         forwardedMode: TRANSPARENT
@@ -302,7 +316,9 @@ spec:
       - homelab-human-web-access
   config:
     upstream:
-      url: http://istio-ingressgateway.istio-system.svc.cluster.local
+      url: https://istio-ingressgateway.istio-system.svc.cluster.local:443
+    tls:
+      insecureSkipVerify: true
     http:
       header:
         forwardedMode: TRANSPARENT
@@ -329,7 +345,9 @@ spec:
       - homelab-human-web-access
   config:
     upstream:
-      url: http://istio-ingressgateway.istio-system.svc.cluster.local
+      url: https://istio-ingressgateway.istio-system.svc.cluster.local:443
+    tls:
+      insecureSkipVerify: true
     http:
       header:
         forwardedMode: TRANSPARENT
@@ -356,7 +374,9 @@ spec:
       - homelab-human-web-access
   config:
     upstream:
-      url: http://istio-ingressgateway.istio-system.svc.cluster.local
+      url: https://istio-ingressgateway.istio-system.svc.cluster.local:443
+    tls:
+      insecureSkipVerify: true
     http:
       header:
         forwardedMode: TRANSPARENT
@@ -383,7 +403,9 @@ spec:
       - homelab-human-web-access
   config:
     upstream:
-      url: http://istio-ingressgateway.istio-system.svc.cluster.local
+      url: https://istio-ingressgateway.istio-system.svc.cluster.local:443
+    tls:
+      insecureSkipVerify: true
     http:
       header:
         forwardedMode: TRANSPARENT
@@ -410,7 +432,9 @@ spec:
       - homelab-human-web-access
   config:
     upstream:
-      url: http://istio-ingressgateway.istio-system.svc.cluster.local
+      url: https://istio-ingressgateway.istio-system.svc.cluster.local:443
+    tls:
+      insecureSkipVerify: true
     http:
       header:
         forwardedMode: TRANSPARENT
@@ -437,7 +461,9 @@ spec:
       - homelab-human-web-access
   config:
     upstream:
-      url: http://istio-ingressgateway.istio-system.svc.cluster.local
+      url: https://istio-ingressgateway.istio-system.svc.cluster.local:443
+    tls:
+      insecureSkipVerify: true
     http:
       header:
         forwardedMode: TRANSPARENT

--- a/docs/knowledge-base/runbooks/octelium.md
+++ b/docs/knowledge-base/runbooks/octelium.md
@@ -39,10 +39,12 @@ a separate workload User `homelab-ci`, Policy
 `homelab-ci-kubernetes-api-access`, and TCP Service
 `kubernetes-api.ci -> tcp://10.1.0.199:6443`; GitHub Actions uses that
 Service as the transport path for live Terragrunt plan/apply and diagnostics.
-The app Services forward HTTP to the in-cluster Istio gateway while setting the
-original app hostname headers, preserving existing `https://*.stinkyboi.com`
-URLs and Istio routing while moving browser authentication to Octelium. Keep
-`forwardedMode: TRANSPARENT` on these `WEB` Services whenever they set
+The app Services forward HTTPS to the in-cluster Istio gateway while setting
+the original app hostname headers, preserving existing
+`https://*.stinkyboi.com` URLs and Istio routing while moving browser
+authentication to Octelium. The internal HTTPS hop avoids the gateway's
+HTTP-to-HTTPS redirect loop for authenticated clientless browser requests.
+Keep `forwardedMode: TRANSPARENT` on these `WEB` Services whenever they set
 `X-Forwarded-*` headers; otherwise Octelium can derive forwarded values from
 the internal upstream and confuse apps that build absolute HTTPS URLs. The
 Kubernetes connector scope list is limited to `homelab-demo.homelab`; app

--- a/docs/knowledge-base/runbooks/tailnet-ingress.md
+++ b/docs/knowledge-base/runbooks/tailnet-ingress.md
@@ -24,9 +24,11 @@ preserves the existing Octelium Cluster `VirtualService`.
 
 The Octelium service catalog in `docs/examples/octelium/homelab-services.yaml`
 keeps the existing app URLs by storing each `*.stinkyboi.com` hostname as a
-service attribute and forwarding TCP/443 to the in-cluster Istio gateway. The
-per-app Istio `VirtualService` objects are private backend routes for that
-Octelium path, not public Funnel routes.
+service attribute and forwarding HTTPS to the in-cluster Istio gateway. The
+internal HTTPS hop avoids the gateway's HTTP-to-HTTPS redirect loop for
+authenticated clientless browser requests. The per-app Istio `VirtualService`
+objects are private backend routes for that Octelium path, not public Funnel
+routes.
 
 Octelium is documented under [[octelium]]. It replaces app access only; it does
 not replace the Tailscale exit node, CI route, or reviewed public webhook

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -122,10 +122,11 @@ client chart plus repo-owned support manifests in
 image by digest and force `--implementation=tun` with `NET_ADMIN` and `MKNOD`
 so the connector can create `/dev/net/tun` when a workload bridge is needed.
 Current app access uses public first-level Octelium `WEB` Services such as
-`grafana` and `argocd`. Each service forwards HTTP to the in-cluster Istio
+`grafana` and `argocd`. Each service forwards HTTPS to the in-cluster Istio
 gateway while setting the original app hostname headers, preserving the
 existing `*.stinkyboi.com` app URLs without requiring users to run
-`octelium connect`. The connector is pinned to nodes with
+`octelium connect` and avoiding the gateway's HTTP-to-HTTPS redirect loop for
+authenticated clientless browser requests. The connector is pinned to nodes with
 `octelium.com/node-mode-dataplane=` for future served workload upstreams.
 
 The connector runs with `replicaCount: 1` after the Octelium API, service

--- a/docs/octelium.md
+++ b/docs/octelium.md
@@ -74,13 +74,15 @@ They create:
   such as `https://grafana.stinkyboi.com`.
 - WEB Service `homelab-demo.homelab` for service-proxy smoke tests.
 
-Each app `WEB` Service forwards HTTP to the in-cluster Istio gateway while
+Each app `WEB` Service forwards HTTPS to the in-cluster Istio gateway while
 setting `Host`, `X-Forwarded-Host`, `X-Forwarded-Port`, and
-`X-Forwarded-Proto` for the original app hostname. The header block also sets
-`forwardedMode: TRANSPARENT` so Octelium preserves those explicit forwarded
-headers instead of deriving them from the internal upstream. That keeps each
-app's existing Istio `VirtualService` and base URL intact while moving the
-user-facing authentication layer to Octelium clientless access.
+`X-Forwarded-Proto` for the original app hostname. The HTTPS hop avoids the
+gateway's HTTP-to-HTTPS redirect loop for authenticated clientless browser
+requests. The header block also sets `forwardedMode: TRANSPARENT` so Octelium
+preserves those explicit forwarded headers instead of deriving them from the
+internal upstream. That keeps each app's existing Istio `VirtualService` and
+base URL intact while moving the user-facing authentication layer to Octelium
+clientless access.
 
 Apply the service catalog to the Octelium Cluster:
 

--- a/scripts/octelium-e2e-check.sh
+++ b/scripts/octelium-e2e-check.sh
@@ -393,6 +393,11 @@ if [ "${GRPC_READY}" -eq 1 ]; then
       else
         fail "Octelium Service ${SERVICE} is not WEB with isPublic=true"
       fi
+      if jq -e --arg service "${SERVICE}" '.items[] | select((.metadata.name == $service or .status.primaryHostname == $service) and .spec.config.upstream.url == "https://istio-ingressgateway.istio-system.svc.cluster.local:443" and .spec.config.tls.insecureSkipVerify == true)' >/dev/null 2>&1 <<<"${SERVICES_JSON}"; then
+        pass "Octelium Service ${SERVICE} uses the non-redirecting Istio HTTPS upstream"
+      else
+        fail "Octelium Service ${SERVICE} is not using the non-redirecting Istio HTTPS upstream"
+      fi
     done
   else
     if [ -s /tmp/octelium-services.err.$$ ]; then


### PR DESCRIPTION
## Summary
- route Octelium app WEB services to Istio over the internal HTTPS listener instead of the redirecting HTTP listener
- allow the Istio gateway HTTPS server to accept the internal service DNS name for that hop
- document the Octelium clientless app path and add an e2e guard for the non-redirecting upstream

## Validation
- Applied the Istio Gateway change live
- Applied docs/examples/octelium/homelab-services.yaml live with octeliumctl
- Confirmed Grafana works in the browser after the fix
- scripts/octelium-e2e-check.sh
- git diff --cached --check
- pre-commit hooks during signed commit
