### PR TITLE
fix(ci): tolerate unauthenticated kube reachability probe

### DIFF
--- a/.github/workflows/homelab-diagnostics.yml
+++ b/.github/workflows/homelab-diagnostics.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Verify Kubernetes API Reachability
         run: |
-          curl -kfsS --max-time 10 "${KUBE_API_SERVER_URL}/version" >/dev/null
+          curl -ksS --max-time 10 -o /dev/null "${KUBE_API_SERVER_URL}/version"
           nix develop --command kubectl --request-timeout=15s version
 
       - name: Inspect Grafana

--- a/.github/workflows/terragrunt-apply.yml
+++ b/.github/workflows/terragrunt-apply.yml
@@ -144,7 +144,7 @@ jobs:
 
       - name: Verify Kubernetes API Reachability
         run: |
-          curl -kfsS --max-time 10 "${KUBE_API_SERVER_URL}/version" >/dev/null
+          curl -ksS --max-time 10 -o /dev/null "${KUBE_API_SERVER_URL}/version"
           nix develop --command kubectl --request-timeout=15s version
 
       - name: Run Terragrunt Apply


### PR DESCRIPTION
## Summary
- allow the raw Kubernetes API reachability curl probe to accept the API server's unauthenticated HTTP status
- keep authenticated Kubernetes validation on kubectl version through the Nix dev shell
- apply the same probe semantics to the diagnostics workflow

## Validation
- bash scripts/ci/static-checks.sh
- ruby YAML parse for affected workflows
- git diff --check

## Failure addressed
- main Terragrunt Apply run 27112496343 reached Octelium and installed kubeconfig, then failed because curl -f treated the API server's 401 response as a failed reachability check before kubectl could run

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

> Live Terragrunt plan skipped because this pull request did not change `IaC/**`, flake inputs, OpenTofu/Terragrunt policy inputs, or live-plan helper scripts.

Rendered Conftest policies still ran for workflows and Kubernetes manifests in this required check.

<!-- terragrunt-plan:end -->
