### PR TITLE
docs(policy-bot): accept Codex review approvals

### DIFF
--- a/.policy.yml
+++ b/.policy.yml
@@ -2,6 +2,7 @@ policy:
   approval:
     - pull request commits have verified signatures
     - or:
+        - codex review bot approved
         - rstuhlmuller thumbs-up comment approved
         - organization member approved
   disapproval:
@@ -18,6 +19,24 @@ approval_rules:
       count: 0
       conditions:
         has_valid_signatures: true
+  - name: codex review bot approved
+    description: >-
+      Count only the exact top-level thumbs-up comment that the Codex review
+      bot posts after approving the latest PR changes with no P0 or P1 review
+      alerts.
+    options:
+      invalidate_on_push: true
+      methods:
+        comments: []
+        comment_patterns:
+          - '^\s*👍\s*$'
+        github_review: false
+        github_review_comment_patterns: []
+        body_patterns: []
+    requires:
+      count: 1
+      users:
+        - "chatgpt-codex-connector[bot]"
   - name: rstuhlmuller thumbs-up comment approved
     description: >-
       Count only an explicit thumbs-up comment from rstuhlmuller; this approval

--- a/clusters/homelab/apps/policy-bot/README.md
+++ b/clusters/homelab/apps/policy-bot/README.md
@@ -13,11 +13,16 @@ config.
 Policy Bot looks for a repository-local `.policy.yml` first and falls back to
 `policy.yml` in the shared `.github` repository. The homelab policy requires
 GitHub-verified commit signatures in addition to the normal review approval
-rules. The explicit comment path accepts a `👍` comment from `rstuhlmuller`,
-including PRs opened by `rodman` and PRs where `rstuhlmuller` authored or
-committed changes; PR body text and other users' comments do not count for that
-rule. The organization-member approval rule also allows author and contributor
-approvals so matching Stuhlmuller approvals are not ignored as disqualified.
+rules. One approval path accepts only the exact top-level `👍` comment from
+`chatgpt-codex-connector[bot]` that `AGENTS.md` requires after a passing Codex
+review with no P0 or P1 alerts. A later push invalidates that approval. This
+allows auto-merge to remain queued until Policy Bot observes a Codex review pass
+for the latest changes. The human comment path accepts a `👍` comment from
+`rstuhlmuller`, including PRs opened by `rodman` and PRs where `rstuhlmuller`
+authored or committed changes; PR body text and other users' comments do not
+count for that rule. The organization-member approval rule also allows author
+and contributor approvals so matching Stuhlmuller approvals are not ignored as
+disqualified.
 
 ## Routes
 

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -52,11 +52,16 @@ contract for Grafana.
 - Policy Bot reads this repository's `.policy.yml` and requires every pull
   request commit to have a GitHub-verified signature before normal review
   approval can satisfy the `policy-bot: main` branch protection check. The
-  explicit comment path accepts only a `👍` comment from `rstuhlmuller`,
-  including PRs opened by `rodman` and PRs where `rstuhlmuller` authored or
-  committed changes; it does not read PR body text or other users' comments.
-  The organization-member approval rule also opts into author and contributor
-  approvals so matching Stuhlmuller approvals are not ignored as disqualified.
+  Codex path accepts only the exact top-level `👍` comment from
+  `chatgpt-codex-connector[bot]` that `AGENTS.md` requires after a passing
+  review with no P0 or P1 alerts. A later push invalidates that approval, so
+  auto-merge remains queued until Policy Bot observes the pass signal for the
+  latest changes. The human comment path accepts only a `👍` comment from
+  `rstuhlmuller`, including PRs opened by `rodman` and PRs where `rstuhlmuller`
+  authored or committed changes; it does not read PR body text or other users'
+  comments. The organization-member approval rule also opts into author and
+  contributor approvals so matching Stuhlmuller approvals are not ignored as
+  disqualified.
 - External GitHub Actions are pinned to full commit SHAs and checked by
   Conftest.
 - The Terragrunt plan and apply workflows restore and save a GitHub Actions

--- a/docs/knowledge-base/runbooks/ci-cd.md
+++ b/docs/knowledge-base/runbooks/ci-cd.md
@@ -36,7 +36,11 @@ Source: `docs/ci-cd.md`
   stale lint runs for the same pull request.
 - Policy Bot reads this repository's `.policy.yml` and requires every PR commit
   to have a GitHub-verified signature before normal review approval can satisfy
-  the `policy-bot: main` branch protection check. The explicit comment path
+  the `policy-bot: main` branch protection check. The Codex path accepts only
+  the exact top-level `👍` comment from `chatgpt-codex-connector[bot]` that
+  `AGENTS.md` requires after a passing review with no P0 or P1 alerts. A later
+  push invalidates that approval, so auto-merge remains queued until Policy Bot
+  observes the pass signal for the latest changes. The human comment path
   accepts only a `👍` comment from `rstuhlmuller`, including PRs opened by
   `rodman` and PRs where `rstuhlmuller` authored or committed changes; it does
   not read PR body text or other users' comments. The organization-member rule

--- a/docs/knowledge-base/workloads/application-notes.md
+++ b/docs/knowledge-base/workloads/application-notes.md
@@ -427,12 +427,16 @@ Argo CD sync before the rendered Kubernetes Secret changes.
 The runtime config reads repository-local `.policy.yml` files before falling
 back to shared `.github/policy.yml`. Homelab's local policy keeps the shared
 review approval choices and adds a Policy Bot condition requiring every PR
-commit to have a GitHub-verified signature. The explicit comment approval path
-counts only a `👍` comment from `rstuhlmuller`, including PRs opened by
-`rodman` and PRs where `rstuhlmuller` authored or committed changes, and does
-not count PR body text or other users' comments. The organization-member rule
-also opts into author and contributor approvals so matching Stuhlmuller
-approvals are not ignored as disqualified.
+commit to have a GitHub-verified signature. The Codex approval path counts only
+the exact top-level `👍` comment from `chatgpt-codex-connector[bot]` that
+`AGENTS.md` requires after a passing review with no P0 or P1 alerts. A later
+push invalidates that approval, so auto-merge remains queued until Policy Bot
+observes the pass signal for the latest changes. The human comment path counts
+only a `👍` comment from `rstuhlmuller`, including PRs opened by `rodman` and PRs
+where `rstuhlmuller` authored or committed changes, and does not count PR body
+text or other users' comments. The organization-member rule also opts into
+author and contributor approvals so matching Stuhlmuller approvals are not
+ignored as disqualified.
 
 ## Prometheus
 


### PR DESCRIPTION
## Summary
- Add a Policy Bot approval rule for the exact top-level `👍` comment from `chatgpt-codex-connector[bot]`
- Document the Codex approval path and its push-invalidation behavior in the policy bot README and CI/CD docs
- Mirror the same guidance in the knowledge base runbooks and workload notes

## Testing
- Not run (not requested)

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

> Live Terragrunt plan skipped because this pull request did not change `IaC/**`, flake inputs, OpenTofu/Terragrunt policy inputs, or live-plan helper scripts.

Rendered Conftest policies still ran for workflows and Kubernetes manifests in this required check.

<!-- terragrunt-plan:end -->
