### PR TITLE
fix: skip Deluge IPv6-only WireGuard repeats

### DIFF
--- a/clusters/homelab/apps/deluge/values.yaml
+++ b/clusters/homelab/apps/deluge/values.yaml
@@ -93,9 +93,8 @@ controllers:
 
               tolower($1) ~ /^[[:space:]]*address[[:space:]]*$/ {
                 ipv4_addresses = ipv4_cidr_list($2)
-                if (ipv4_addresses == "") {
-                  print "WireGuard config must contain an IPv4 Address entry" > "/dev/stderr"
-                  exit 1
+                if (ipv4_addresses == "" || address_done) {
+                  next
                 }
                 print "Address = " ipv4_addresses
                 address_done=1
@@ -104,9 +103,8 @@ controllers:
 
               tolower($1) ~ /^[[:space:]]*allowedips[[:space:]]*$/ {
                 ipv4_allowed_ips = ipv4_cidr_list($2)
-                if (ipv4_allowed_ips == "") {
-                  print "WireGuard config must contain IPv4 AllowedIPs" > "/dev/stderr"
-                  exit 1
+                if (ipv4_allowed_ips == "" || allowed_ips_done) {
+                  next
                 }
                 print "AllowedIPs = " ipv4_allowed_ips
                 allowed_ips_done=1
@@ -115,7 +113,16 @@ controllers:
 
               { print }
               END {
-                if (!done || !address_done || !allowed_ips_done) {
+                if (!done) {
+                  print "WireGuard config must contain Endpoint = host:port" > "/dev/stderr"
+                  exit 1
+                }
+                if (!address_done) {
+                  print "WireGuard config must contain an IPv4 Address entry" > "/dev/stderr"
+                  exit 1
+                }
+                if (!allowed_ips_done) {
+                  print "WireGuard config must contain IPv4 AllowedIPs" > "/dev/stderr"
                   exit 1
                 }
               }


### PR DESCRIPTION
## Summary
- skip IPv6-only repeated WireGuard Address and AllowedIPs lines after/before an IPv4 value is found
- keep explicit failures when the rendered profile has no Endpoint, IPv4 Address, or IPv4 AllowedIPs

## Validation
- git diff --check
- kubectl kustomize clusters/homelab/apps/deluge
- helm template deluge bjw-s-labs/app-template --version 4.4.0 -f clusters/homelab/apps/deluge/values.yaml
- pre-commit run --files clusters/homelab/apps/deluge/values.yaml
- focused awk sample with repeated IPv6-only Address/AllowedIPs lines

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

> Live Terragrunt plan skipped because this pull request did not change `IaC/**`, flake inputs, OpenTofu/Terragrunt policy inputs, or live-plan helper scripts.

Rendered Conftest policies still ran for workflows and Kubernetes manifests in this required check.

<!-- terragrunt-plan:end -->
