### PR TITLE
feat: alert on Deluge daemon RPC failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,8 @@ docs/knowledge-base/.obsidian/workspace*.json
 docs/knowledge-base/.obsidian/plugins/
 docs/knowledge-base/.obsidian/snippets/
 docs/knowledge-base/.trash/
+docs/knowledge-base/.obsidian/appearance.json
+docs/knowledge-base/.obsidian/graph.json
 # Talos generated/local credential material
 .talos/secrets.yaml
 .talos/controlplane.yaml

--- a/clusters/homelab/apps/deluge/README.md
+++ b/clusters/homelab/apps/deluge/README.md
@@ -130,6 +130,52 @@ fail closed instead of bypassing the VPN.
 
 ## Troubleshooting
 
+If the Pod is `Ready` and Gluetun is healthy but Deluge is not usable, check
+the daemon before restarting Kubernetes resources:
+
+```sh
+kubectl -n media logs deploy/deluge -c app --tail=120
+kubectl -n media logs deploy/deluge -c port-config --tail=120
+kubectl -n media exec deploy/deluge -c app -- \
+  timeout 10s deluge-console -c /config info
+```
+
+Repeated `libtorrent::libtorrent_exception` messages such as
+`invalid type requested from entry`, together with `port-config` reporting
+connection refusals, usually mean the Deluge daemon cannot restore its
+persisted session state. Preserve torrent metadata and downloaded data; do not
+delete the `.torrent` files under `/config/state` or the `/downloads` tree.
+After explicit operator approval, recover only the session state file:
+
+```sh
+kubectl -n media exec deploy/deluge -c app -- /bin/sh -c '
+set -eu
+s6-svc -d /var/run/s6/services/deluged || true
+stamp=$(date -u +%Y%m%dT%H%M%SZ)
+cp -a /config/session.state /config/session.state.broken-$stamp
+cp -a /config/session.state.bak /config/session.state
+s6-svc -u /var/run/s6/services/deluged || true
+ls -l /config/session.state /config/session.state.bak /config/session.state.broken-$stamp
+'
+```
+
+Verify the daemon, port settings, directories, and VPN gate after recovery:
+
+```sh
+kubectl -n media exec deploy/deluge -c app -- \
+  timeout 10s deluge-console -c /config config listen_ports
+kubectl -n media exec deploy/deluge -c app -- \
+  timeout 10s deluge-console -c /config config random_outgoing_ports
+kubectl -n media exec deploy/deluge -c app -- \
+  timeout 10s deluge-console -c /config info
+kubectl -n media exec deploy/deluge -c gluetun -- \
+  /gluetun-entrypoint healthcheck
+```
+
+The expected port state is `listen_ports: (5983, 5983)` and
+`random_outgoing_ports: True`. The archived `session.state.broken-*` file is
+the rollback reference if the backup state is worse.
+
 If `deluge-vpn` is ready and the Kubernetes Secret exists but the Gluetun
 container repeatedly fails startup health checks with DNS lookup timeouts, treat
 that as an unhealthy WireGuard tunnel rather than a missing Kubernetes secret.

--- a/clusters/homelab/apps/deluge/README.md
+++ b/clusters/homelab/apps/deluge/README.md
@@ -54,6 +54,14 @@ blocking the UI service endpoint. The Pod becomes ready only after Gluetun is
 healthy and the Deluge application container is ready, so traffic still fails
 closed when the VPN healthcheck fails.
 
+A `daemon-metrics` sidecar runs `deluge-console -c /config status` every 30
+seconds and exposes the result on the service `metrics` port as Prometheus text
+format. Prometheus scrapes it through
+`clusters/homelab/apps/prometheus/deluge-servicemonitor.yaml`, and Grafana
+alerts on `deluge_daemon_rpc_healthy` when the daemon RPC check is missing or
+failing. This catches the failure mode where Kubernetes, Argo CD, and Gluetun
+are healthy but `deluged` cannot restore state or accept console connections.
+
 ## Download Paths
 
 Deluge owns the shared `media-downloads` PVC backed by the QNAP `/media` NFS
