### PR TITLE
fix(n8n): allow authenticated self-api calls

### DIFF
--- a/clusters/homelab/apps/n8n/README.md
+++ b/clusters/homelab/apps/n8n/README.md
@@ -29,6 +29,10 @@ persisted settings file instead of crashlooping on an accidental mismatch.
 
 - Editor/UI target: `https://n8n.stinkyboi.com` through Octelium service
   `n8n.homelab`
+- Internal self-API base URL:
+  `http://n8n.automation.svc.cluster.local:5678/api/v1`, allowed only from the
+  `automation/n8n` service account and still protected by n8n API-key
+  authentication
 - Public webhook host:
   `https://n8n-webhook.stinkyboi.com` through the `octelium-public` tunnel
 - Public webhook paths: `/webhook`, `/webhook-test`, and `/webhook-waiting`
@@ -40,6 +44,16 @@ callback. The public callback route is a narrow Istio `VirtualService` reached
 through the repo-owned `octelium-public` Cloudflare Tunnel connector. It routes
 only the webhook path prefixes to the n8n service. Do not add the root path,
 editor routes, static assets, or API routes to the public callback host.
+
+Workflows that use the n8n API to call this same instance must use the internal
+self-API URL. The Kubernetes Service serves plain HTTP on port `5678`; TLS is
+terminated on the ingress path, so `https://n8n.automation.svc.cluster.local`
+will fail. The external editor URL is also unsuitable for unattended API
+calls because Octelium correctly requires an interactive user session. The
+workload AuthorizationPolicy therefore permits the `automation/n8n` principal
+to traverse the Service back to itself without widening access to other
+workload identities.
+
 After rollout, update external callers that still use the retired
 `n8n-webhook.tail67beb.ts.net` Funnel URL to the new
 `n8n-webhook.stinkyboi.com` host.
@@ -62,6 +76,11 @@ credentials before rollout if the existing SQLite contents must be preserved.
 kubectl kustomize clusters/homelab/apps/n8n
 kubectl -n automation get deploy/n8n svc/n8n externalsecret/n8n-secrets
 kubectl -n automation get virtualservice/n8n-octelium virtualservice/n8n-webhook-octelium
+kubectl -n automation exec deploy/n8n -c app -- \
+  node -e '
+    fetch("http://n8n.automation.svc.cluster.local:5678/healthz")
+      .then((response) => console.log(response.status));
+  '
 kubectl -n octelium-public get deploy cloudflared
 curl -I https://n8n.stinkyboi.com/
 curl -sS -D /tmp/n8n-webhook-headers.txt -o /tmp/n8n-webhook-body.txt -w '%{http_code}\n' https://n8n-webhook.stinkyboi.com/webhook/__missing__
@@ -73,7 +92,8 @@ callback host reaches n8n only under the webhook prefixes, and an unknown
 webhook path returns an n8n not-found response until a workflow registers that
 webhook. A generic 404 without n8n webhook text means the request may still be
 stopping at the Cloudflare tunnel catch-all or Istio gateway instead of the n8n
-backend.
+backend. The internal health request from the n8n pod should print `200` after
+the AuthorizationPolicy syncs.
 
 ## Rollback
 
@@ -83,4 +103,6 @@ editor host if webhook publishing is no longer desired. Then sync the n8n Argo
 CD Application and remove `n8n-webhook.stinkyboi.com` from the
 `octelium-public` tunnel/DNS reconciler in the same PR. Preserve both the n8n
 PVC and `n8n-postgres` PVC unless the operator explicitly chooses to rebuild
-from exports.
+from exports. To roll back internal self-API access alone, remove the
+`cluster.local/ns/automation/sa/n8n` principal and sync n8n; workflows using
+the self-API URL will fail again, but no persisted data is changed.

--- a/clusters/homelab/apps/n8n/authorizationpolicy.yaml
+++ b/clusters/homelab/apps/n8n/authorizationpolicy.yaml
@@ -14,3 +14,4 @@ spec:
             principals:
               - cluster.local/ns/istio-system/sa/istio-ingressgateway
               - cluster.local/ns/octelium-client/sa/octelium-client
+              - cluster.local/ns/automation/sa/n8n

--- a/docs/knowledge-base/runbooks/runtime-isolation.md
+++ b/docs/knowledge-base/runbooks/runtime-isolation.md
@@ -53,3 +53,9 @@ Octelium-serving paths use Istio `AuthorizationPolicy` for ambient-enrolled
 destinations and Kubernetes `NetworkPolicy` intent for workloads that already
 have NetworkPolicy manifests. The Octelium connector should stay scoped to the
 explicit service catalog in `docs/examples/octelium/homelab-services.yaml`.
