### PR TITLE
fix: use recreate for octelium enterprise stores

### DIFF
--- a/clusters/homelab/apps/octelium-enterprise/README.md
+++ b/clusters/homelab/apps/octelium-enterprise/README.md
@@ -26,12 +26,19 @@ shape. Checkov exceptions are scoped per Deployment for that adoption boundary;
 change them only after validating the new runtime constraints against the
 Enterprise package.
 
+The `octeliumee-logstore`, `octeliumee-metricstore`, and
+`octeliumee-rscstore` Deployments intentionally use `Recreate` instead of a
+rolling update. Each process opens a DuckDB-backed `store.db` on its PVC, so a
+second pod against the same volume can fail on the single-writer lock while the
+old pod is still terminating.
+
 ## Updating
 
 Use `scripts/octelium-enterprise-package.sh --upgrade` first when changing the
 Enterprise package version. After the package settles, refresh
 `resources.yaml` from the healthy live resources, scrub generated metadata, pin
-images as `tag@sha256:digest`, and re-run validation.
+images as `tag@sha256:digest`, preserve `Recreate` on the three store
+Deployments, and re-run validation.
 
 ## Validation
 

--- a/clusters/homelab/apps/octelium-enterprise/resources.yaml
+++ b/clusters/homelab/apps/octelium-enterprise/resources.yaml
@@ -257,10 +257,7 @@ spec:
       octelium.com/component: logstore
       octelium.com/component-type: cluster
   strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
-    type: RollingUpdate
+    type: Recreate
   template:
     metadata:
       annotations:
@@ -341,10 +338,7 @@ spec:
       octelium.com/component: metricstore
       octelium.com/component-type: cluster
   strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
-    type: RollingUpdate
+    type: Recreate
   template:
     metadata:
       annotations:
@@ -729,10 +723,7 @@ spec:
       octelium.com/component: rscstore
       octelium.com/component-type: cluster
   strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
-    type: RollingUpdate
+    type: Recreate
   template:
     metadata:
       annotations:

--- a/docs/knowledge-base/architecture/storage-and-state.md
+++ b/docs/knowledge-base/architecture/storage-and-state.md
@@ -41,6 +41,8 @@ n8n-postgres, octelium-storage PostgreSQL/Redis, Octelium Enterprise package
 stores (`octelium-rscstore`, `octelium-logstore`, `octelium-metricstore`),
 Prowlarr, Radarr, Sonarr, LiteLLM, OpenClaw, n8n, and OctoBot. See
 [[workloads/inventory]] for ownership and dependency notes.
+The Octelium Enterprise package stores are DuckDB-backed single-writer stores,
+so their Deployments must use `Recreate` rather than rolling updates.
 
 ## Source Files
 

--- a/docs/knowledge-base/runbooks/octelium.md
+++ b/docs/knowledge-base/runbooks/octelium.md
@@ -94,6 +94,11 @@ package resources and PVC declarations; generated Secrets such as
 `sys-init-kek`, database credentials, license material, and kubeconfigs stay
 outside git.
 
+The `octeliumee-logstore`, `octeliumee-metricstore`, and
+`octeliumee-rscstore` Deployments use `Recreate` because each store opens a
+DuckDB-backed `store.db` on its PVC. Do not change those workloads back to
+rolling updates unless the package moves to a multi-writer-safe storage model.
+
 The Octelium Cluster domain is `stinkyboi.com`, which makes the client contact
 `octelium-api.stinkyboi.com`. `octelium.stinkyboi.com` is a public alias for
 the Octelium control plane, not the CLI domain. This keeps the public API and
@@ -117,7 +122,8 @@ The operator workstation needs `octops` `v0.29.0` or later and kubeconfig
 access to the Octelium Cluster. Keep commercial or production license material
 outside git; add only safe references or secret contracts here.
 After install or upgrade, refresh the GitOps capture, keep all images pinned as
-`tag@sha256:digest`, and sync the `octelium-enterprise` Argo CD Application.
+`tag@sha256:digest`, preserve `Recreate` on the three store Deployments, and
+sync the `octelium-enterprise` Argo CD Application.
 
 ## Bootstrap Access
 

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -162,7 +162,9 @@ with `scripts/octelium-enterprise-package.sh`, then let the
 state from `clusters/homelab/apps/octelium-enterprise`. The Octelium Cluster
 domain is `stinkyboi.com`, so clients contact `octelium-api.stinkyboi.com`;
 certificate and bootstrap routing use apex plus first-level `*.stinkyboi.com`
-coverage, with `octelium.stinkyboi.com` as an alias.
+coverage, with `octelium.stinkyboi.com` as an alias. The Enterprise log,
+metric, and resource store Deployments use `Recreate` because their DuckDB
+files on PVCs are single-writer stores.
 
 Before changing app transport, run `scripts/octelium-e2e-check.sh` and confirm
 the service catalog plus direct HTTPS probes for the existing

--- a/docs/octelium.md
+++ b/docs/octelium.md
@@ -319,6 +319,11 @@ declarations after the initial `octops` package install. Generated Secrets such
 as `sys-init-kek`, database credentials, license material, and kubeconfigs stay
 outside git.
 
+The `octeliumee-logstore`, `octeliumee-metricstore`, and
+`octeliumee-rscstore` Deployments use `Recreate` because each store opens a
+DuckDB-backed `store.db` on its PVC. Do not change those workloads back to
+rolling updates unless the package moves to a multi-writer-safe storage model.
+
 The configured Octelium Cluster domain is `stinkyboi.com`, which makes the
 client use `octelium-api.stinkyboi.com`. The Istio and Cloudflare edge
 certificates only need apex plus first-level `*.stinkyboi.com` coverage.
@@ -346,8 +351,8 @@ default kubeconfig for the operator shell.
 
 After install or upgrade, refresh the GitOps capture in
 `clusters/homelab/apps/octelium-enterprise/resources.yaml`, keep images pinned
-as `tag@sha256:digest`, and sync the `octelium-enterprise` Argo CD
-Application.
+as `tag@sha256:digest`, preserve `Recreate` on the three store Deployments,
+and sync the `octelium-enterprise` Argo CD Application.
 
 ## Full Cluster Bootstrap
 


### PR DESCRIPTION
## Summary
- switch Octelium Enterprise DuckDB-backed store deployments to Recreate
- document the single-writer PVC rollout constraint

## Validation
- kubectl kustomize clusters/homelab/apps/octelium-enterprise
- bash scripts/ci/static-checks.sh