### PR TITLE
fix: avoid octelium enterprise strategy diff loop

### DIFF
--- a/clusters/homelab/apps/octelium-enterprise/README.md
+++ b/clusters/homelab/apps/octelium-enterprise/README.md
@@ -30,19 +30,20 @@ The `octeliumee-logstore`, `octeliumee-metricstore`, and
 `octeliumee-rscstore` Deployments intentionally use `Recreate` instead of a
 rolling update. Each process opens a DuckDB-backed `store.db` on its PVC, so a
 second pod against the same volume can fail on the single-writer lock while the
-old pod is still terminating. Keep `rollingUpdate: null` on those strategies;
-the Application uses server-side apply, and the explicit null clears the
-package-adopted rolling-update field from live Deployments. The resource-level
+old pod is still terminating. The resource-level
 `argocd.argoproj.io/sync-options: Replace=true` annotation makes Argo replace
-those adopted Deployments instead of server-side applying the strategy change.
+those adopted Deployments instead of server-side applying the strategy change;
+that replacement clears the package-adopted rolling-update field from live
+Deployments. Do not keep an explicit `rollingUpdate: null` field because it can
+compare differently from the live object's absent field.
 
 ## Updating
 
 Use `scripts/octelium-enterprise-package.sh --upgrade` first when changing the
 Enterprise package version. After the package settles, refresh
 `resources.yaml` from the healthy live resources, scrub generated metadata, pin
-images as `tag@sha256:digest`, preserve `Recreate`, `rollingUpdate: null`, and
-resource-level `Replace=true` on the three store Deployments, and re-run
+images as `tag@sha256:digest`, preserve `Recreate` and resource-level
+`Replace=true` on the three store Deployments, omit `rollingUpdate`, and re-run
 validation.
 
 ## Validation

--- a/clusters/homelab/apps/octelium-enterprise/resources.yaml
+++ b/clusters/homelab/apps/octelium-enterprise/resources.yaml
@@ -258,7 +258,6 @@ spec:
       octelium.com/component: logstore
       octelium.com/component-type: cluster
   strategy:
-    rollingUpdate: null
     type: Recreate
   template:
     metadata:
@@ -341,7 +340,6 @@ spec:
       octelium.com/component: metricstore
       octelium.com/component-type: cluster
   strategy:
-    rollingUpdate: null
     type: Recreate
   template:
     metadata:
@@ -728,7 +726,6 @@ spec:
       octelium.com/component: rscstore
       octelium.com/component-type: cluster
   strategy:
-    rollingUpdate: null
     type: Recreate
   template:
     metadata:

--- a/docs/knowledge-base/runbooks/octelium.md
+++ b/docs/knowledge-base/runbooks/octelium.md
@@ -98,11 +98,11 @@ The `octeliumee-logstore`, `octeliumee-metricstore`, and
 `octeliumee-rscstore` Deployments use `Recreate` because each store opens a
 DuckDB-backed `store.db` on its PVC. Do not change those workloads back to
 rolling updates unless the package moves to a multi-writer-safe storage model.
-Keep `rollingUpdate: null` in the desired state for those Deployments because
-the Application uses server-side apply and must clear the rolling-update field
-from the package-adopted live objects. Also keep resource-level
-`argocd.argoproj.io/sync-options: Replace=true` on those Deployments so Argo
-uses replace semantics for the strategy handoff.
+Keep resource-level `argocd.argoproj.io/sync-options: Replace=true` on those
+Deployments so Argo uses replace semantics for the strategy handoff and clears
+the package-adopted rolling-update field. Omit `rollingUpdate`; an explicit
+`rollingUpdate: null` can compare differently from the live object's absent
+field.
 
 The Octelium Cluster domain is `stinkyboi.com`, which makes the client contact
 `octelium-api.stinkyboi.com`. `octelium.stinkyboi.com` is a public alias for
