### PR TITLE
fix: render Deluge WireGuard profile IPv4-only

### DIFF
--- a/clusters/homelab/apps/deluge/README.md
+++ b/clusters/homelab/apps/deluge/README.md
@@ -28,8 +28,11 @@ exact AirVPN peer instead of selecting a random AirVPN server from provider
 metadata. Gluetun's custom WireGuard path still requires the endpoint host to
 be an IP address at startup, while AirVPN profiles can contain an endpoint DNS
 name. A `config-wireguard` init container reads the secret profile, resolves a
-DNS endpoint to its first IPv4 address when needed, and writes the normalized
-profile into an in-memory volume mounted at `/gluetun/wireguard/wg0.conf`.
+DNS endpoint to its first IPv4 address when needed, strips IPv6 `Address` and
+`AllowedIPs` entries, and writes the normalized profile into an in-memory
+volume mounted at `/gluetun/wireguard/wg0.conf`. Keep
+`homelab.rst.io/wireguard-profile-renderer-revision` in the pod template so
+renderer-only changes roll the singleton and clear stale Gluetun network rules.
 
 The AirVPN forwarded port is not secret desired state. This deployment uses
 AirVPN forwarded port `5983`; set Deluge's incoming BitTorrent port to that same
@@ -194,3 +197,9 @@ The usual repair is to generate a fresh AirVPN WireGuard profile, replace
 `homelab.rst.io/wireguard-profile-ssm-version` in both `externalsecret.yaml`
 and `values.yaml` so External Secrets renders the new Secret and Argo CD rolls
 the Pod. Do not patch or restart the live Pod as the durable fix.
+
+If Gluetun loops on `adding IPv6 rule ... file exists`, verify the rendered
+profile is still IPv4-only. AirVPN profiles can include IPv6 interface and
+allowed-route entries even when the homelab only needs IPv4; passing those
+through can leave the restartable Gluetun init sidecar stuck in the same pod
+network namespace while Deluge's daemon itself still answers RPC.

--- a/clusters/homelab/apps/deluge/values.yaml
+++ b/clusters/homelab/apps/deluge/values.yaml
@@ -9,6 +9,7 @@ controllers:
       annotations:
         homelab.rst.io/rollout-strategy: "recreate-singleton"
         homelab.rst.io/wireguard-address-mode: "ipv4-only"
+        homelab.rst.io/wireguard-profile-renderer-revision: "strip-ipv6-routes-v1"
         homelab.rst.io/wireguard-profile-ssm-version: "4"
     strategy: Recreate
     initContainers:
@@ -66,15 +67,55 @@ controllers:
                 exit 1
               fi
             fi
-            awk -v replacement="Endpoint = ${endpoint_ip}:${port}" '
+            awk -F= -v replacement="Endpoint = ${endpoint_ip}:${port}" '
+              function trim(value) {
+                gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+                return value
+              }
+
+              function ipv4_cidr_list(value, parts, count, output, item, i) {
+                count = split(value, parts, ",")
+                output = ""
+                for (i = 1; i <= count; i++) {
+                  item = trim(parts[i])
+                  if (item ~ /^[0-9]+([.][0-9]+){3}\/[0-9]+$/) {
+                    output = output (output == "" ? "" : ", ") item
+                  }
+                }
+                return output
+              }
+
               /^[[:space:]]*Endpoint[[:space:]]*=/ && !done {
                 print replacement
                 done=1
                 next
               }
+
+              tolower($1) ~ /^[[:space:]]*address[[:space:]]*$/ {
+                ipv4_addresses = ipv4_cidr_list($2)
+                if (ipv4_addresses == "") {
+                  print "WireGuard config must contain an IPv4 Address entry" > "/dev/stderr"
+                  exit 1
+                }
+                print "Address = " ipv4_addresses
+                address_done=1
+                next
+              }
+
+              tolower($1) ~ /^[[:space:]]*allowedips[[:space:]]*$/ {
+                ipv4_allowed_ips = ipv4_cidr_list($2)
+                if (ipv4_allowed_ips == "") {
+                  print "WireGuard config must contain IPv4 AllowedIPs" > "/dev/stderr"
+                  exit 1
+                }
+                print "AllowedIPs = " ipv4_allowed_ips
+                allowed_ips_done=1
+                next
+              }
+
               { print }
               END {
-                if (!done) {
+                if (!done || !address_done || !allowed_ips_done) {
                   exit 1
                 }
               }

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -56,10 +56,16 @@ updating that SSM value and bumping
 `homelab.rst.io/wireguard-profile-ssm-version` on both the `deluge-vpn`
 ExternalSecret and Deluge pod template so External Secrets rereads SSM and
 Gluetun restarts with the new profile. The pod resolves endpoint DNS names in
-the profile to IPv4 before Gluetun starts. Keep Deluge's AirVPN forwarded port
-fixed only for `listen_ports`; `outgoing_ports` should stay at Deluge's default
-random behavior, otherwise active torrents can report too few outgoing ports
-and fail to establish enough peer connections.
+the profile to IPv4 before Gluetun starts and strips IPv6 `Address` and
+`AllowedIPs` entries so Gluetun does not install IPv6 routing rules in this
+IPv4-only deployment. Keep Deluge's AirVPN forwarded port fixed only for
+`listen_ports`; `outgoing_ports` should stay at Deluge's default random
+behavior, otherwise active torrents can report too few outgoing ports and fail
+to establish enough peer connections.
+If Gluetun loops on `adding IPv6 rule ... file exists`, the public service can
+be down even while `deluged` still answers local RPC; roll a rendered
+IPv4-only profile through the repo-owned pod-template annotations instead of
+only checking torrent status.
 If Kubernetes and Gluetun are healthy but `deluged` loops with
 `libtorrent::libtorrent_exception` and `port-config` gets connection refused,
 check `clusters/homelab/apps/deluge/README.md` for the narrow


### PR DESCRIPTION
## Summary
- strip IPv6 Address and AllowedIPs entries from the rendered Deluge WireGuard profile
- add a renderer revision annotation so Argo rolls the Deluge singleton and clears stale Gluetun network rules
- document the Gluetun IPv6 rule failure mode in the Deluge README and knowledge base

## Validation
- git diff --check
- kubectl kustomize clusters/homelab/apps/deluge
- helm template deluge bjw-s-labs/app-template --version 4.4.0 -f clusters/homelab/apps/deluge/values.yaml
- sanitized awk renderer sample
- pre-commit run --files clusters/homelab/apps/deluge/values.yaml clusters/homelab/apps/deluge/README.md docs/knowledge-base/workloads/application-notes.md

## Incident context
Deluge's daemon RPC was healthy, but the Pod was unavailable because the restartable Gluetun init sidecar looped on `adding IPv6 rule ... file exists`, leaving the Service with no ready endpoint.

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

> Live Terragrunt plan skipped because this pull request did not change `IaC/**`, flake inputs, OpenTofu/Terragrunt policy inputs, or live-plan helper scripts.

Rendered Conftest policies still ran for workflows and Kubernetes manifests in this required check.

<!-- terragrunt-plan:end -->