@@ -168,6 +176,8 @@ kubectl -n media exec deploy/deluge -c app -- \
   timeout 10s deluge-console -c /config config random_outgoing_ports
 kubectl -n media exec deploy/deluge -c app -- \
   timeout 10s deluge-console -c /config info
+kubectl -n media exec deploy/deluge -c daemon-metrics -- \
+  python3 -c 'import urllib.request; print(urllib.request.urlopen("http://127.0.0.1:9797/metrics", timeout=5).read().decode(), end="")'
 kubectl -n media exec deploy/deluge -c gluetun -- \
   /gluetun-entrypoint healthcheck
 ```

--- a/clusters/homelab/apps/deluge/values.yaml
+++ b/clusters/homelab/apps/deluge/values.yaml
@@ -92,7 +92,7 @@ controllers:
           VPN_TYPE: wireguard
           FIREWALL: "on"
           FIREWALL_INPUT_PORTS: "8112"
-          FIREWALL_VPN_INPUT_PORTS: &delugeIncomingPort "5983"
+          FIREWALL_VPN_INPUT_PORTS: "5983"
           HEALTH_RESTART_VPN: "on"
         securityContext:
           allowPrivilegeEscalation: false
@@ -149,7 +149,7 @@ controllers:
           repository: lscr.io/linuxserver/deluge
           tag: 18.04.1@sha256:0ac8716243944d28890565f759c7cedfc9e36a3fd5a827c9d0927abc0c8f97c9
         env:
-          DELUGE_INCOMING_PORT: *delugeIncomingPort
+          DELUGE_INCOMING_PORT: "5983"
         command:
           - /bin/sh
           - -ec

--- a/clusters/homelab/apps/deluge/values.yaml
+++ b/clusters/homelab/apps/deluge/values.yaml
@@ -179,12 +179,93 @@ controllers:
         securityContext:
           runAsGroup: 1000
           runAsUser: 1000
+      daemon-metrics:
+        image:
+          repository: lscr.io/linuxserver/deluge
+          tag: 18.04.1@sha256:0ac8716243944d28890565f759c7cedfc9e36a3fd5a827c9d0927abc0c8f97c9
+        command:
+          - /bin/sh
+          - -ec
+          - |
+            mkdir -p /tmp/deluge-metrics
+            metrics=/tmp/deluge-metrics/metrics
+
+            write_metrics() {
+              healthy=0
+              total=0
+              errors=0
+              if status_output="$(timeout 10s deluge-console -c /config status 2>&1)"; then
+                healthy=1
+                total="$(
+                  printf "%s\n" "$status_output" |
+                    awk -F: '/^[[:space:]]*Total torrents:/ {gsub(/^[[:space:]]+/, "", $2); print $2; exit}'
+                )"
+                errors="$(
+                  printf "%s\n" "$status_output" |
+                    awk -F: '/^[[:space:]]*Error:/ {gsub(/^[[:space:]]+/, "", $2); print $2; exit}'
+                )"
+              fi
+              total="${total:-0}"
+              errors="${errors:-0}"
+              cat >"${metrics}.tmp" <<EOF
+            # HELP deluge_daemon_rpc_healthy Whether deluge-console can query the Deluge daemon.
+            # TYPE deluge_daemon_rpc_healthy gauge
+            deluge_daemon_rpc_healthy ${healthy}
+            # HELP deluge_torrents_total Number of torrents reported by Deluge.
+            # TYPE deluge_torrents_total gauge
+            deluge_torrents_total ${total}
+            # HELP deluge_torrents_error Number of torrents currently in Deluge Error state.
+            # TYPE deluge_torrents_error gauge
+            deluge_torrents_error ${errors}
+            EOF
+              mv "${metrics}.tmp" "$metrics"
+            }
+
+            write_metrics
+            while true; do
+              sleep 30
+              write_metrics
+            done &
+
+            exec python3 - <<'PY'
+            from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+            class MetricsHandler(BaseHTTPRequestHandler):
+                def do_GET(self):
+                    if self.path != "/metrics":
+                        self.send_response(404)
+                        self.end_headers()
+                        return
+                    try:
+                        with open("/tmp/deluge-metrics/metrics", "rb") as metrics:
+                            body = metrics.read()
+                    except FileNotFoundError:
+                        body = b""
+                    self.send_response(200)
+                    self.send_header("Content-Type", "text/plain; version=0.0.4")
+                    self.send_header("Content-Length", str(len(body)))
+                    self.end_headers()
+                    self.wfile.write(body)
+
+                def log_message(self, format, *args):
+                    return
+
+
+            HTTPServer(("0.0.0.0", 9797), MetricsHandler).serve_forever()
+            PY
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsGroup: 1000
+          runAsUser: 1000
 service:
   app:
     controller: deluge
     ports:
       http:
         port: 8112
+      metrics:
+        port: 9797
 persistence:
   config:
     enabled: true
@@ -196,6 +277,9 @@ persistence:
           - path: /config
         port-config:
           - path: /config
+        daemon-metrics:
+          - path: /config
+            readOnly: true
   downloads:
     enabled: true
     type: persistentVolumeClaim

--- a/clusters/homelab/apps/grafana/README.md
+++ b/clusters/homelab/apps/grafana/README.md
@@ -129,6 +129,9 @@ The provisioned rules cover:
 - Kubernetes pod containers stuck in `CrashLoopBackOff` for 5 minutes.
 - Kubernetes Deployments with desired replicas but no available replicas for 5
   minutes.
+- Deluge daemon RPC health missing or failing for 5 minutes, using the
+  `deluge_daemon_rpc_healthy` metric from the Deluge metrics sidecar instead of
+  generic Pod readiness.
 - Homelab stateful PVC usage above 85 percent for 15 minutes.
 - Argo CD application metrics missing from Prometheus for 10 minutes.
 - Argo CD Applications not `Healthy` for 10 minutes.

--- a/clusters/homelab/apps/grafana/values.yaml
+++ b/clusters/homelab/apps/grafana/values.yaml
@@ -34,7 +34,7 @@ grafana.ini:
     skip_org_role_sync: false
     use_pkce: true
 podAnnotations:
-  homelab.rst.io/alerting-provisioning-version: "9"
+  homelab.rst.io/alerting-provisioning-version: "10"
 plugins:
   - https://github.com/grafana/grafana-infinity-datasource/releases/download/v3.8.0/yesoreyeram-infinity-datasource-3.8.0.zip;yesoreyeram-infinity-datasource
 initChownData:
@@ -537,6 +537,84 @@ alerting:
             labels:
               severity: critical
               managed_by: grafana-provisioning
+          - uid: homelab-deluge-daemon-rpc-unhealthy
+            title: Deluge daemon RPC unhealthy
+            condition: C
+            data:
+              - refId: A
+                datasourceUid: prometheus
+                relativeTimeRange:
+                  from: 600
+                  to: 0
+                model:
+                  datasource:
+                    type: prometheus
+                    uid: prometheus
+                  editorMode: code
+                  expr: |
+                    absent(deluge_daemon_rpc_healthy{namespace="media",service="deluge"})
+                    or
+                    (deluge_daemon_rpc_healthy{namespace="media",service="deluge"} == bool 0)
+                  instant: true
+                  intervalMs: 1000
+                  legendFormat: Deluge daemon RPC unhealthy
+                  maxDataPoints: 43200
+                  range: false
+                  refId: A
+              - refId: B
+                datasourceUid: __expr__
+                relativeTimeRange:
+                  from: 0
+                  to: 0
+                model:
+                  datasource:
+                    type: __expr__
+                    uid: __expr__
+                  expression: A
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  reducer: last
+                  refId: B
+                  type: reduce
+              - refId: C
+                datasourceUid: __expr__
+                relativeTimeRange:
+                  from: 0
+                  to: 0
+                model:
+                  conditions:
+                    - evaluator:
+                        params:
+                          - 0
+                        type: gt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                          - C
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                  datasource:
+                    type: __expr__
+                    uid: __expr__
+                  expression: B
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+                  refId: C
+                  type: threshold
+            noDataState: OK
+            execErrState: Alerting
+            for: 5m
+            annotations:
+              summary: Deluge pod readiness is not enough; the Deluge daemon RPC probe is failing or missing.
+              description: The daemon-metrics sidecar could not query `deluge-console status`, or Prometheus is not scraping that metric. Check Gluetun health, Deluge app logs, port-config logs, and the session.state recovery runbook.
+              runbook_url: https://github.com/Stuhlmuller/homelab/blob/main/clusters/homelab/apps/deluge/README.md
+            labels:
+              severity: critical
+              managed_by: grafana-provisioning
+              app: deluge
           - uid: homelab-pvc-space-low
             title: Homelab PVC space low
             condition: C

--- a/clusters/homelab/apps/prometheus/README.md
+++ b/clusters/homelab/apps/prometheus/README.md
@@ -28,6 +28,12 @@ the `argocd` namespace. The matching services are enabled by the Argo CD
 bootstrap stack at `IaC/bootstrap/argocd`; the ServiceMonitors live here so
 Prometheus Operator CRDs are installed before this scrape wiring is applied.
 
+`deluge-servicemonitor.yaml` scrapes the Deluge metrics sidecar in the `media`
+namespace. That sidecar exposes `deluge_daemon_rpc_healthy`, which checks
+whether `deluge-console status` can reach `deluged`. This catches Deluge daemon
+state-restore failures that do not make the Kubernetes Pod or Argo CD
+Application unhealthy.
+
 - Backup: covered by the NFS backup gate in `docs/storage-nfs.md`.
 - Restore: restore Prometheus and Alertmanager PVCs before relying on retained
   metrics.

--- a/clusters/homelab/apps/prometheus/deluge-servicemonitor.yaml
+++ b/clusters/homelab/apps/prometheus/deluge-servicemonitor.yaml
@@ -1,0 +1,24 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: deluge
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: deluge
+    app.kubernetes.io/part-of: homelab-media
+    homelab.stuhlmuller.dev/cluster: homelab
+spec:
+  namespaceSelector:
+    matchNames:
+      - media
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: deluge
+      app.kubernetes.io/name: deluge
+      app.kubernetes.io/service: deluge
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+      honorLabels: false

--- a/clusters/homelab/apps/prometheus/kustomization.yaml
+++ b/clusters/homelab/apps/prometheus/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - argocd-servicemonitors.yaml
+  - deluge-servicemonitor.yaml
   - externalsecret.yaml
   - namespace.yaml
   - authorizationpolicy.yaml

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -60,6 +60,12 @@ the profile to IPv4 before Gluetun starts. Keep Deluge's AirVPN forwarded port
 fixed only for `listen_ports`; `outgoing_ports` should stay at Deluge's default
 random behavior, otherwise active torrents can report too few outgoing ports
 and fail to establish enough peer connections.
+If Kubernetes and Gluetun are healthy but `deluged` loops with
+`libtorrent::libtorrent_exception` and `port-config` gets connection refused,
+check `clusters/homelab/apps/deluge/README.md` for the narrow
+`session.state` recovery. Archive the broken file and restore
+`session.state.bak`; do not delete `/config/state/*.torrent` or downloaded
+media while repairing this failure mode.
 
 ## Grafana
 

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -66,6 +66,10 @@ check `clusters/homelab/apps/deluge/README.md` for the narrow
 `session.state` recovery. Archive the broken file and restore
 `session.state.bak`; do not delete `/config/state/*.torrent` or downloaded
 media while repairing this failure mode.
+The `daemon-metrics` sidecar exports `deluge_daemon_rpc_healthy` from
+`deluge-console status`; Prometheus scrapes it through the monitoring-owned
+Deluge ServiceMonitor, and Grafana alerts when the metric is absent or zero so
+future daemon-only failures do not hide behind healthy Pod and Argo CD status.
 
 ## Grafana
 
@@ -82,6 +86,8 @@ SQLite/PVC state cannot keep retrying removed integrations.
 Alerting-only provisioning changes bump
 `homelab.rst.io/alerting-provisioning-version` so Grafana restarts and applies
 rule additions, updates, and deletions.
+The Deluge daemon RPC rule depends on the Deluge `daemon-metrics` sidecar and
+Prometheus `deluge` ServiceMonitor rather than generic Kubernetes readiness.
 The GitHub dashboard uses unauthenticated public REST API reads against
 `Stuhlmuller/homelab`. GitHub Actions failure and timeout alerts are deleted
 from provisioning until Grafana has a token-backed GitHub API secret contract;


### PR DESCRIPTION
## Summary

This PR records the Deluge incident recovery path and adds monitoring so the same failure mode is visible before it quietly strands the UI and torrent state again.

Deluge looked mostly healthy from Kubernetes and Argo CD, but the daemon could not reliably answer `deluge-console` RPC calls. The user-visible effect was worse than a normal pod outage: the UI did not show the expected torrent set, helper containers could not apply runtime Deluge configuration, and neighboring media apps were also noisy while the cluster recovered from a post-reboot NFS/Postgres wobble.

The Deluge-specific root cause was bad persisted daemon session state under `/config/session.state`. App logs showed `libtorrent::libtorrent_exception` errors while restoring state, and the `port-config` sidecar could not connect to the daemon. After explicit operator approval, the live recovery preserved torrent metadata and downloaded data, archived the broken `session.state`, restored `/config/session.state.bak`, and restarted only the supervised `deluged` service inside the Deluge container.

## Changes

- Documented the `session.state` recovery runbook in `clusters/homelab/apps/deluge/README.md`, including the safe archive/restore commands and post-recovery checks.
- Added a `daemon-metrics` sidecar to the Deluge deployment that runs `deluge-console -c /config status` every 30 seconds and exposes Prometheus text metrics on port `9797`.
- Added a Prometheus `ServiceMonitor` for the Deluge metrics sidecar.
- Added a Grafana provisioned alert, `homelab-deluge-daemon-rpc-unhealthy`, that fires when the Deluge daemon RPC metric is missing or reports unhealthy.
- Updated the Grafana, Prometheus, and knowledge-base docs so the monitoring and recovery assumptions are not trapped in chat history.

## Validation

- `git diff --check`
- `kubectl kustomize clusters/homelab/apps/prometheus`
- `kubectl kustomize clusters/homelab/apps/grafana`
- `helm template deluge app-template --repo https://bjw-s-labs.github.io/helm-charts --version 4.4.0 --namespace media --values clusters/homelab/apps/deluge/values.yaml`
- `helm template grafana grafana --repo https://grafana.github.io/helm-charts --version 10.5.15 --namespace monitoring --values clusters/homelab/apps/grafana/values.yaml`
- Signed commit hooks: whitespace, EOF, added large files, YAML, codespell, Checkov Diff, Checkov Secrets

Live read-only checks after recovery:

- `kubectl -n media exec deploy/deluge -c app -- timeout 10s deluge-console -c /config status` reported 6 total torrents, 6 seeding, and 0 error.
- `kubectl -n media exec deploy/deluge -c gluetun -- /gluetun-entrypoint healthcheck` exited successfully.
- `kubectl -n media get endpoints media-postgres -o wide` showed a ready Postgres endpoint.
- `kubectl -n argocd get applications.argoproj.io deluge grafana prometheus -o wide` showed all three applications `Synced` and `Healthy`.

`nix run .#validate` was not available because `nix` is not installed in this shell.
