### PR TITLE
fix: clear octelium enterprise rolling update fields

### DIFF
--- a/clusters/homelab/apps/octelium-enterprise/README.md
+++ b/clusters/homelab/apps/octelium-enterprise/README.md
@@ -30,15 +30,20 @@ The `octeliumee-logstore`, `octeliumee-metricstore`, and
 `octeliumee-rscstore` Deployments intentionally use `Recreate` instead of a
 rolling update. Each process opens a DuckDB-backed `store.db` on its PVC, so a
 second pod against the same volume can fail on the single-writer lock while the
-old pod is still terminating.
+old pod is still terminating. Keep `rollingUpdate: null` on those strategies;
+the Application uses server-side apply, and the explicit null clears the
+package-adopted rolling-update field from live Deployments. The resource-level
+`argocd.argoproj.io/sync-options: Replace=true` annotation makes Argo replace
+those adopted Deployments instead of server-side applying the strategy change.
 
 ## Updating
 
 Use `scripts/octelium-enterprise-package.sh --upgrade` first when changing the
 Enterprise package version. After the package settles, refresh
 `resources.yaml` from the healthy live resources, scrub generated metadata, pin
-images as `tag@sha256:digest`, preserve `Recreate` on the three store
-Deployments, and re-run validation.
+images as `tag@sha256:digest`, preserve `Recreate`, `rollingUpdate: null`, and
+resource-level `Replace=true` on the three store Deployments, and re-run
+validation.
 
 ## Validation
 

--- a/clusters/homelab/apps/octelium-enterprise/resources.yaml
+++ b/clusters/homelab/apps/octelium-enterprise/resources.yaml
@@ -232,6 +232,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: Replace=true
     checkov.io/skip1: CKV_K8S_37=Adopts upstream Octelium Enterprise package capabilities until package-validated hardening is available.
     checkov.io/skip2: CKV_K8S_31=Adopts upstream Octelium Enterprise package seccomp defaults until package-validated hardening is available.
     checkov.io/skip3: CKV_K8S_40=Adopts upstream Octelium Enterprise package user IDs; changing them can break packaged services.
@@ -257,6 +258,7 @@ spec:
       octelium.com/component: logstore
       octelium.com/component-type: cluster
   strategy:
+    rollingUpdate: null
     type: Recreate
   template:
     metadata:
@@ -313,6 +315,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: Replace=true
     checkov.io/skip1: CKV_K8S_37=Adopts upstream Octelium Enterprise package capabilities until package-validated hardening is available.
     checkov.io/skip2: CKV_K8S_31=Adopts upstream Octelium Enterprise package seccomp defaults until package-validated hardening is available.
     checkov.io/skip3: CKV_K8S_40=Adopts upstream Octelium Enterprise package user IDs; changing them can break packaged services.
@@ -338,6 +341,7 @@ spec:
       octelium.com/component: metricstore
       octelium.com/component-type: cluster
   strategy:
+    rollingUpdate: null
     type: Recreate
   template:
     metadata:
@@ -698,6 +702,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: Replace=true
     checkov.io/skip1: CKV_K8S_37=Adopts upstream Octelium Enterprise package capabilities until package-validated hardening is available.
     checkov.io/skip2: CKV_K8S_31=Adopts upstream Octelium Enterprise package seccomp defaults until package-validated hardening is available.
     checkov.io/skip3: CKV_K8S_40=Adopts upstream Octelium Enterprise package user IDs; changing them can break packaged services.
@@ -723,6 +728,7 @@ spec:
       octelium.com/component: rscstore
       octelium.com/component-type: cluster
   strategy:
+    rollingUpdate: null
     type: Recreate
   template:
     metadata:

--- a/docs/knowledge-base/runbooks/octelium.md
+++ b/docs/knowledge-base/runbooks/octelium.md
@@ -98,6 +98,11 @@ The `octeliumee-logstore`, `octeliumee-metricstore`, and
 `octeliumee-rscstore` Deployments use `Recreate` because each store opens a
 DuckDB-backed `store.db` on its PVC. Do not change those workloads back to
 rolling updates unless the package moves to a multi-writer-safe storage model.
