### PR TITLE
fix(security): pin terragrunt catalog modules

### DIFF
--- a/IaC/bootstrap/argocd/terragrunt.hcl
+++ b/IaC/bootstrap/argocd/terragrunt.hcl
@@ -14,7 +14,7 @@ locals {
 }
 
 terraform {
-  source = "git::https://github.com/Stuhlmuller/terragrunt-catalog.git//modules/helm-release?ref=0.4.0"
+  source = "git::https://github.com/Stuhlmuller/terragrunt-catalog.git//modules/helm-release?ref=19df2cb291eef0084cafb85bed644dcdb082108c"
 
   after_hook "apply_self_management_application" {
     commands = ["apply"]

--- a/IaC/live/azuread-applications/grafana/terragrunt.hcl
+++ b/IaC/live/azuread-applications/grafana/terragrunt.hcl
@@ -14,7 +14,7 @@ locals {
 }
 
 terraform {
-  source = "git::https://github.com/Stuhlmuller/terragrunt-catalog.git//modules/azuread-application?ref=0.4.0"
+  source = "git::https://github.com/Stuhlmuller/terragrunt-catalog.git//modules/azuread-application?ref=19df2cb291eef0084cafb85bed644dcdb082108c"
 }
 
 dependencies {

--- a/IaC/live/azuread-applications/octelium/terragrunt.hcl
+++ b/IaC/live/azuread-applications/octelium/terragrunt.hcl
@@ -15,7 +15,7 @@ locals {
 }
 
 terraform {
-  source = "git::https://github.com/Stuhlmuller/terragrunt-catalog.git//modules/azuread-application?ref=0.4.0"
+  source = "git::https://github.com/Stuhlmuller/terragrunt-catalog.git//modules/azuread-application?ref=19df2cb291eef0084cafb85bed644dcdb082108c"
 }
 
 dependencies {

--- a/docs/knowledge-base/operations/continuous-improvement.md
+++ b/docs/knowledge-base/operations/continuous-improvement.md
@@ -123,13 +123,21 @@ policy`.
 - **Evidence:** June 2026 security audit found remaining structural hardening
   work: the shared Argo CD AppProject can still deploy cluster-scoped RBAC,
   Kiali remains anonymous/view-only on the tailnet, several app-template
-  workloads need explicit restricted container security contexts, and remote
-  Terragrunt catalog modules are still referenced by the mutable `0.4.0` tag.
+  workloads need explicit restricted container security contexts.
 - **Risk:** these are reviewability, reconnaissance, and lateral-movement risks
   that are larger than a single safe patch.
 - **Next step:** split AppProjects, add Kiali identity controls, harden
-  compatible app-template values, and pin or vendor remote modules once the
-  immutable commit for `terragrunt-catalog` tag `0.4.0` can be verified.
+  compatible app-template values, and keep shared platform changes small enough
+  to validate independently.
+- **Status:** fixed
+- **Area:** infrastructure supply chain
+- **Evidence:** The Terragrunt catalog release tag `0.4.0` was verified with
+  `git ls-remote` as commit `19df2cb291eef0084cafb85bed644dcdb082108c`, and
+  the bootstrap/Entra units now pin module sources to that immutable commit.
+- **Risk:** mutable or retargeted module tags can change infrastructure module
+  code outside this repository's review path.
+- **Next step:** keep remote Terragrunt module sources pinned to immutable
+  commits, or vendor the module before using a mutable release tag again.
 - **Status:** fixed
 - **Area:** platform service / Pod Security
 - **Evidence:** June 2026 security audit found privileged namespaces using

--- a/docs/secrets-aws-ssm.md
+++ b/docs/secrets-aws-ssm.md
@@ -218,7 +218,9 @@ so External Secrets refreshes the Kubernetes Secret.
 ## Microsoft Entra SSO Bootstrap
 
 Grafana and Octelium SSO use Microsoft Entra application registrations managed
-through the Terragrunt catalog `azuread-application` module pinned to `0.4.0`.
+through the Terragrunt catalog `azuread-application` module pinned to commit
+`19df2cb291eef0084cafb85bed644dcdb082108c`, the immutable commit behind the
+reviewed `0.4.0` catalog release.
 
 Bootstrap order:
 


### PR DESCRIPTION
## Summary

- Replace remaining `terragrunt-catalog` source refs that used mutable tag `0.4.0` with commit `19df2cb291eef0084cafb85bed644dcdb082108c`.
- Cover the Argo CD bootstrap `helm-release` module and the Grafana/Octelium Entra `azuread-application` modules.
- Update the SSM/Entra docs and KB finding so the supply-chain risk is marked fixed while the larger AppProject/Kiali/app-template hardening remains open.

## Validation

- `git ls-remote https://github.com/Stuhlmuller/terragrunt-catalog.git refs/tags/0.4.0` returned `19df2cb291eef0084cafb85bed644dcdb082108c`
- `terragrunt hcl fmt --check`
- `terragrunt hcl validate`
- `rg -n "terragrunt-catalog\.git//.*ref=0\.4\.0|ref=0\.4\.0" IaC docs/knowledge-base docs/secrets-aws-ssm.md` returned no matches
- `terragrunt --log-disable init -backend=false -no-color` in `IaC/bootstrap/argocd`, `IaC/live/azuread-applications/grafana`, and `IaC/live/azuread-applications/octelium`
- `terragrunt --log-disable validate -no-color` in the same three units
- `bash scripts/ci/static-checks.sh`
- Focused pre-commit hooks: trailing whitespace, end-of-file-fixer, Terragrunt HCL fmt, codespell

## Notes

The two Entra unit validations still emit the existing AzureAD provider warning that `end_date_relative` is deprecated. That is not introduced by this pinning change and should stay as a separate follow-up.

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `5d4ee45005330e0c32706a1788097e7fa496e52a`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.

> AzureAD application registration plans were skipped because the plan environment did not provide `ARM_CLIENT_ID`, `ARM_CLIENT_SECRET`, and `ARM_TENANT_ID`. Production apply still fails fast when `IaC/live/azuread-applications` changes and those credentials are absent.


<!-- terragrunt-plan:end -->
