### PR TITLE
fix: recover openclaw discord bootstrap

### DIFF
--- a/clusters/homelab/apps/openclaw/README.md
+++ b/clusters/homelab/apps/openclaw/README.md
@@ -78,9 +78,12 @@ The `openclaw-secrets` ExternalSecret reads the Discord bot token from
 `DISCORD_BOT_TOKEN`.
 
 On pod startup, the `bootstrap-config` init container keeps the Control UI
-origin allow-list current. When `DISCORD_BOT_TOKEN` is populated, it installs
-the official `@openclaw/discord` channel plugin pinned to the running OpenClaw
-image version in pod-local plugin storage, enables the plugin, and stores a
+origin allow-list current. When `DISCORD_BOT_TOKEN` is populated, it first tries
+to install the official `@openclaw/discord` channel plugin pinned to the running
+OpenClaw image version in pod-local plugin storage. If ClawHub has not published
+that exact plugin version yet, bootstrap falls back to the current official
+Discord plugin so the pod can finish starting instead of crash-looping on a
+missing registry version. Bootstrap then enables the plugin and stores a
 SecretRef to the environment-backed token.
 The npm cache and extension directory are intentionally not on the NFS-backed
 state PVC because OpenClaw rejects code plugins owned by the QNAP NFS `nobody`

--- a/clusters/homelab/apps/openclaw/values.yaml
+++ b/clusters/homelab/apps/openclaw/values.yaml
@@ -252,11 +252,15 @@ controllers:
             if [ -z "${DISCORD_BOT_TOKEN:-}" ] || [ "$DISCORD_BOT_TOKEN" = "REPLACE_ME" ]; then
               echo "DISCORD_BOT_TOKEN is not populated; skipping Discord channel bootstrap"
             else
-              echo "DISCORD_BOT_TOKEN is populated; installing the pinned Discord channel plugin"
+              echo "DISCORD_BOT_TOKEN is populated; installing the Discord channel plugin"
               openclaw_version="$(openclaw --version | awk 'NR == 1 { if ($1 == "OpenClaw") print $2; else print $1 }')"
               : "${openclaw_version:?failed to parse OpenClaw version for Discord plugin install}"
-              discord_plugin_spec="clawhub:@openclaw/discord@${openclaw_version}"
-              openclaw plugins install "$discord_plugin_spec" --force
+              pinned_discord_plugin_spec="clawhub:@openclaw/discord@${openclaw_version}"
+              current_discord_plugin_spec="clawhub:@openclaw/discord"
+              if ! openclaw plugins install "$pinned_discord_plugin_spec" --force; then
+                echo "Pinned Discord plugin ${pinned_discord_plugin_spec} is unavailable; falling back to ${current_discord_plugin_spec}"
+                openclaw plugins install "$current_discord_plugin_spec" --force
+              fi
               openclaw plugins enable discord
               openclaw config set --strict-json \
                 channels.discord.enabled \

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -274,13 +274,16 @@ keeps the tailnet Control UI origin allow-list in config and stores
 hook token is populated, bootstrap expands `GRAFANA_ALERT_HOOK_TOKEN` from the
 mounted Secret, JSON-encodes the runtime value, and stores it as a plain string
 because OpenClaw rejects SecretRef objects for that hook-token surface. When
-`/homelab/openclaw/discord-bot-token` has been replaced in SSM, bootstrap
-force-installs the official `@openclaw/discord` plugin pinned to the running
-OpenClaw image version, enables it, and writes a SecretRef to
-`DISCORD_BOT_TOKEN`. The plugin npm cache and extension directory
-are `emptyDir` mounts at `/data/openclaw/npm` and
-`/data/openclaw/extensions` because QNAP NFS maps PVC writes to `nobody`, and
-OpenClaw blocks code plugins with suspicious ownership. ChatGPT Pro access uses
+`/homelab/openclaw/discord-bot-token` has been replaced in SSM, bootstrap first
+tries to force-install the official `@openclaw/discord` plugin pinned to the
+running OpenClaw image version. If ClawHub has not published that exact plugin
+version yet, bootstrap falls back to the current official Discord plugin so a
+registry/version skew does not keep the pod in an init crash loop. Bootstrap
+then enables the plugin and writes a SecretRef to `DISCORD_BOT_TOKEN`. The
+plugin npm cache and extension directory are `emptyDir` mounts at
+`/data/openclaw/npm` and `/data/openclaw/extensions` because QNAP NFS maps PVC
+writes to `nobody`, and OpenClaw blocks code plugins with suspicious ownership.
+ChatGPT Pro access uses
 interactive OpenAI Codex OAuth stored on the PVC; do not model that as an SSM
 secret or committed API key. The bootstrap also enables the bundled `codex`
 plugin and sets the default agent model to `openai/gpt-5.5` with


### PR DESCRIPTION
## Summary
- keep the pinned OpenClaw Discord plugin install as the first bootstrap attempt
- fall back to the current official ClawHub Discord plugin when the exact app-image version is not published
- document the registry/version skew failure mode in the OpenClaw README and knowledge base

## Validation
- git diff --check
- kubectl kustomize clusters/homelab/apps/openclaw
- helm template openclaw bjw-s-labs/app-template --version 4.4.0 -f clusters/homelab/apps/openclaw/values.yaml --namespace ai

## Live evidence
- openclaw.stinkyboi.com, portal.stinkyboi.com, grafana.stinkyboi.com, and policy-bot.stinkyboi.com return Octelium 401, so the public edge is healthy
- cloudflared tunnel info homelab-octelium-public shows two active connectors
- openclaw Deployment is 0/1 because bootstrap-config crash-loops on Version not found on ClawHub: @openclaw/discord@2026.6.6

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

> Live Terragrunt plan skipped because this pull request did not change `IaC/**`, flake inputs, OpenTofu/Terragrunt policy inputs, or live-plan helper scripts.

Rendered Conftest policies still ran for workflows and Kubernetes manifests in this required check.

<!-- terragrunt-plan:end -->
