### PR TITLE
fix(argocd): detect multi-source revision drift

### DIFF
--- a/IaC/modules/argocd-application-kubernetes/main.tf
+++ b/IaC/modules/argocd-application-kubernetes/main.tf
@@ -63,11 +63,15 @@ locals {
     "spec.destination.name",
   ]
   multi_source_computed_fields = length(var.sources) > 1 ? [
-    # Argo CD normalizes multi-source entries after apply, including default path
-    # values and empty nested source blocks. Treat the list as API-computed so
-    # the Kubernetes provider stores Argo CD's returned shape without failing
-    # state reconciliation while still sending the repo-owned sources below.
-    "spec.sources",
+    # Argo CD normalizes default path values for multi-source entries. Keep
+    # those path-only fields API-computed without masking repo-owned fields such
+    # as targetRevision, otherwise temporary branch pins can drift indefinitely.
+    for idx, source in var.sources : "spec.sources[${idx}].path"
+    if try(source.path, null) == null && (
+      try(source.chart, null) != null ||
+      try(source.ref, null) != null ||
+      try(source.directory, null) != null
+    )
   ] : []
   computed_field_defaults = concat(local.default_computed_fields, local.multi_source_computed_fields)
   computed_fields         = var.computed_fields == null ? local.computed_field_defaults : distinct(concat(local.computed_field_defaults, var.computed_fields))


### PR DESCRIPTION
## Summary
- narrow Argo CD Application multi-source computed fields to API-normalized path fields only
- keep targetRevision repo-owned so temporary branch pins are detected and repaired by Terragrunt

## Validation
- tofu fmt -check IaC/modules/argocd-application-kubernetes/main.tf
- terragrunt --log-disable plan -no-color in IaC/live/argocd-apps/istio showed targetRevision drift from codex/connect-cicd-octelium to main
- terragrunt --log-disable apply -no-color plan.out restored live Istio sources to main
- kubectl confirmed live Istio Application sources target main and Argo reports Synced/Healthy
- scripts/octelium-e2e-check.sh
- pre-commit hooks during signed commit
