### PR TITLE
fix: roll octelium public tunnel

### DIFF
--- a/clusters/homelab/apps/octelium-public/deployment.yaml
+++ b/clusters/homelab/apps/octelium-public/deployment.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        homelab.rst.io/cloudflared-config-revision: console-istio-route-quic-api-streams-v1
+        homelab.rst.io/cloudflared-config-revision: tunnel-reconnect-2026-06-18
       labels:
         app.kubernetes.io/name: cloudflared
         app.kubernetes.io/part-of: octelium-public
@@ -36,7 +36,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cloudflared
-          image: cloudflare/cloudflared:2026.6.0@sha256:ba461b8aa9c042156dbd39c38657fe7431bafa063220eab8d5330a523863da9f
+          image: cloudflare/cloudflared:2026.6.1@sha256:6d91c121b803126f7a5344005d17a9324788fc09d305b6e2560ec6040a7ae283
           imagePullPolicy: IfNotPresent
           args:
             - tunnel

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -156,8 +156,8 @@ WEB access separate from the reserved workload WEB-serving rule for
 the public Octelium ingress.
 
 The public Octelium control-plane path is a separate `octelium-public`
-Application. It runs two `cloudflared` replicas in `octelium-public`, reads the
-named tunnel credentials JSON and UUID from
+Application. It runs two digest-pinned `cloudflared` replicas in
+`octelium-public`, reads the named tunnel credentials JSON and UUID from
 `/homelab/octelium/cloudflare-tunnel-credentials-json` and
 `/homelab/octelium/cloudflare-tunnel-id`, and forwards only
 `stinkyboi.com`, `octelium.stinkyboi.com`, `portal.stinkyboi.com`,
@@ -173,7 +173,10 @@ routes through the Istio gateway to the package-owned
 The tunnel transport uses QUIC because the public Octelium API carries
 long-lived gRPC `MainService/Connect` streams; forced HTTP/2 transport
 previously reset those streams after about 125 seconds while short API calls
-continued to pass.
+continued to pass. During the 2026-06-18 public outage, Cloudflare reported
+zero active connections for the named tunnel, so the repo-owned recovery lever
+was a pod-template rollout of `octelium-public` while preserving QUIC and
+UDP/7844.
 Protected ambient workloads allow
 `cluster.local/ns/octelium-client/sa/octelium-client` as a narrow source.
 Octelium Enterprise is tracked separately as the `octeliumee` package at


### PR DESCRIPTION
## Summary
- update the octelium-public cloudflared connector from 2026.6.0 to 2026.6.1 with the pinned manifest-list digest
- bump the pod-template revision annotation so Argo CD rolls the tunnel connector
- record the Cloudflare 1033 / zero-active-connector recovery note in the knowledge base

## Evidence
- Cloudflare returned 1033 for openclaw.stinkyboi.com, octelium-api.stinkyboi.com, portal.stinkyboi.com, and grafana.stinkyboi.com
- cloudflared tunnel info homelab-octelium-public reported zero active connections
- main is protected, so this is published as a focused GitOps PR

## Validation
- kubectl kustomize clusters/homelab/apps/octelium-public
- git diff --check
- pre-commit hooks during signed commit: trim trailing whitespace, end-of-file, large files, YAML, codespell, Checkov Diff, Checkov Secrets

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

> Live Terragrunt plan skipped because this pull request did not change `IaC/**`, flake inputs, OpenTofu/Terragrunt policy inputs, or live-plan helper scripts.

Rendered Conftest policies still ran for workflows and Kubernetes manifests in this required check.

<!-- terragrunt-plan:end -->
