### PR TITLE
fix: repair Deluge daemon observability

### DIFF
--- a/clusters/homelab/apps/deluge/values.yaml
+++ b/clusters/homelab/apps/deluge/values.yaml
@@ -198,11 +198,11 @@ controllers:
                 healthy=1
                 total="$(
                   printf "%s\n" "$status_output" |
-                    awk -F: '/^[[:space:]]*Total torrents:/ {gsub(/^[[:space:]]+/, "", $2); print $2; exit}'
+                    awk -F: '/^[ \t]*Total torrents:/ {gsub(/^[ \t]+/, "", $2); print $2; exit}'
                 )"
                 errors="$(
                   printf "%s\n" "$status_output" |
-                    awk -F: '/^[[:space:]]*Error:/ {gsub(/^[[:space:]]+/, "", $2); print $2; exit}'
+                    awk -F: '/^[ \t]*Error:/ {gsub(/^[ \t]+/, "", $2); print $2; exit}'
                 )"
               fi
               total="${total:-0}"

--- a/docs/knowledge-base/operations/continuous-improvement.md
+++ b/docs/knowledge-base/operations/continuous-improvement.md
@@ -150,3 +150,18 @@ policy`.
   tighter profile or accidentally expand the exception blast radius.
 - **Next step:** continue splitting the Deluge VPN privilege exception into a
   dedicated namespace once the media workloads can stay restricted.
+- **Status:** open
+- **Area:** workload reliability / Deluge
+- **Evidence:** On 2026-06-15 UTC, Deluge was Kubernetes-ready and Argo CD
+  `Synced/Healthy`, but `deluged` was repeatedly crashing with
+  `libtorrent::libtorrent_exception: invalid type requested from entry`.
+  `deluge_daemon_rpc_healthy` was `0` until the documented
+  `session.state` recovery restored `/config/session.state.bak` and archived
+  the broken state file as `session.state.broken-20260615T040836Z`.
+- **Risk:** Deluge can be unavailable while Kubernetes readiness, Gluetun, and
+  Argo CD still look healthy, and the same persisted-state corruption may
+  recur after future pod or daemon restarts.
+- **Next step:** investigate a durable fix for recurring Deluge
+  `session.state` corruption, such as a safer shutdown path, a newer Deluge or
+  libtorrent image, or an automated guarded recovery that preserves
+  `/config/state/*.torrent` and `/downloads`.


### PR DESCRIPTION
## Summary

This PR captures the follow-up from the Deluge outage where the live
Deployment, Pod, Gluetun VPN gate, and Argo CD Application all reported healthy
while the Deluge daemon itself was unavailable.

Deluge was down because `deluged` was repeatedly crashing with
`libtorrent::libtorrent_exception: invalid type requested from entry`. The
documented recovery restored `/config/session.state.bak` over the active
`/config/session.state` and archived the broken file as
`session.state.broken-20260615T040836Z`, which brought the daemon RPC endpoint
back without deleting torrent metadata or downloads.

## Cause And Effect

The immediate cause was corrupted persisted Deluge session state. Kubernetes
readiness and Argo CD health did not catch the outage because the container and
VPN sidecar stayed healthy even though `deluge-console` could not connect to the
daemon. Users saw Deluge as down while the normal platform health checks looked
green.

During validation, the `daemon-metrics` sidecar correctly surfaced
`deluge_daemon_rpc_healthy`, but the torrent count and error gauges were
silently stuck at zero. The sidecar image's `awk` did not match the POSIX
`[[:space:]]` expression used in the parser, so successful status output still
fell back to zero-valued metrics.

## Fix

The Deluge metrics parser now uses a portable `[ \t]` character class for the
`Total torrents` and `Error` lines, matching the `awk` behavior in the
linuxserver Deluge image. This keeps the daemon RPC health signal intact and
also makes the count/error gauges reflect the same `deluge-console status`
output used during incident verification.

The knowledge base now records the recurring `session.state` corruption mode,
the recovery evidence, the archived state filename, and the next durable
follow-up options: safer shutdown behavior, a newer Deluge or libtorrent image,
or guarded automated recovery that preserves `/config/state/*.torrent` and
`/downloads`.

## Validation

- `pre-commit run --files clusters/homelab/apps/deluge/values.yaml docs/knowledge-base/operations/continuous-improvement.md`
- `kubectl kustomize clusters/homelab/apps/deluge`
- `helm template deluge app-template --repo https://bjw-s-labs.github.io/helm-charts --version 4.4.0 -f clusters/homelab/apps/deluge/values.yaml`
- `git diff --check`

Live recovery verification after the incident:

- `deluge-console status` reported 6 torrents, 6 seeding, and 0 errors.
- `deluge_daemon_rpc_healthy` returned `1`.
- `listen_ports` returned `(5983, 5983)`.
- `random_outgoing_ports` returned `True`.
- Gluetun healthcheck passed.


<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

> Live Terragrunt plan skipped because this pull request did not change `IaC/**`, flake inputs, OpenTofu/Terragrunt policy inputs, or live-plan helper scripts.

Rendered Conftest policies still ran for workflows and Kubernetes manifests in this required check.

<!-- terragrunt-plan:end -->
