### PR TITLE
fix(radarr): harden auth config normalization

### DIFF
--- a/clusters/homelab/apps/radarr/README.md
+++ b/clusters/homelab/apps/radarr/README.md
@@ -28,16 +28,16 @@ Secrets. Do not commit it to this repository.
 
 The startup `configure-postgres` init container also sets
 `<AuthenticationMethod>External</AuthenticationMethod>` and
-`<AuthenticationType>DisabledForLocalAddresses</AuthenticationType>` plus
 `<AuthenticationRequired>DisabledForLocalAddresses</AuthenticationRequired>` in
-`/config/config.xml`. The Servarr FAQ documents `AuthenticationType` as the
-config-file equivalent for this setting, while the environment variable table
-uses `AuthenticationRequired`, so the startup reset writes both names.
+`/config/config.xml`. The init container removes stale
+`AuthenticationEnabled` and `AuthenticationType` entries first, then rewrites
+the target tags so exactly one copy remains. This matters because old
+`AuthenticationEnabled=true` config forces Forms authentication before Radarr
+reads `AuthenticationMethod`, and duplicate XML tags are treated by Radarr as
+missing values.
+
 The Radarr app container also sets `RADARR__AUTH__METHOD=External` and
-`RADARR__AUTH__REQUIRED=DisabledForLocalAddresses`, because Radarr environment
-variables override persisted `config.xml` entries at startup and keep the
-running process aligned if the PVC copy drifts back to Forms authentication or
-password-required mode.
+`RADARR__AUTH__REQUIRED=DisabledForLocalAddresses` as a secondary runtime guard.
 Radarr targets Octelium as the external access boundary. The stable
 `https://radarr.stinkyboi.com` hostname resolves to the Octelium service
 address, Funnel stays disabled, and Radarr's own password prompt is
@@ -50,6 +50,22 @@ authentication or add a dedicated forward auth layer before rollout. Upstream
 documents `External` as the config-file-only mode for deployments protected by
 external authentication:
 <https://wiki.servarr.com/radarr/faq#authentication-method>.
+
+The app has startup, readiness, and liveness probes against
+`/initialize.json`. That endpoint is the UI bootstrap path and includes the
+runtime API key in its response body, so validation commands must discard the
+body:
+
+```sh
+kubectl -n media exec deploy/radarr -c app -- \
+  sh -c 'curl -fsS -o /dev/null http://127.0.0.1:7878/initialize.json'
+kubectl -n media exec deploy/radarr -c app -- \
+  sh -c 'grep -nE "<Authentication(Enabled|Method|Required|Type)>" /config/config.xml || true'
+```
+
+Expected config output contains only one `AuthenticationMethod=External` line
+and one `AuthenticationRequired=DisabledForLocalAddresses` line. Do not print
+`/initialize.json`; it contains the live Radarr API key.
 
 ## Media Storage
 

--- a/clusters/homelab/apps/radarr/values.yaml
+++ b/clusters/homelab/apps/radarr/values.yaml
@@ -33,23 +33,75 @@ controllers:
                   -e "s/'/\&apos;/g"
             }
 
