### PR TITLE
fix(ci): adopt preseeded runner ssm token

### DIFF
--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -165,6 +165,12 @@ rules and tighter rotation:
 | `KUBE_CONFIG_B64` | both | Base64-encoded kubeconfig for the homelab cluster. |
 | `AZUREAD_CLIENT_SECRET` | `homelab-production`; optional in `homelab-plan` | Microsoft Entra application secret used by the AzureAD provider during production applies and optional trusted PR plans. |
 
+The production apply script adopts the runner registration-token parameter into
+the `IaC/live/aws-ssm-parameters` state when the token was preseeded during a
+local bootstrap. This keeps the first GitOps apply from overwriting or failing
+on the existing short-lived token while preserving a from-scratch path where
+OpenTofu creates the placeholder.
+
 Add these environment variables. The workflows read each non-sensitive value
 from a GitHub variable first and fall back to a secret with the same name, so
 storing them as environment secrets also works when that is how the repository

--- a/docs/knowledge-base/runbooks/ci-cd.md
+++ b/docs/knowledge-base/runbooks/ci-cd.md
@@ -103,6 +103,11 @@ Source: `docs/ci-cd.md`
   `run --all --filter-affected --non-interactive -- apply ...` form so the run
   queue is accepted in Actions and OpenTofu flags such as `-auto-approve` are
   forwarded to OpenTofu instead of being parsed as Terragrunt CLI flags.
+- Protected applies adopt the preseeded
+  `/homelab/github-actions-runner/registration-token` SSM parameter into
+  `IaC/live/aws-ssm-parameters` state before planning. This handles the
+  bootstrap path where a short-lived token was written locally so the runner
+  could come online before GitHub Actions could manage the placeholder itself.
 
 ## Monitoring
 

--- a/scripts/ci/terragrunt-apply.sh
+++ b/scripts/ci/terragrunt-apply.sh
@@ -86,6 +86,42 @@ destroy_deleted_terragrunt_units() {
   done
 }
 
+adopt_existing_ssm_parameters() {
+  local parameter_region="us-west-2"
+  local state_resources
+  local parameter_name
+  local resource_address
+  local existing_name
+
+  terragrunt init -no-color
+  state_resources="$(terragrunt state list -no-color 2>/dev/null || true)"
+
+  for parameter_name in "/homelab/github-actions-runner/registration-token"; do
+    resource_address="aws_ssm_parameter.this[\"${parameter_name}\"]"
+
+    if grep -Fxq "$resource_address" <<<"$state_resources"; then
+      echo "SSM parameter ${parameter_name} is already managed in OpenTofu state."
+      continue
+    fi
+
+    existing_name="$(
+      aws ssm describe-parameters \
+        --region "$parameter_region" \
+        --parameter-filters "Key=Name,Option=Equals,Values=${parameter_name}" \
+        --query "Parameters[0].Name" \
+        --output text 2>/dev/null || true
+    )"
+
+    if [[ "$existing_name" == "$parameter_name" ]]; then
+      echo "Adopting existing SSM parameter ${parameter_name} into OpenTofu state."
+      terragrunt import -no-color "$resource_address" "$parameter_name"
+      state_resources="${state_resources}"$'\n'"${resource_address}"
+    else
+      echo "SSM parameter ${parameter_name} is absent; OpenTofu will create the placeholder."
+    fi
+  done
+}
+
 prepare_terragrunt_filter_base
 
 if ! azuread_credentials_available && azuread_stack_changed; then
@@ -107,6 +143,7 @@ echo "::group::AWS SSM parameter declaration plan and apply"
 (
   cd IaC/live/aws-ssm-parameters
   rm -f plan.out plan.json
+  adopt_existing_ssm_parameters
   terragrunt plan -out plan.out -no-color
   terragrunt --log-disable show -json plan.out >plan.json
   conftest test --policy ../../../policy --output github plan.json


### PR DESCRIPTION
## Summary
- import the preseeded GitHub Actions runner registration-token SSM parameter into OpenTofu state before the production SSM plan when it already exists
- keep from-scratch behavior intact when the parameter is absent so OpenTofu creates the placeholder
- document the bootstrap adoption behavior in the CI/CD runbook and knowledge base

## Validation
- bash scripts/ci/static-checks.sh
- bash -n scripts/ci/terragrunt-apply.sh
- git diff --check

## Failure addressed
- main Terragrunt Apply run 27112692998 reached Octelium, Kubernetes, and the real SSM apply, then failed because /homelab/github-actions-runner/registration-token was preseeded locally but not yet owned by OpenTofu state

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `ab72f6c27cf188898541401df674865de3a64113`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.

> AzureAD application registration plans were skipped because the plan environment did not provide `ARM_CLIENT_ID`, `ARM_CLIENT_SECRET`, and `ARM_TENANT_ID`. Production apply still fails fast when `IaC/live/azuread-applications` changes and those credentials are absent.


<!-- terragrunt-plan:end -->
