### PR TITLE
fix: route openclaw openai model through codex runtime

### DIFF
--- a/.github/workflows/terragrunt-plan.yml
+++ b/.github/workflows/terragrunt-plan.yml
@@ -108,7 +108,32 @@ jobs:
           primary-key: nix-develop-${{ runner.os }}-${{ hashFiles('flake.nix', 'flake.lock') }}
           restore-prefixes-first-match: nix-develop-${{ runner.os }}-
 
+      - name: Detect Live Terragrunt Plan Scope
+        id: live-plan-scope
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          requires_live_plan=false
+          while IFS= read -r changed_path; do
+            case "${changed_path}" in
+              IaC/*|flake.nix|flake.lock|policy/*)
+                requires_live_plan=true
+                ;;
+              scripts/ci/connect-octelium.sh|scripts/ci/disconnect-octelium.sh|scripts/ci/install-kubeconfig.sh|scripts/ci/install-octelium-client.sh|scripts/ci/terragrunt-*|scripts/ci/update-pr-plan-description.sh)
+                requires_live_plan=true
+                ;;
+            esac
+          done < <(git diff --name-only "origin/${BASE_REF}...HEAD")
+
+          echo "requires-live-plan=${requires_live_plan}" >>"${GITHUB_OUTPUT}"
+          if [ "${requires_live_plan}" = "true" ]; then
+            echo "Live Terragrunt plan is required for this pull request."
+          else
+            echo "No live Terragrunt plan inputs changed; skipping Octelium, Kubernetes, and OpenTofu plan steps."
+          fi
+
       - name: Verify Live Plan Inputs
+        if: steps.live-plan-scope.outputs.requires-live-plan == 'true'
         env:
           OCTELIUM_AUTH_TOKEN: ${{ secrets.OCTELIUM_CI_AUTH_TOKEN }}
         run: |
@@ -116,6 +141,7 @@ jobs:
           test -n "${OCTELIUM_AUTH_TOKEN}" || { echo "OCTELIUM_CI_AUTH_TOKEN must be set as a homelab-plan environment secret."; exit 1; }
 
       - name: Configure AWS Credentials
+        if: steps.live-plan-scope.outputs.requires-live-plan == 'true'
         # aws-actions/configure-aws-credentials@v6.1.1
         uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885
         with:
@@ -126,14 +152,17 @@ jobs:
           unset-current-credentials: true
 
       - name: Install Octelium Client
+        if: steps.live-plan-scope.outputs.requires-live-plan == 'true'
         run: bash scripts/ci/install-octelium-client.sh
 
       - name: Connect To Octelium
+        if: steps.live-plan-scope.outputs.requires-live-plan == 'true'
         env:
           OCTELIUM_AUTH_TOKEN: ${{ secrets.OCTELIUM_CI_AUTH_TOKEN }}
         run: bash scripts/ci/connect-octelium.sh
 
       - name: Install Kubeconfig
+        if: steps.live-plan-scope.outputs.requires-live-plan == 'true'
         env:
           KUBE_CONFIG_B64: ${{ secrets.KUBE_CONFIG_B64 }}
           KUBE_API_SERVER_URL: ${{ env.KUBE_API_SERVER_URL }}
@@ -141,28 +170,35 @@ jobs:
         run: bash scripts/ci/install-kubeconfig.sh
 
       - name: Verify Kubernetes API Reachability
+        if: steps.live-plan-scope.outputs.requires-live-plan == 'true'
         run: |
           curl -ksS --max-time 10 -o /dev/null "${KUBE_API_SERVER_URL}/version"
           kubectl --request-timeout=15s version
 
       - name: Run Terragrunt Plan
+        if: steps.live-plan-scope.outputs.requires-live-plan == 'true'
         env:
           TERRAGRUNT_PLAN_MARKDOWN: ${{ runner.temp }}/terragrunt-plan.md
         run: nix develop --command bash scripts/ci/terragrunt-plan.sh
 
       - name: Update PR Description With Plan
+        if: steps.live-plan-scope.outputs.requires-live-plan == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           TERRAGRUNT_PLAN_MARKDOWN: ${{ runner.temp }}/terragrunt-plan.md
         run: bash scripts/ci/update-pr-plan-description.sh
 
+      - name: Explain Live Plan Skip
+        if: steps.live-plan-scope.outputs.requires-live-plan != 'true'
+        run: echo "Live Terragrunt plan was skipped because this pull request did not change IaC, OpenTofu/Terragrunt policy inputs, flake inputs, or live-plan helper scripts."
+
       - name: Run Conftest Policies
         if: ${{ !cancelled() }}
         run: nix develop --command bash scripts/ci/conftest-policies.sh
 
       - name: Disconnect Octelium
-        if: always()
+        if: ${{ always() && steps.live-plan-scope.outputs.requires-live-plan == 'true' }}
         run: bash scripts/ci/disconnect-octelium.sh
 
   fork-plan-skipped:

--- a/.github/workflows/terragrunt-plan.yml
+++ b/.github/workflows/terragrunt-plan.yml
@@ -181,17 +181,23 @@ jobs:
           TERRAGRUNT_PLAN_MARKDOWN: ${{ runner.temp }}/terragrunt-plan.md
         run: nix develop --command bash scripts/ci/terragrunt-plan.sh
 
-      - name: Update PR Description With Plan
-        if: steps.live-plan-scope.outputs.requires-live-plan == 'true'
+      - name: Write Live Plan Skip Note
+        if: steps.live-plan-scope.outputs.requires-live-plan != 'true'
+        env:
+          TERRAGRUNT_PLAN_MARKDOWN: ${{ runner.temp }}/terragrunt-plan.md
+        run: |
+          {
+            printf '## Terragrunt Plan Output\n\n'
+            printf '> Live Terragrunt plan skipped because this pull request did not change `IaC/**`, flake inputs, OpenTofu/Terragrunt policy inputs, or live-plan helper scripts.\n\n'
+            printf 'Rendered Conftest policies still ran for workflows and Kubernetes manifests in this required check.\n'
+          } >"${TERRAGRUNT_PLAN_MARKDOWN}"
+
+      - name: Update PR Description With Plan Or Skip Note
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           TERRAGRUNT_PLAN_MARKDOWN: ${{ runner.temp }}/terragrunt-plan.md
         run: bash scripts/ci/update-pr-plan-description.sh
-
-      - name: Explain Live Plan Skip
-        if: steps.live-plan-scope.outputs.requires-live-plan != 'true'
-        run: echo "Live Terragrunt plan was skipped because this pull request did not change IaC, OpenTofu/Terragrunt policy inputs, flake inputs, or live-plan helper scripts."
 
       - name: Run Conftest Policies
         if: ${{ !cancelled() }}

--- a/clusters/homelab/apps/openclaw/README.md
+++ b/clusters/homelab/apps/openclaw/README.md
@@ -198,9 +198,10 @@ uses the committed NetworkPolicy and ambient mesh policies, and writes durable
 agent state only under the OpenClaw PVC. If Docker or another sandbox runtime is
 added to the workload later, revisit this setting before enabling it.
 
-During startup, the bootstrap runs OpenClaw's safe doctor repairs when the
-persisted PVC config no longer matches the current OpenClaw schema. This keeps
-version upgrades from blocking on stale runtime config while preserving secrets
+During startup, the bootstrap always runs OpenClaw's safe non-interactive
+doctor repairs before applying desired state. This keeps version upgrades from
+blocking on stale runtime config and gives valid legacy PVC auth/order entries
+a chance to migrate to the canonical `openai` route while preserving secrets
 and OAuth state on the PVC. It also pins `gateway.mode` to `local`, which is
 required for the container-managed gateway process.
 

--- a/clusters/homelab/apps/openclaw/README.md
+++ b/clusters/homelab/apps/openclaw/README.md
@@ -208,14 +208,14 @@ Run the interactive login from a tailnet-connected operator machine:
 
 ```sh
 kubectl -n ai exec -it deploy/openclaw -c app -- \
-  openclaw models auth login --provider openai-codex --set-default
+  openclaw models auth login --provider openai --set-default
 ```
 
 For a headless terminal or callback-hostile network, use the device-code flow:
 
 ```sh
 kubectl -n ai exec deploy/openclaw -c app -- \
-  openclaw models auth login --provider openai-codex --device-code --set-default
+  openclaw models auth login --provider openai --device-code --set-default
 ```
 
 Then verify the default model and plugin-backed runtime:

--- a/clusters/homelab/apps/openclaw/README.md
+++ b/clusters/homelab/apps/openclaw/README.md
@@ -177,10 +177,13 @@ billing, but OpenAI Codex can sign in with a ChatGPT plan and store local
 credentials on the OpenClaw PVC.
 
 The pod startup bootstrap enables the bundled `codex` plugin and sets the
-default agent model to the authenticated Codex route, `codex/gpt-5.5`. The
-older `openai-codex/gpt-*` model refs are legacy routes, and
-`openai/gpt-*` routes require a separate OpenAI auth surface that this
-deployment does not manage.
+default agent model to `openai/gpt-5.5` with model-scoped
+`agentRuntime.id: "codex"`. OpenClaw 2026.6.1 routes canonical `openai/gpt-*`
+agent refs through the Codex app-server harness when that runtime policy is
+selected, so the PVC-backed Codex OAuth profile supplies the ChatGPT Pro auth
+without storing an API key in SSM or git. The older `openai-codex/gpt-*` and
+`codex/gpt-*` refs are compatibility routes, not the desired bootstrap default
+for this deployment.
 
 The bootstrap also enables the bundled `memory-wiki` plugin. OpenClaw uses that
 plugin for Imported Insights and Memory Palace, so reload the Control UI tab
@@ -219,10 +222,10 @@ Then verify the default model and plugin-backed runtime:
 
 ```sh
 kubectl -n ai exec deploy/openclaw -c app -- \
-  openclaw models status --plain
+  openclaw models status --json
 
 kubectl -n ai exec deploy/openclaw -c app -- \
-  openclaw models list --provider codex
+  openclaw models list --provider openai
 ```
 
 Those OAuth credentials persist on the `/data/openclaw` volume and should not be

--- a/clusters/homelab/apps/openclaw/values.yaml
+++ b/clusters/homelab/apps/openclaw/values.yaml
@@ -122,9 +122,8 @@ controllers:
               printf '{}\n' > "$OPENCLAW_CONFIG_PATH"
             fi
 
-            if ! openclaw config validate; then
-              openclaw doctor --fix --non-interactive
-            fi
+            openclaw doctor --fix --non-interactive
+            openclaw config validate
 
             openclaw config set --strict-json \
               gateway.mode \

--- a/clusters/homelab/apps/openclaw/values.yaml
+++ b/clusters/homelab/apps/openclaw/values.yaml
@@ -179,9 +179,24 @@ controllers:
               plugins.entries.memory-wiki.enabled \
               'true'
 
-            openclaw config set --strict-json \
-              agents.defaults.model \
-              '{"primary":"codex/gpt-5.5"}'
+            openclaw config patch --stdin <<'OPENCLAW_MODEL_PATCH'
+            {
+              "agents": {
+                "defaults": {
+                  "model": {
+                    "primary": "openai/gpt-5.5"
+                  },
+                  "models": {
+                    "openai/gpt-5.5": {
+                      "agentRuntime": {
+                        "id": "codex"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            OPENCLAW_MODEL_PATCH
 
             openclaw config set --strict-json \
               agents.defaults.sandbox.mode \

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -13,7 +13,8 @@ This repository uses GitHub Actions for the review and rollout path:
   a live Terragrunt plan, and updates the managed plan section in the PR
   description. Manifest-only, workflow-only, and docs-only changes skip the
   Octelium/Kubernetes/OpenTofu live-plan steps but still run rendered Conftest
-  policies. Forked pull requests run Conftest after the live plan skip notice.
+  policies and replace the managed PR plan section with an explicit skip note.
+  Forked pull requests run Conftest after the live plan skip notice.
 - `Terragrunt Apply` runs after changes land on `main` and can also be started
   manually with `workflow_dispatch`. It repeats static checks and Conftest
   before connecting to Octelium and applying the live Terragrunt phases in
@@ -89,7 +90,9 @@ contract for Grafana.
   include sensitive state context. Trusted same-repository PR plans render the
   saved `plan.out` files with `terragrunt show -no-color plan.out` and replace
   the managed `<!-- terragrunt-plan:start -->` section in the PR description
-  after every successful plan.
+  after every successful plan. Trusted PRs that do not require a live plan
+  replace that same managed section with a skip note so stale plan output is not
+  left behind after a force-push or scope reduction.
 - Automatic PR plans intentionally skip `IaC/live/aws-ssm-parameters` because
   that unit refreshes managed KMS, IAM, and SSM resources that require the
   protected production apply role. They also skip `IaC/live/kubernetes-secrets`

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -7,9 +7,13 @@ This repository uses GitHub Actions for the review and rollout path:
   every PR; the repository-specific blocking checks remain in `Terragrunt Plan`
   and `validate`.
 - `Terragrunt Plan` runs on pull requests. It always runs static checks and
-  Checkov first. Trusted same-repository pull requests then connect to the
-  Octelium VPN, run a live Terragrunt plan, and run Conftest policies after the
-  plan step. Forked pull requests run Conftest after the live plan skip notice.
+  Checkov first. Trusted same-repository pull requests then inspect the changed
+  paths. If the change touches `IaC/**`, flake inputs, OpenTofu/Terragrunt
+  policy inputs, or live-plan helper scripts, the job connects to Octelium, runs
+  a live Terragrunt plan, and updates the managed plan section in the PR
+  description. Manifest-only, workflow-only, and docs-only changes skip the
+  Octelium/Kubernetes/OpenTofu live-plan steps but still run rendered Conftest
+  policies. Forked pull requests run Conftest after the live plan skip notice.
 - `Terragrunt Apply` runs after changes land on `main` and can also be started
   manually with `workflow_dispatch`. It repeats static checks and Conftest
   before connecting to Octelium and applying the live Terragrunt phases in
@@ -70,6 +74,8 @@ contract for Grafana.
   disable Octelium DNS, publish only that Service to `127.0.0.1:16443`, and
   rely on the
   `homelab-ci-kubernetes-api-access` policy as the hard access boundary.
+  Trusted pull requests only open this live access path when the diff includes
+  IaC, flake, OpenTofu/Terragrunt policy, or live-plan helper inputs.
 - The kubeconfig is injected only from GitHub environment secrets and written to
   `$HOME/.kube/config` with mode `0600`. After writing it, CI rewrites the
   current cluster server to `https://127.0.0.1:16443` and sets the TLS server

--- a/docs/knowledge-base/runbooks/ci-cd.md
+++ b/docs/knowledge-base/runbooks/ci-cd.md
@@ -10,10 +10,15 @@ Source: `docs/ci-cd.md`
   advisory shared lint signal; repository-specific blocking checks stay in
   `Terragrunt Plan` and `validate`.
 - `Terragrunt Plan` runs on pull requests. It always runs static checks and
-  Checkov first. Trusted same-repo PRs connect to Octelium, run a live
-  Terragrunt plan, validate the rendered Terraform plan JSON with Conftest,
-  and then run static Conftest checks. Forked PRs run static Conftest after the
-  live plan skip notice.
+  Checkov first. Trusted same-repo PRs inspect changed paths before opening the
+  CI Kubernetes access path. Changes to `IaC/**`, flake inputs,
+  OpenTofu/Terragrunt policy inputs, or live-plan helper scripts connect to
+  Octelium, run a live Terragrunt plan, validate rendered Terraform plan JSON
+  with Conftest, and update the managed PR plan section. Manifest-only,
+  workflow-only, and docs-only changes skip Octelium/Kubernetes/OpenTofu live
+  planning, still run rendered Conftest policies, and replace the managed PR
+  plan section with an explicit skip note. Forked PRs run static Conftest after
+  the live plan skip notice.
 - `Terragrunt Apply` runs after merge to `main` and through
   `workflow_dispatch`. It repeats static checks and Conftest, connects to
   Octelium, and applies the live Terragrunt phases in order: Argo CD bootstrap,
@@ -59,9 +64,11 @@ Source: `docs/ci-cd.md`
 - Plans are not uploaded as artifacts because they may include sensitive state.
   Trusted same-repo PR plans render saved `plan.out` files with
   `terragrunt show -no-color plan.out` and replace the managed plan section in
-  the PR description after each successful plan run. The same job also renders
-  local `plan.json` files from those saved plans and runs Terraform-plan
-  Conftest policies before the PR description update.
+  the PR description after each successful plan run. Trusted PRs that do not
+  require a live plan replace that same managed section with a skip note so
+  stale plan output is not left behind after a force-push or scope reduction.
+  The same job also renders local `plan.json` files from those saved plans and
+  runs Terraform-plan Conftest policies before the PR description update.
 - Automatic PR plans skip `IaC/live/aws-ssm-parameters` because it refreshes
   managed KMS, IAM, and SSM resources that require the protected apply role.
   They also skip `IaC/live/kubernetes-secrets`; protected apply runs those

--- a/docs/knowledge-base/runbooks/validation.md
+++ b/docs/knowledge-base/runbooks/validation.md
@@ -21,6 +21,11 @@ terragrunt run --all --filter-affected --parallelism 1 --source-update -- plan -
 
 Expected app-registration plans include the Argo CD Application units affected
 by `main...HEAD`; unaffected units are skipped by the Terragrunt run queue.
+In pull-request CI, the required `Terragrunt Plan` job opens Octelium and runs a
+live OpenTofu/Terragrunt plan only when the diff changes `IaC/**`, flake inputs,
+OpenTofu/Terragrunt policy inputs, or live-plan helper scripts. Manifest-only,
+workflow-only, and docs-only changes still run static checks and rendered
+Conftest policies without requiring the CI Kubernetes access path.
 
 ## Render And Diff
 

--- a/docs/knowledge-base/runbooks/validation.md
+++ b/docs/knowledge-base/runbooks/validation.md
@@ -25,7 +25,8 @@ In pull-request CI, the required `Terragrunt Plan` job opens Octelium and runs a
 live OpenTofu/Terragrunt plan only when the diff changes `IaC/**`, flake inputs,
 OpenTofu/Terragrunt policy inputs, or live-plan helper scripts. Manifest-only,
 workflow-only, and docs-only changes still run static checks and rendered
-Conftest policies without requiring the CI Kubernetes access path.
+Conftest policies without requiring the CI Kubernetes access path, and the job
+replaces the managed PR plan section with an explicit skip note.
 
 ## Render And Diff
 

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -216,12 +216,13 @@ are `emptyDir` mounts at `/data/openclaw/npm` and
 OpenClaw blocks code plugins with suspicious ownership. ChatGPT Pro access uses
 interactive OpenAI Codex OAuth stored on the PVC; do not model that as an SSM
 secret or committed API key. The bootstrap also enables the bundled `codex`
-plugin and sets the default agent model to `codex/gpt-5.5`, which is the
-authenticated Codex route exposed by the current OpenClaw runtime. The older
-`openai-codex/gpt-*` model refs are legacy routes, and `openai/gpt-*` routes
-require a separate OpenAI auth surface that this deployment does not manage. The
-bootstrap enables the bundled `memory-wiki` plugin so Imported Insights and
-Memory Palace are available after the Control UI tab is reloaded. The
+plugin and sets the default agent model to `openai/gpt-5.5` with
+`agentRuntime.id: "codex"` on that model. OpenClaw 2026.6.1 treats canonical
+`openai/gpt-*` agent refs plus the Codex runtime policy as the subscription
+backed app-server route; legacy `openai-codex/gpt-*` and `codex/gpt-*` refs are
+not the desired bootstrap default. The bootstrap enables the bundled
+`memory-wiki` plugin so Imported Insights and Memory Palace are available after
+the Control UI tab is reloaded. The
 bootstrap pins `agents.defaults.sandbox.mode` to `off` because the Codex
 harness otherwise tries to start a Docker sandbox, while the OpenClaw app image
 does not include Docker and this Kubernetes workload does not run

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -228,8 +228,10 @@ harness otherwise tries to start a Docker sandbox, while the OpenClaw app image
 does not include Docker and this Kubernetes workload does not run
 Docker-in-Docker. The pod boundary, disabled service account token, NetworkPolicy
 and ambient mesh policies are the runtime containment model for Discord-triggered
-agent work. The bootstrap runs safe `openclaw doctor --fix --non-interactive`
-repairs when the persisted PVC config does not validate against the current
+agent work. The bootstrap always runs safe `openclaw doctor --fix --non-interactive`
+repairs before applying desired state so valid legacy PVC auth/order entries can
+migrate to the canonical `openai` route even when the persisted config still
+validates against the current
 OpenClaw schema, and sets `gateway.mode` to `local` for the container-managed
 gateway process.
 GitHub App identity is SSM-backed: `GITHUB_APP_ID` and


### PR DESCRIPTION
## Summary
- route OpenClaw's default GPT-5.5 model through canonical openai/gpt-5.5 with model-scoped agentRuntime.id=codex
- keep Codex OAuth on the PVC and avoid SSM/API-key changes
- update OpenClaw docs and the knowledge-base note for the 2026.6.1 routing model

## Validation
- ruby YAML parse for clusters/homelab/apps/openclaw/values.yaml
- kubectl kustomize clusters/homelab/apps/openclaw
- helm template openclaw app-template --repo https://bjw-s-labs.github.io/helm-charts --version 4.4.0 -f clusters/homelab/apps/openclaw/values.yaml
- bash scripts/ci/static-checks.sh

Live diagnosis: Discord transport is connected and working; the failure is downstream model auth, where the current codex/gpt-5.5 route starts the app-server without a bearer despite a valid PVC-backed openai-codex OAuth profile.

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

> Live Terragrunt plan skipped because this pull request did not change `IaC/**`, flake inputs, OpenTofu/Terragrunt policy inputs, or live-plan helper scripts.

Rendered Conftest policies still ran for workflows and Kubernetes manifests in this required check.

<!-- terragrunt-plan:end -->