-            set_config_tag() {
+            remove_config_tag() {
               tag="$1"
-              value="$(xml_escape "$2")"
-              awk -v tag="$tag" -v value="$value" '
-                BEGIN { found = 0 }
-                $0 ~ "<" tag ">" {
-                  print "  <" tag ">" value "</" tag ">"
-                  found = 1
+              awk -v tag="$tag" '
+                $0 ~ "^[[:space:]]*<" tag ">.*</" tag ">[[:space:]]*$" {
                   next
-                }
-                $0 ~ "</Config>" && found == 0 {
-                  print "  <" tag ">" value "</" tag ">"
-                  found = 1
                 }
                 { print }
               ' "$config" > "$tmp"
               cat "$tmp" > "$config"
+            }
+
+            set_config_tag() {
+              tag="$1"
+              value="$(xml_escape "$2")"
+              awk -v tag="$tag" -v value="$value" '
+                BEGIN { inserted = 0 }
+                $0 ~ "^[[:space:]]*<" tag ">.*</" tag ">[[:space:]]*$" {
+                  next
+                }
+                $0 ~ "^[[:space:]]*</Config>[[:space:]]*$" {
+                  print "  <" tag ">" value "</" tag ">"
+                  inserted = 1
+                }
+                { print }
+                END {
+                  if (inserted == 0) {
+                    exit 1
+                  }
+                }
+              ' "$config" > "$tmp"
+              cat "$tmp" > "$config"
+            }
+
+            assert_single_config_tag() {
+              tag="$1"
+              expected="$2"
+              total="$(awk -v tag="$tag" '
+                $0 ~ "^[[:space:]]*<" tag ">.*</" tag ">[[:space:]]*$" { count++ }
+                END { print count + 0 }
+              ' "$config")"
+              matches="$(awk -v tag="$tag" -v expected="$expected" '
+                $0 ~ "^[[:space:]]*<" tag ">.*</" tag ">[[:space:]]*$" {
+                  value = $0
+                  sub("^[[:space:]]*<" tag ">", "", value)
+                  sub("</" tag ">[[:space:]]*$", "", value)
+                  if (value == expected) {
+                    count++
+                  }
+                }
+                END { print count + 0 }
+              ' "$config")"
+
+              if [ "$total" -ne 1 ] || [ "$matches" -ne 1 ]; then
+                echo "Radarr config.xml must contain exactly one ${tag}=${expected}; found ${matches}/${total}" >&2
+                exit 1
+              fi
+            }
+
+            assert_absent_config_tag() {
+              tag="$1"
+              total="$(awk -v tag="$tag" '
+                $0 ~ "^[[:space:]]*<" tag ">.*</" tag ">[[:space:]]*$" { count++ }
+                END { print count + 0 }
+              ' "$config")"
+
+              if [ "$total" -ne 0 ]; then
+                echo "Radarr config.xml must not contain legacy ${tag}; found ${total}" >&2
+                exit 1
+              fi
             }
 
             : "${RADARR_POSTGRES_HOST:?}"
@@ -74,9 +126,18 @@ controllers:
             set_config_tag PostgresHost "$RADARR_POSTGRES_HOST"
             set_config_tag PostgresMainDb "$RADARR_POSTGRES_MAIN_DB"
             set_config_tag PostgresLogDb "$RADARR_POSTGRES_LOG_DB"
+
+            # AuthenticationEnabled is a legacy switch that forces Forms auth
+            # before Radarr reads AuthenticationMethod. AuthenticationType is a
+            # retired/incorrect auth-required key. Keep both out of the PVC.
+            remove_config_tag AuthenticationEnabled
+            remove_config_tag AuthenticationType
             set_config_tag AuthenticationMethod External
-            set_config_tag AuthenticationType DisabledForLocalAddresses
             set_config_tag AuthenticationRequired DisabledForLocalAddresses
+            assert_absent_config_tag AuthenticationEnabled
+            assert_absent_config_tag AuthenticationType
+            assert_single_config_tag AuthenticationMethod External
+            assert_single_config_tag AuthenticationRequired DisabledForLocalAddresses
         securityContext:
           runAsGroup: 1000
           runAsUser: 1000
@@ -92,6 +153,43 @@ controllers:
           DELUGE_URL: http://deluge.media.svc.cluster.local:8112
           RADARR__AUTH__METHOD: External
           RADARR__AUTH__REQUIRED: DisabledForLocalAddresses
+        probes:
+          startup:
+            enabled: true
+            custom: true
+            spec:
+              exec:
+                command:
+                  - /bin/sh
+                  - -ec
+                  - curl -fsS -o /dev/null http://127.0.0.1:7878/initialize.json
+              failureThreshold: 36
+              periodSeconds: 5
+              timeoutSeconds: 5
+          readiness:
+            enabled: true
+            custom: true
+            spec:
+              exec:
+                command:
+                  - /bin/sh
+                  - -ec
+                  - curl -fsS -o /dev/null http://127.0.0.1:7878/initialize.json
+              failureThreshold: 3
+              periodSeconds: 10
+              timeoutSeconds: 5
+          liveness:
+            enabled: true
+            custom: true
+            spec:
+              exec:
+                command:
+                  - /bin/sh
+                  - -ec
+                  - curl -fsS -o /dev/null http://127.0.0.1:7878/initialize.json
+              failureThreshold: 3
+              periodSeconds: 30
+              timeoutSeconds: 5
 service:
   app:
     controller: radarr

--- a/docs/knowledge-base/runbooks/validation.md
+++ b/docs/knowledge-base/runbooks/validation.md
@@ -70,6 +70,13 @@ Sonarr, Radarr, and Prowlarr also wait for `media-postgres` and Servarr
 PostgreSQL fields. n8n also waits for `n8n-postgres`, the
 `n8n-postgres-auth` and `n8n-postgres-client` ExternalSecrets, and an
 authenticated `n8n` database connection before the app is considered ready.
+Radarr has an extra lockout check: `config.xml` must contain exactly one
+`AuthenticationMethod=External` entry and one
+`AuthenticationRequired=DisabledForLocalAddresses` entry, with no legacy
+`AuthenticationEnabled` or retired `AuthenticationType` entries. Probe
+`/initialize.json` with the body discarded because the response contains the
+live API key; a direct `/api/v3/...` request without that key can still return
+`401` normally.
 
 ## Common Stop Conditions
 

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -459,11 +459,16 @@ their library mounts now target the QNAP `/media` export: Radarr uses
 `media-downloads` at `/downloads`. The old dynamic media PVCs stay declared as
 migration sources until the `/media` copy is verified.
 
-Radarr uses `AuthenticationMethod=External` in `/config/config.xml`, managed by
-the startup init container in `clusters/homelab/apps/radarr/values.yaml`.
-Octelium is the target access boundary, with Funnel disabled. This avoids
-recurring Radarr password lockouts from internal auth drift while keeping
-browser access behind a reviewed private access layer.
+Radarr uses `AuthenticationMethod=External` and
+`AuthenticationRequired=DisabledForLocalAddresses` in `/config/config.xml`,
+managed by the startup init container in
+`clusters/homelab/apps/radarr/values.yaml`. The init container removes legacy
+`AuthenticationEnabled` and retired `AuthenticationType` entries, rewrites the
+target tags so only one copy remains, and asserts the final non-secret auth
+state. This avoids recurring Radarr password lockouts from old Forms-auth
+flags or duplicate XML tags while keeping browser access behind Octelium, with
+Funnel disabled. The Radarr probes check `/initialize.json` with the response
+body discarded because that endpoint includes the live API key.
 
 ## Tailscale
 

--- a/docs/validation-runbook.md
+++ b/docs/validation-runbook.md
@@ -144,6 +144,23 @@ the persistent `/config/config.xml` contains the Servarr-documented
 `PostgresMainDb`, and `PostgresLogDb` entries before running any SQLite
 migration.
 
+For Radarr access lockout checks, validate that the auth-normalized
+`config.xml` contains exactly one `AuthenticationMethod=External` entry and
+one `AuthenticationRequired=DisabledForLocalAddresses` entry, with no
+`AuthenticationEnabled` or `AuthenticationType` entries. Also verify the UI
+bootstrap endpoint returns success while discarding the response body:
+
+```sh
+kubectl -n media exec deploy/radarr -c app -- \
+  sh -c 'grep -nE "<Authentication(Enabled|Method|Required|Type)>" /config/config.xml || true'
+kubectl -n media exec deploy/radarr -c app -- \
+  sh -c 'curl -fsS -o /dev/null http://127.0.0.1:7878/initialize.json'
+```
+
+Do not print `/initialize.json`; it contains the live Radarr API key. A bare
+`/api/v3/...` request without that key may still return `401` and is not, by
+itself, a lockout signal.
+
 n8n must also wait for `n8n-postgres` to sync and become healthy. Verify the
 `n8n-postgres-auth` and `n8n-postgres-client` ExternalSecrets, the StatefulSet,
 the PVC, and an authenticated connection to the `n8n` database documented in


### PR DESCRIPTION
## Summary
- normalize Radarr config.xml auth tags by removing legacy AuthenticationEnabled and retired AuthenticationType entries
- rewrite auth tags so exactly one AuthenticationMethod=External and one AuthenticationRequired=DisabledForLocalAddresses remain
- add Radarr UI bootstrap probes and document safe validation without printing initialize.json

## Validation
- kubectl kustomize clusters/homelab/apps/radarr
- helm template radarr app-template --repo https://bjw-s-labs.github.io/helm-charts --version 4.4.0 -f clusters/homelab/apps/radarr/values.yaml
- git diff --check -- clusters/homelab/apps/radarr/values.yaml clusters/homelab/apps/radarr/README.md docs/knowledge-base/runbooks/validation.md docs/knowledge-base/workloads/application-notes.md docs/validation-runbook.md
- bash scripts/ci/static-checks.sh
- bash scripts/ci/conftest-policies.sh

Note: nix is not installed in this local shell, so I ran the static checks directly.

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

> Live Terragrunt plan skipped because this pull request did not change `IaC/**`, flake inputs, OpenTofu/Terragrunt policy inputs, or live-plan helper scripts.

Rendered Conftest policies still ran for workflows and Kubernetes manifests in this required check.

<!-- terragrunt-plan:end -->