+
+n8n additionally allows its own
+`cluster.local/ns/automation/sa/n8n` principal so authenticated workflows can
+call `http://n8n.automation.svc.cluster.local:5678/api/v1` without routing an
+unattended request through Octelium. This is a self-call exception, not a
+general namespace allow.

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -393,8 +393,12 @@ stable editor URL remains `https://n8n.stinkyboi.com`. It advertises workflow
 webhook URLs through `https://n8n-webhook.stinkyboi.com`. The public callback
 route is limited to `/webhook`, `/webhook-test`, and `/webhook-waiting`, and
 forwards through the `octelium-public` tunnel and Istio ingress gateway so the
-n8n workload AuthorizationPolicy can continue allowing only the gateway service
-account.
+n8n workload AuthorizationPolicy can keep public traffic limited to the gateway
+service account. Authenticated workflows that call the same n8n instance use
+`http://n8n.automation.svc.cluster.local:5678/api/v1`; the policy separately
+allows only `cluster.local/ns/automation/sa/n8n` for that self-call path. The
+Service is plain HTTP because TLS terminates at ingress, and the external editor
+URL requires interactive Octelium authentication.
 
 ## Policy Bot
 

--- a/docs/knowledge-base/workloads/inventory.md
+++ b/docs/knowledge-base/workloads/inventory.md
@@ -50,7 +50,7 @@ utility, not as an app, callback, or CI access path.
 | `sonarr` | `media` | `clusters/homelab/apps/sonarr` | `IaC/live/argocd-apps/sonarr` | persistent config and PostgreSQL databases on `nfs-default`; TV and downloads on QNAP `/media` | cert-manager, istio, deluge, media-postgres, prowlarr, platform-storage |
 | `litellm` | `ai` | `clusters/homelab/apps/litellm` | `IaC/live/argocd-apps/litellm` | optional persistent config or DB state | external-secrets, cert-manager, istio, platform-storage |
 | `openclaw` | `ai` | `clusters/homelab/apps/openclaw` | `IaC/live/argocd-apps/openclaw` | persistent runtime state, SSM-backed gateway auth, Discord channel config, SSM-backed GitHub App credentials, Codex OAuth credentials on PVC, and explicit agent resource profile | external-secrets, cert-manager, istio, litellm, platform-storage |
-| `n8n` | `automation` | `clusters/homelab/apps/n8n` | `IaC/live/argocd-apps/n8n` | persistent workflows, credential metadata, users, and execution history in n8n-postgres; instance settings and file-backed runtime data on PVC; SSM key bootstraps fresh PVCs only; public callbacks use `https://n8n-webhook.stinkyboi.com` through `octelium-public` and are limited to webhook prefixes | external-secrets, cert-manager, istio, platform-storage, n8n-postgres |
+| `n8n` | `automation` | `clusters/homelab/apps/n8n` | `IaC/live/argocd-apps/n8n` | persistent workflows, credential metadata, users, and execution history in n8n-postgres; instance settings and file-backed runtime data on PVC; SSM key bootstraps fresh PVCs only; public callbacks use `https://n8n-webhook.stinkyboi.com` through `octelium-public` and are limited to webhook prefixes; authenticated self-API calls use the plain-HTTP in-cluster Service and are limited to the n8n workload identity | external-secrets, cert-manager, istio, platform-storage, n8n-postgres |
 | `policy-bot` | `automation` | `clusters/homelab/apps/policy-bot` | `IaC/live/argocd-apps/policy-bot` | stateless GitHub App policy evaluator; one replica after SSM placeholders are replaced; GitHub webhooks use `https://policy-bot-hook.stinkyboi.com/api/github/hook` through `octelium-public` | external-secrets, cert-manager, istio |
 | `octobot` | `finance` | `clusters/homelab/apps/octobot` | `IaC/live/argocd-apps/octobot` | UI-configured bot state, tentacles, exchange credentials after operator setup, logs, and Octelium-targeted UI access | cert-manager, istio, platform-storage |
 
@@ -64,10 +64,11 @@ namespaces. The source of truth is `docs/runtime-isolation.md` plus the
   Istio gateway path used by Octelium service proxies, the Octelium connector
   principal reserved for future served upstreams, Alertmanager to reach
   OpenClaw `/hooks/agent`, and OpenClaw to reach LiteLLM.
