### PR TITLE
fix: tighten octelium e2e callback probes

### DIFF
--- a/docs/knowledge-base/operations/validation-gates.md
+++ b/docs/knowledge-base/operations/validation-gates.md
@@ -102,7 +102,9 @@ Octelium clientless WEB access. App hostnames must not resolve to private
 Octelium service IPs or the old Tailscale wildcard. The same script probes the
 reviewed callback hostnames for public DNS and path-limited reachability; the
 n8n expected-negative webhook probe must see an n8n webhook response body, not
-only a generic HTTP 404 from Cloudflare or the Istio gateway.
+only a generic HTTP 404 from Cloudflare or the Istio gateway, while the Policy
+Bot webhook probe must use the POST shape GitHub sends and require the app-level
+HTTP 400 webhook validation response, not just any non-404 response.
 
 Rendered Kubernetes policy also enforces the access contract:
 `policy/kubernetes.rego` rejects Tailscale Funnel, requires public

--- a/scripts/octelium-e2e-check.sh
+++ b/scripts/octelium-e2e-check.sh
@@ -115,8 +115,8 @@ sonarr.stinkyboi.com
 "
 
 CALLBACK_PROBES="
-n8n-webhook.stinkyboi.com /webhook/__octelium_e2e_missing__ expect-n8n-404
-policy-bot-hook.stinkyboi.com /api/github/hook no-404
+n8n-webhook.stinkyboi.com /webhook/__octelium_e2e_missing__ expect-n8n-404 GET
+policy-bot-hook.stinkyboi.com /api/github/hook expect-policy-bot-400 POST
 "
 
 REQUIRED_SERVICES="
@@ -194,7 +194,7 @@ kubectl_octelium() {
 }
 
 octeliumctl_cluster() {
-  octeliumctl --domain "${DOMAIN}" "$@"
+  octeliumctl "$@" --domain "${DOMAIN}"
 }
 
 run_with_timeout() {
@@ -485,8 +485,9 @@ while read -r HOST; do
 done <<<"${APP_HOSTS}"
 
 note "Checking public callback hostnames"
-while read -r HOST CALLBACK_PATH MODE; do
+while read -r HOST CALLBACK_PATH MODE METHOD; do
     [ -n "${HOST}" ] || continue
+    METHOD="${METHOD:-GET}"
     HEADER_FILE="$(mktemp "${TMPDIR:-/tmp}/octelium-callback-headers.XXXXXX")"
     BODY_FILE="$(mktemp "${TMPDIR:-/tmp}/octelium-callback-body.XXXXXX")"
     CURL_ERR="$(mktemp "${TMPDIR:-/tmp}/octelium-callback-curl.XXXXXX")"
@@ -516,7 +517,7 @@ while read -r HOST CALLBACK_PATH MODE; do
     fi
 
     CURL_OUT="$(
-      curl -sS --max-time 20 -D "${HEADER_FILE}" -o "${BODY_FILE}" -w '%{http_code} %{remote_ip}' "https://${HOST}${CALLBACK_PATH}" 2>"${CURL_ERR}" || true
+      curl -sS -X "${METHOD}" --max-time 20 -D "${HEADER_FILE}" -o "${BODY_FILE}" -w '%{http_code} %{remote_ip}' "https://${HOST}${CALLBACK_PATH}" 2>"${CURL_ERR}" || true
     )"
     HTTP_CODE="${CURL_OUT%% *}"
     REMOTE_IP="${CURL_OUT#* }"
@@ -524,20 +525,28 @@ while read -r HOST CALLBACK_PATH MODE; do
 
     case "${HTTP_CODE}" in
       200|204|301|302|307|308|400|401|403|405)
-        pass "https://${HOST}${CALLBACK_PATH} reached the callback route with HTTP ${HTTP_CODE}"
+        if [ "${MODE}" = "expect-policy-bot-400" ]; then
+          if [ "${HTTP_CODE}" = "400" ]; then
+            pass "${METHOD} https://${HOST}${CALLBACK_PATH} reached the Policy Bot webhook handler with HTTP 400"
+          else
+            fail "${METHOD} https://${HOST}${CALLBACK_PATH} returned HTTP ${HTTP_CODE}; expected Policy Bot webhook validation HTTP 400"
+          fi
+        else
+          pass "${METHOD} https://${HOST}${CALLBACK_PATH} reached the callback route with HTTP ${HTTP_CODE}"
+        fi
         ;;
       404)
         if [ "${MODE}" = "expect-n8n-404" ] && grep -qi 'webhook' "${BODY_FILE}"; then
-          pass "https://${HOST}${CALLBACK_PATH} reached the callback host with expected app-level HTTP 404"
+          pass "${METHOD} https://${HOST}${CALLBACK_PATH} reached the callback host with expected app-level HTTP 404"
         else
-          fail "https://${HOST}${CALLBACK_PATH} returned HTTP 404 without an expected app response; the callback route may be hitting an edge or gateway catch-all"
+          fail "${METHOD} https://${HOST}${CALLBACK_PATH} returned HTTP 404 without an expected app response; the callback route may be hitting an edge or gateway catch-all"
         fi
         ;;
       000|"")
-        fail "https://${HOST}${CALLBACK_PATH} did not respond publicly; curl: $(tr '\n' ' ' <"${CURL_ERR}")"
+        fail "${METHOD} https://${HOST}${CALLBACK_PATH} did not respond publicly; curl: $(tr '\n' ' ' <"${CURL_ERR}")"
         ;;
       *)
-        fail "https://${HOST}${CALLBACK_PATH} returned unexpected HTTP ${HTTP_CODE} from ${REMOTE_IP:-unknown} server ${SERVER:-unknown}"
+        fail "${METHOD} https://${HOST}${CALLBACK_PATH} returned unexpected HTTP ${HTTP_CODE} from ${REMOTE_IP:-unknown} server ${SERVER:-unknown}"
         ;;
     esac
 


### PR DESCRIPTION
## Summary
- make Octelium e2e callback probes method-aware so n8n uses GET and Policy Bot uses the POST shape GitHub sends
- pass the Octelium CLI domain flag after the get command for this local v0.35 CLI behavior
- document the validation expectation in the knowledge base

## Validation
- bash -n scripts/octelium-e2e-check.sh
- git diff --check
- bash scripts/ci/static-checks.sh (passes; local gitleaks unavailable and Checkov guideline DNS warnings only)
- bash scripts/ci/conftest-policies.sh
- live patched e2e route checks pass for app hosts and callback hosts; remaining catalog failures require an authenticated Octelium admin session

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

> Live Terragrunt plan skipped because this pull request did not change `IaC/**`, flake inputs, OpenTofu/Terragrunt policy inputs, or live-plan helper scripts.

Rendered Conftest policies still ran for workflows and Kubernetes manifests in this required check.

<!-- terragrunt-plan:end -->
