### PR TITLE
fix: upgrade openclaw plugin api

### DIFF
--- a/clusters/homelab/apps/openclaw/README.md
+++ b/clusters/homelab/apps/openclaw/README.md
@@ -89,6 +89,11 @@ The npm cache and extension directory are intentionally not on the NFS-backed
 state PVC because OpenClaw rejects code plugins owned by the QNAP NFS `nobody`
 mapping.
 
+Keep the OpenClaw image new enough for the current official Discord plugin API.
+The 2026-06-24 recovery moved the app, proxy, and bootstrap images to
+`2026.6.10` because the current ClawHub Discord plugin requires plugin API
+`2026.6.10` or newer and rejected the older `2026.6.6` runtime.
+
 Discord bootstrap is skipped when the SSM value is still `REPLACE_ME`, so the
 app can start before the real Discord bot token exists. After replacing the SSM
 value, bump
@@ -182,7 +187,7 @@ credentials on the OpenClaw PVC.
 
 The pod startup bootstrap enables the bundled `codex` plugin and sets the
 default agent model to `openai/gpt-5.5` with model-scoped
-`agentRuntime.id: "codex"`. OpenClaw 2026.6.1 routes canonical `openai/gpt-*`
+`agentRuntime.id: "codex"`. OpenClaw 2026.6.10 routes canonical `openai/gpt-*`
 agent refs through the Codex app-server harness when that runtime policy is
 selected, so the PVC-backed Codex OAuth profile supplies the ChatGPT Pro auth
 without storing an API key in SSM or git. The older `openai-codex/gpt-*` and

--- a/clusters/homelab/apps/openclaw/values.yaml
+++ b/clusters/homelab/apps/openclaw/values.yaml
@@ -57,7 +57,7 @@ controllers:
       bootstrap-config:
         image:
           repository: ghcr.io/openclaw/openclaw
-          tag: "2026.6.6@sha256:4826ca6157377e93463786d5c16852e34eede9f4bd4be55e3773cdc509762857"
+          tag: "2026.6.10@sha256:af7ea052cf216f581fb18fabada01552356c53717461c0399b623cba7ecad4b1"
         resources:
           requests:
             cpu: 500m
@@ -275,7 +275,7 @@ controllers:
       app:
         image:
           repository: ghcr.io/openclaw/openclaw
-          tag: "2026.6.6@sha256:4826ca6157377e93463786d5c16852e34eede9f4bd4be55e3773cdc509762857"
+          tag: "2026.6.10@sha256:af7ea052cf216f581fb18fabada01552356c53717461c0399b623cba7ecad4b1"
         env:
           OPENCLAW_HOME: /data/openclaw
           OPENCLAW_CONFIG_PATH: /data/openclaw/config/openclaw.json
@@ -335,7 +335,7 @@ controllers:
       proxy:
         image:
           repository: ghcr.io/openclaw/openclaw
-          tag: "2026.6.6@sha256:4826ca6157377e93463786d5c16852e34eede9f4bd4be55e3773cdc509762857"
+          tag: "2026.6.10@sha256:af7ea052cf216f581fb18fabada01552356c53717461c0399b623cba7ecad4b1"
         command:
           - python3
           - -u

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -283,11 +283,17 @@ then enables the plugin and writes a SecretRef to `DISCORD_BOT_TOKEN`. The
 plugin npm cache and extension directory are `emptyDir` mounts at
 `/data/openclaw/npm` and `/data/openclaw/extensions` because QNAP NFS maps PVC
 writes to `nobody`, and OpenClaw blocks code plugins with suspicious ownership.
+
+Keep the OpenClaw image new enough for the current official Discord plugin API:
+the 2026-06-24 recovery moved the app, proxy, and bootstrap images to
+`2026.6.10` because ClawHub's current Discord plugin requires plugin API
+`2026.6.10` or newer and rejected the older `2026.6.6` runtime.
+
 ChatGPT Pro access uses
 interactive OpenAI Codex OAuth stored on the PVC; do not model that as an SSM
 secret or committed API key. The bootstrap also enables the bundled `codex`
 plugin and sets the default agent model to `openai/gpt-5.5` with
-`agentRuntime.id: "codex"` on that model. OpenClaw 2026.6.1 treats canonical
+`agentRuntime.id: "codex"` on that model. OpenClaw 2026.6.10 treats canonical
 `openai/gpt-*` agent refs plus the Codex runtime policy as the subscription
 backed app-server route; legacy `openai-codex/gpt-*` and `codex/gpt-*` refs are
 not the desired bootstrap default. The bootstrap enables the bundled


### PR DESCRIPTION
## Summary
- upgrade OpenClaw bootstrap, app, and proxy images from 2026.6.6 to 2026.6.10
- pin the 2026.6.10 image index digest verified from GHCR
- document that the current official Discord plugin requires plugin API 2026.6.10 or newer

## Validation
- docker buildx imagetools inspect ghcr.io/openclaw/openclaw:2026.6.10
- git diff --check
- kubectl kustomize clusters/homelab/apps/openclaw
- helm template openclaw bjw-s-labs/app-template --version 4.4.0 -f clusters/homelab/apps/openclaw/values.yaml --namespace ai

## Live evidence
- PR #523 reached the fallback path, but bootstrap still failed because current @openclaw/discord requires plugin API >=2026.6.10 while OpenClaw 2026.6.6 exposes 2026.6.6
- the OpenClaw Application is synced to PR #523 and still Progressing because bootstrap-config is restarting on that plugin API mismatch

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

> Live Terragrunt plan skipped because this pull request did not change `IaC/**`, flake inputs, OpenTofu/Terragrunt policy inputs, or live-plan helper scripts.

Rendered Conftest policies still ran for workflows and Kubernetes manifests in this required check.

<!-- terragrunt-plan:end -->