-- `automation` currently restricts `n8n` workload access to the Istio gateway;
-  the reviewed public n8n and Policy Bot callback hosts forward through the
-  `octelium-public` tunnel into that gateway instead of directly to the
-  workloads. `n8n-postgres` has a NetworkPolicy that documents n8n-only
+- `automation` currently restricts `n8n` workload access to the Istio gateway,
+  the Octelium client bridge, and n8n's own service account for authenticated
+  self-API calls; the reviewed public n8n and Policy Bot callback hosts forward
+  through the `octelium-public` tunnel into that gateway instead of directly
+  to the workloads. `n8n-postgres` has a NetworkPolicy that documents n8n-only
   database access, but the current flannel CNI does not enforce NetworkPolicy
   yet. The namespace is not default-denied because callback traffic and
   database source-identity validation still need live validation after rollout.

--- a/docs/runtime-isolation.md
+++ b/docs/runtime-isolation.md
@@ -57,6 +57,7 @@ The current service access contract is:
 | `openclaw` | `ai` | `cluster.local/ns/monitoring/sa/prometheus-kube-prometheus-alertmanager` | Alertmanager direct `/hooks/agent` delivery. |
 | `n8n` | `automation` | `cluster.local/ns/istio-system/sa/istio-ingressgateway` | Octelium service-proxy app access and reviewed n8n webhook callback traffic forwarded through the Istio gateway. |
 | `n8n` | `automation` | `cluster.local/ns/octelium-client/sa/octelium-client` | Octelium private service bridge. |
+| `n8n` | `automation` | `cluster.local/ns/automation/sa/n8n` | Authenticated n8n workflows calling the same instance through its in-cluster Service. |
 | `grafana` | `monitoring` | `cluster.local/ns/istio-system/sa/istio-ingressgateway` | Octelium service-proxy app access through the Istio gateway. |
 | `grafana` | `monitoring` | `cluster.local/ns/monitoring/sa/kiali-service-account` | Kiali dashboard links and health checks. |
 | `grafana` | `monitoring` | `cluster.local/ns/monitoring/sa/prometheus-kube-prometheus-prometheus` | Prometheus scrapes Grafana metrics. |


### PR DESCRIPTION
## Summary

- allow the `automation/n8n` service account to reach n8n through its in-cluster Service
- document `http://n8n.automation.svc.cluster.local:5678/api/v1` as the self-API base URL
- record the narrow workload-identity exception in the runtime isolation docs and knowledge base

## Root cause

The external editor endpoint is protected by Octelium and returns `401` with `x-octelium-unauthorized: true` for unattended workflow requests. The internal Kubernetes Service serves plain HTTP on port `5678`, but n8n's Istio `AuthorizationPolicy` did not allow the n8n workload identity to traverse the Service back to itself.

## Security impact

This adds only `cluster.local/ns/automation/sa/n8n` to the existing n8n destination policy. It does not expose API routes publicly or allow the rest of the `automation` namespace. n8n API-key authentication remains required.

## Validation

- `kubectl kustomize clusters/homelab/apps/n8n`
- Kubernetes server-side dry-run accepted the changed `AuthorizationPolicy`
- live `kubectl diff` showed only the new n8n principal
- repository static checks passed: Terragrunt HCL, all Kustomize overlays, image pins, secret markers, Checkov with zero failures, and whitespace
- Conftest: 5,800 passed, 0 failures
- signed commit verified with GPG
- local `nix run .#validate` was unavailable because `nix` is not installed; CI remains the authoritative full gate
- local gitleaks was unavailable; GitHub Actions runs it from the Nix dev shell

## Post-sync verification

After Argo CD syncs n8n, verify the real caller path:

```sh
kubectl -n automation exec deploy/n8n -c app -- \
  node -e '
    fetch("http://n8n.automation.svc.cluster.local:5678/healthz")
      .then((response) => console.log(response.status));
  '
```

Expected output: `200`. Then configure the n8n API credential with `http://n8n.automation.svc.cluster.local:5678/api/v1` and retry it in the UI.

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

> Live Terragrunt plan skipped because this pull request did not change `IaC/**`, flake inputs, OpenTofu/Terragrunt policy inputs, or live-plan helper scripts.

Rendered Conftest policies still ran for workflows and Kubernetes manifests in this required check.

<!-- terragrunt-plan:end -->