@@ -127,8 +127,8 @@ The operator workstation needs `octops` `v0.29.0` or later and kubeconfig
 access to the Octelium Cluster. Keep commercial or production license material
 outside git; add only safe references or secret contracts here.
 After install or upgrade, refresh the GitOps capture, keep all images pinned as
-`tag@sha256:digest`, preserve `Recreate`, `rollingUpdate: null`, and
-resource-level `Replace=true` on the three store Deployments, and sync the
+`tag@sha256:digest`, preserve `Recreate` and resource-level `Replace=true` on
+the three store Deployments, omit `rollingUpdate`, and sync the
 `octelium-enterprise` Argo CD Application.
 
 ## Bootstrap Access

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -164,9 +164,9 @@ domain is `stinkyboi.com`, so clients contact `octelium-api.stinkyboi.com`;
 certificate and bootstrap routing use apex plus first-level `*.stinkyboi.com`
 coverage, with `octelium.stinkyboi.com` as an alias. The Enterprise log,
 metric, and resource store Deployments use `Recreate` because their DuckDB
-files on PVCs are single-writer stores; keep `rollingUpdate: null` on those
-strategies and resource-level `Replace=true` so Argo can clear the adopted
-rolling-update field.
+files on PVCs are single-writer stores; keep resource-level `Replace=true` and
+omit `rollingUpdate` so Argo can clear the adopted rolling-update field without
+a null-vs-absent diff loop.
 
 Before changing app transport, run `scripts/octelium-e2e-check.sh` and confirm
 the service catalog plus direct HTTPS probes for the existing

--- a/docs/octelium.md
+++ b/docs/octelium.md
@@ -323,11 +323,11 @@ The `octeliumee-logstore`, `octeliumee-metricstore`, and
 `octeliumee-rscstore` Deployments use `Recreate` because each store opens a
 DuckDB-backed `store.db` on its PVC. Do not change those workloads back to
 rolling updates unless the package moves to a multi-writer-safe storage model.
-Keep `rollingUpdate: null` in the desired state for those Deployments because
-the Application uses server-side apply and must clear the rolling-update field
-from the package-adopted live objects. Also keep resource-level
-`argocd.argoproj.io/sync-options: Replace=true` on those Deployments so Argo
-uses replace semantics for the strategy handoff.
+Keep resource-level `argocd.argoproj.io/sync-options: Replace=true` on those
+Deployments so Argo uses replace semantics for the strategy handoff and clears
+the package-adopted rolling-update field. Omit `rollingUpdate`; an explicit
+`rollingUpdate: null` can compare differently from the live object's absent
+field.
 
 The configured Octelium Cluster domain is `stinkyboi.com`, which makes the
 client use `octelium-api.stinkyboi.com`. The Istio and Cloudflare edge
@@ -356,8 +356,8 @@ default kubeconfig for the operator shell.
 
 After install or upgrade, refresh the GitOps capture in
 `clusters/homelab/apps/octelium-enterprise/resources.yaml`, keep images pinned
-as `tag@sha256:digest`, preserve `Recreate`, `rollingUpdate: null`, and
-resource-level `Replace=true` on the three store Deployments, and sync the
+as `tag@sha256:digest`, preserve `Recreate` and resource-level `Replace=true`
+on the three store Deployments, omit `rollingUpdate`, and sync the
 `octelium-enterprise` Argo CD Application.
 
 ## Full Cluster Bootstrap


### PR DESCRIPTION
## Summary
- remove explicit rollingUpdate: null from the Enterprise store Deployments
- keep resource-level Replace=true with Recreate so Argo clears adopted rolling-update fields without a null-vs-absent diff loop
- update Octelium docs and KB notes with the final adoption pattern

## Validation
- kubectl kustomize clusters/homelab/apps/octelium-enterprise
- kubectl kustomize clusters/homelab/apps/octelium-enterprise | awk 'BEGIN { RS="---"; ORS="---\n" } /kind: Deployment/ && /name: octeliumee-(logstore|metricstore|rscstore)/ { print }' | kubectl replace --dry-run=server -f -
- bash scripts/ci/static-checks.sh