### PR TITLE
fix(cordium): allow genesis to create managed rbac

### DIFF
--- a/clusters/homelab/apps/cordium/README.md
+++ b/clusters/homelab/apps/cordium/README.md
@@ -20,8 +20,11 @@ long-running Cordium `nocturne` and `rscserver` Deployments and registers the
 `apiserver` and `portal` managed services with Octelium. The image declares the
 non-root user by name, so the hook pins `runAsUser: 100` and
 `runAsGroup: 65533` to satisfy kubelet's `runAsNonRoot` verification. The
-Argo CD app keeps the hook and RBAC visible in git; the generated
-Octelium/Cordium runtime resources remain owned by Octelium controllers.
+bootstrap service account also needs Kubernetes' `bind` and `escalate` RBAC
+verbs because upstream genesis creates ClusterRoles with permissions the
+service account does not otherwise hold directly. The Argo CD app keeps the
+hook and RBAC visible in git; the generated Octelium/Cordium runtime resources
+remain owned by Octelium controllers.
 
 ## Activation
 

--- a/clusters/homelab/apps/cordium/genesis.yaml
+++ b/clusters/homelab/apps/cordium/genesis.yaml
@@ -17,6 +17,8 @@ metadata:
     app.kubernetes.io/name: cordium
     app.kubernetes.io/component: genesis
     app.kubernetes.io/part-of: homelab
+  annotations:
+    checkov.io/skip1: CKV_K8S_158=Upstream Cordium genesis creates its managed ClusterRoles and needs Kubernetes RBAC escalation only for bootstrap.
 rules:
   - apiGroups:
       - ""
@@ -56,6 +58,14 @@ rules:
       - create
       - update
       - patch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterroles
+      - roles
+    verbs:
+      - bind
+      - escalate
   - apiGroups:
       - rbac.authorization.k8s.io
     resources:
@@ -112,7 +122,7 @@ metadata:
     checkov.io/skip2: CKV_K8S_38=The bootstrap job needs a Kubernetes service-account token to create Cordium controller resources.
     checkov.io/skip3: CKV_K8S_40=The upstream image runs as its bundled non-root octelium user with UID 100.
     checkov.io/skip4: CKV2_K8S_6=cordium-genesis is covered by networkpolicy.yaml; diff-only scans do not include sibling manifests.
-    homelab.rst.io/cordium-genesis-revision: "2"
+    homelab.rst.io/cordium-genesis-revision: "3"
 spec:
   backoffLimit: 2
   ttlSecondsAfterFinished: 86400
@@ -123,7 +133,7 @@ spec:
         app.kubernetes.io/component: genesis
         app.kubernetes.io/part-of: homelab
       annotations:
-        homelab.rst.io/cordium-genesis-revision: "2"
+        homelab.rst.io/cordium-genesis-revision: "3"
     spec:
       serviceAccountName: cordium-genesis
       restartPolicy: OnFailure

--- a/docs/knowledge-base/runbooks/octelium.md
+++ b/docs/knowledge-base/runbooks/octelium.md
@@ -396,3 +396,8 @@ Cordium genesis `0.12.7` uses the named image user `octelium`. Kubelet cannot
 prove a named user is non-root when `runAsNonRoot` is set, so the hook pins the
 image's numeric identity (`runAsUser: 100`, `runAsGroup: 65533`) and bumps
 `homelab.rst.io/cordium-genesis-revision` when the hook must be recreated.
+The genesis service account also needs the RBAC special verbs `bind` and
+`escalate` on Roles and ClusterRoles because upstream genesis creates privileged
+Cordium ClusterRoles such as `cordium-nocturne`; without those verbs, Kubernetes
+blocks the install with a privilege-escalation error before the Cordium
+controllers are created.


### PR DESCRIPTION
## Summary
- grant Cordium genesis the Kubernetes RBAC bind/escalate verbs needed to create upstream managed ClusterRoles
- bump the genesis hook revision so Argo recreates the Job after merge
- document the bootstrap RBAC requirement in the Cordium README and Octelium runbook

## Validation
- kubectl kustomize clusters/homelab/apps/cordium
- git diff --check
- pre-commit hooks during signed commit: check yaml, codespell, Checkov Diff, Checkov Secrets

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

> Live Terragrunt plan skipped because this pull request did not change `IaC/**`, flake inputs, OpenTofu/Terragrunt policy inputs, or live-plan helper scripts.

Rendered Conftest policies still ran for workflows and Kubernetes manifests in this required check.

<!-- terragrunt-plan:end -->
