### PR TITLE
fix(security): tighten pod security warning labels

### DIFF
--- a/clusters/homelab/apps/github-actions-runner/namespace.yaml
+++ b/clusters/homelab/apps/github-actions-runner/namespace.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/part-of: homelab
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/enforce-version: latest
-    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/audit: restricted
     pod-security.kubernetes.io/audit-version: latest
-    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/warn: restricted
     pod-security.kubernetes.io/warn-version: latest

--- a/clusters/homelab/apps/octobot/namespace.yaml
+++ b/clusters/homelab/apps/octobot/namespace.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/part-of: homelab
     pod-security.kubernetes.io/enforce: baseline
     pod-security.kubernetes.io/enforce-version: latest
-    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/audit: restricted
     pod-security.kubernetes.io/audit-version: latest
-    pod-security.kubernetes.io/warn: baseline
+    pod-security.kubernetes.io/warn: restricted
     pod-security.kubernetes.io/warn-version: latest

--- a/docs/knowledge-base/operations/continuous-improvement.md
+++ b/docs/knowledge-base/operations/continuous-improvement.md
@@ -132,11 +132,12 @@ policy`.
   immutable commit for `terragrunt-catalog` tag `0.4.0` can be verified.
 - **Status:** fixed
 - **Area:** platform service / Pod Security
-- **Evidence:** June 2026 security audit found privileged namespaces using
-  `privileged` for `enforce`, `audit`, and `warn`. This change keeps the
-  required `enforce: privileged` exception for Deluge VPN, Istio ingress, and
-  Tailscale operator proxy workloads, but moves `audit` and `warn` to
-  `restricted` so drift is visible during review and sync.
+- **Evidence:** June 2026 security audits found namespaces using weak
+  `audit`/`warn` Pod Security labels. The fixes keep required
+  `enforce: privileged` exceptions for Deluge VPN, Istio ingress, Octelium,
+  Octelium client, Tailscale, and the host-networked GitHub Actions runner,
+  keep baseline enforcement for `finance`, and require repo-owned namespaces to
+  set `audit` and `warn` to `restricted` through Conftest.
 - **Risk:** privileged audit/warn labels hide workloads that could run under a
   tighter profile or accidentally expand the exception blast radius.
 - **Next step:** continue splitting the Deluge VPN privilege exception into a

--- a/docs/knowledge-base/runbooks/runtime-isolation.md
+++ b/docs/knowledge-base/runbooks/runtime-isolation.md
@@ -21,6 +21,7 @@ Current enforced controls:
 | Namespace | Reason |
 | --- | --- |
 | `media` | Deluge Gluetun needs `NET_ADMIN` and `/dev/net/tun` |
+| `github-actions-runner` | Self-hosted CI runner uses host networking so jobs can reach Octelium gateway hostnames; containers remain non-privileged |
 | `istio-system` | Istio gateway and dataplane networking |
 | `octelium` | Octelium data-plane gateway pods need host networking, hostPath CNI access, and `NET_ADMIN`/`NET_RAW`; labels are applied by `scripts/octelium-cluster-bootstrap.sh` after `octops` creates the namespace |
 | `octelium-client` | Octelium connector pods need `NET_ADMIN` and `MKNOD` to create `/dev/net/tun` and serve app Services over a real TUN interface |
@@ -29,8 +30,8 @@ Current enforced controls:
 ## Baseline Namespaces
 
 `argocd`, `cert-manager`, `external-secrets`, `ai`, `automation`, `finance`,
-`monitoring`, `octelium-client`, and `storage` are explicitly baseline in
-repo-owned namespace manifests. `octelium-client` is ambient-enrolled so the
+`monitoring`, and `storage` are explicitly baseline in repo-owned namespace
+manifests. `octelium-client` is privileged-enforce and ambient-enrolled so the
 Octelium connector can be allowed as
 `cluster.local/ns/octelium-client/sa/octelium-client` by protected workloads.
 `finance` is not mesh-enrolled; OctoBot's UI is reached through the Octelium

--- a/docs/runtime-isolation.md
+++ b/docs/runtime-isolation.md
@@ -95,8 +95,9 @@ Ambient is intentionally not enabled for:
   service-to-service or trading API control path is mesh-enrolled;
 - `argocd`, `cert-manager`, `external-secrets`, and `storage`, because their
   API server, webhook, NFS, and controller paths need separate validation;
-- `istio-system` and `tailscale`, because they are privileged networking
-  infrastructure rather than application namespaces.
+- `istio-system`, `octelium`, `octelium-client`, `tailscale`, and
+  `github-actions-runner`, because they are privileged networking or CI
+  infrastructure rather than ordinary application namespaces.
 
 ## Privileged Workloads
 
@@ -106,8 +107,10 @@ workload that needs it.
 | Namespace | Reason | Desired-state owner |
 |-----------|--------|---------------------|
 | `media` | Deluge Gluetun needs `NET_ADMIN` and `/dev/net/tun` for WireGuard. | `clusters/homelab/apps/deluge/namespace.yaml` |
+| `github-actions-runner` | The self-hosted CI runner uses host networking so Octelium gateway hostnames are reachable from GitHub Actions jobs; containers remain non-privileged. | `clusters/homelab/apps/github-actions-runner/namespace.yaml` |
 | `istio-system` | Istio gateway and dataplane components need elevated networking permissions. | `clusters/homelab/apps/istio/namespace.yaml` |
 | `octelium` | Octelium data-plane gateway pods need host networking, hostPath CNI access, and `NET_ADMIN`/`NET_RAW`. | `scripts/octelium-cluster-bootstrap.sh` |
+| `octelium-client` | Octelium connector pods need `NET_ADMIN` and `MKNOD` to create `/dev/net/tun` and serve app Services over a real TUN interface. | `clusters/homelab/apps/octelium/namespace.yaml` |
 | `tailscale` | Tailscale operator proxy Pods need privileged networking for connector and load-balancer devices. | `clusters/homelab/apps/tailscale/namespace.yaml` |
 
 ## Baseline Workloads
@@ -123,7 +126,6 @@ These namespaces are explicitly kept at the Pod Security `baseline` profile:
 | `automation` | `clusters/homelab/apps/n8n/namespace.yaml` |
 | `finance` | `clusters/homelab/apps/octobot/namespace.yaml` |
 | `monitoring` | `clusters/homelab/apps/prometheus/namespace.yaml` |
-| `octelium-client` | `clusters/homelab/apps/octelium/namespace.yaml` |
 | `storage` | `clusters/homelab/platform/storage/namespace.yaml` |
 
 Do not broaden privileged admission for convenience. If another workload needs

--- a/policy/kubernetes.rego
+++ b/policy/kubernetes.rego
@@ -36,6 +36,24 @@ deny contains msg if {
 	input.kind == "Namespace"
 	metadata := object.get(input, "metadata", {})
 	labels := object.get(metadata, "labels", {})
+	object.get(labels, "pod-security.kubernetes.io/audit", "") != "restricted"
+	name := object.get(metadata, "name", "<unknown>")
+	msg := sprintf("namespace %q must audit Pod Security violations at restricted", [name])
+}
+
+deny contains msg if {
+	input.kind == "Namespace"
+	metadata := object.get(input, "metadata", {})
+	labels := object.get(metadata, "labels", {})
+	object.get(labels, "pod-security.kubernetes.io/warn", "") != "restricted"
+	name := object.get(metadata, "name", "<unknown>")
+	msg := sprintf("namespace %q must warn on Pod Security violations at restricted", [name])
+}
+
+deny contains msg if {
+	input.kind == "Namespace"
+	metadata := object.get(input, "metadata", {})
+	labels := object.get(metadata, "labels", {})
 	labels["pod-security.kubernetes.io/enforce"] == "privileged"
 	annotations := object.get(metadata, "annotations", {})
 	not has_nonempty_annotation(annotations, "homelab.rst.io/privileged-namespace-justification")


### PR DESCRIPTION
## Summary

- Set `github-actions-runner` namespace Pod Security `audit` and `warn` labels to `restricted` while keeping the documented `enforce: privileged` exception.
- Set the `finance` namespace `audit` and `warn` labels to `restricted` while keeping `enforce: baseline`.
- Add a Conftest rule so repo-owned Namespaces must keep Pod Security `audit` and `warn` at `restricted`, and update runtime-isolation docs/KB notes.

## Validation

- `kubectl kustomize clusters/homelab/apps/github-actions-runner`
- `kubectl kustomize clusters/homelab/apps/octobot`
- `conftest test --policy policy --output github /tmp/github-actions-runner.rendered.yaml /tmp/octobot.rendered.yaml` (308 passed)
- `bash scripts/ci/conftest-policies.sh` (3520 passed)
- `pre-commit run trailing-whitespace --files ...`
- `pre-commit run end-of-file-fixer --files ...`
- `pre-commit run check-yaml --files ...`
- `pre-commit run codespell --files ...`
- `pre-commit run checkov_secrets --files ...`

## Notes

Live read-only scan showed `github-actions-runner` had `privileged` audit/warn labels and `finance` had `baseline` audit/warn labels. This keeps enforcement unchanged and makes stricter audit/warn drift visible during admission and review.

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `5161b919a52422681b2fe1cfdd150aa6cb76dfda`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.

> AzureAD application registration plans were skipped because the plan environment did not provide `ARM_CLIENT_ID`, `ARM_CLIENT_SECRET`, and `ARM_TENANT_ID`. Production apply still fails fast when `IaC/live/azuread-applications` changes and those credentials are absent.


<!-- terragrunt-plan:end -->