+Keep `rollingUpdate: null` in the desired state for those Deployments because
+the Application uses server-side apply and must clear the rolling-update field
+from the package-adopted live objects. Also keep resource-level
+`argocd.argoproj.io/sync-options: Replace=true` on those Deployments so Argo
+uses replace semantics for the strategy handoff.
 
 The Octelium Cluster domain is `stinkyboi.com`, which makes the client contact
 `octelium-api.stinkyboi.com`. `octelium.stinkyboi.com` is a public alias for
@@ -122,8 +127,9 @@ The operator workstation needs `octops` `v0.29.0` or later and kubeconfig
 access to the Octelium Cluster. Keep commercial or production license material
 outside git; add only safe references or secret contracts here.
 After install or upgrade, refresh the GitOps capture, keep all images pinned as
-`tag@sha256:digest`, preserve `Recreate` on the three store Deployments, and
-sync the `octelium-enterprise` Argo CD Application.
+`tag@sha256:digest`, preserve `Recreate`, `rollingUpdate: null`, and
+resource-level `Replace=true` on the three store Deployments, and sync the
+`octelium-enterprise` Argo CD Application.
 
 ## Bootstrap Access
 

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -164,7 +164,9 @@ domain is `stinkyboi.com`, so clients contact `octelium-api.stinkyboi.com`;
 certificate and bootstrap routing use apex plus first-level `*.stinkyboi.com`
 coverage, with `octelium.stinkyboi.com` as an alias. The Enterprise log,
 metric, and resource store Deployments use `Recreate` because their DuckDB
-files on PVCs are single-writer stores.
+files on PVCs are single-writer stores; keep `rollingUpdate: null` on those
+strategies and resource-level `Replace=true` so Argo can clear the adopted
+rolling-update field.
 
 Before changing app transport, run `scripts/octelium-e2e-check.sh` and confirm
 the service catalog plus direct HTTPS probes for the existing

--- a/docs/octelium.md
+++ b/docs/octelium.md
@@ -323,6 +323,11 @@ The `octeliumee-logstore`, `octeliumee-metricstore`, and
 `octeliumee-rscstore` Deployments use `Recreate` because each store opens a
 DuckDB-backed `store.db` on its PVC. Do not change those workloads back to
 rolling updates unless the package moves to a multi-writer-safe storage model.
+Keep `rollingUpdate: null` in the desired state for those Deployments because
+the Application uses server-side apply and must clear the rolling-update field
+from the package-adopted live objects. Also keep resource-level
+`argocd.argoproj.io/sync-options: Replace=true` on those Deployments so Argo
+uses replace semantics for the strategy handoff.
 
 The configured Octelium Cluster domain is `stinkyboi.com`, which makes the
 client use `octelium-api.stinkyboi.com`. The Istio and Cloudflare edge
@@ -351,8 +356,9 @@ default kubeconfig for the operator shell.
 
 After install or upgrade, refresh the GitOps capture in
 `clusters/homelab/apps/octelium-enterprise/resources.yaml`, keep images pinned
-as `tag@sha256:digest`, preserve `Recreate` on the three store Deployments,
-and sync the `octelium-enterprise` Argo CD Application.
+as `tag@sha256:digest`, preserve `Recreate`, `rollingUpdate: null`, and
+resource-level `Replace=true` on the three store Deployments, and sync the
+`octelium-enterprise` Argo CD Application.
 
 ## Full Cluster Bootstrap
 


### PR DESCRIPTION
## Summary
- add resource-level Replace=true to the three Octelium Enterprise store Deployments
- keep rollingUpdate: null with Recreate so adopted RollingUpdate fields are cleared
- document the server-side apply adoption pattern for future package refreshes

## Validation
- kubectl kustomize clusters/homelab/apps/octelium-enterprise
- kubectl kustomize clusters/homelab/apps/octelium-enterprise | awk 'BEGIN { RS="---"; ORS="---\n" } /kind: Deployment/ && /name: octeliumee-(logstore|metricstore|rscstore)/ { print }' | kubectl replace --dry-run=server -f -
- bash scripts/ci/static-checks.sh