### PR TITLE
fix: split SSM reader IAM policies

### DIFF
--- a/IaC/modules/aws-ssm-parameters/main.tf
+++ b/IaC/modules/aws-ssm-parameters/main.tf
@@ -49,6 +49,10 @@ locals {
   effective_kms_key_id   = var.create_kms_key ? aws_kms_alias.this[0].name : var.kms_key_id
   effective_kms_key_arn  = var.create_kms_key ? aws_kms_key.this[0].arn : data.aws_kms_key.existing[0].arn
   parameter_reader_names = setunion(toset(keys(var.parameters)), var.additional_parameter_reader_names)
+  parameter_reader_policy_chunks = length(var.parameter_reader_iam_user_names) > 0 ? {
+    for index, names in chunklist(sort(tolist(local.parameter_reader_names)), 25) :
+    format("%02d", index) => names
+  } : {}
   external_parameters = {
     for name, parameter in var.parameters :
     name => parameter
@@ -174,22 +178,26 @@ moved {
 }
 
 data "aws_iam_policy_document" "parameter_reader" {
-  count = length(var.parameter_reader_iam_user_names) > 0 ? 1 : 0
+  for_each = local.parameter_reader_policy_chunks
 
   statement {
     sid = "ReadManagedSsmParameters"
 
     actions = [
-      "ssm:DescribeParameters",
       "ssm:GetParameter",
       "ssm:GetParameters",
     ]
 
     resources = [
-      for name in local.parameter_reader_names :
+      for name in each.value :
       "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/${trimprefix(name, "/")}"
     ]
   }
+
+}
+
+data "aws_iam_policy_document" "parameter_reader_kms" {
+  count = length(var.parameter_reader_iam_user_names) > 0 ? 1 : 0
 
   statement {
     sid = "DecryptManagedSsmParameters"
@@ -209,14 +217,51 @@ resource "aws_iam_group" "parameter_readers" {
   count = length(var.parameter_reader_iam_user_names) > 0 ? 1 : 0
 
   name = "homelab-ssm-parameter-readers"
+
+  lifecycle {
+    precondition {
+      condition     = length(local.parameter_reader_policy_chunks) <= 10
+      error_message = "The SSM parameter reader group cannot attach more than 10 managed IAM policies. Reduce the parameter set or increase the deterministic chunk size."
+    }
+  }
 }
 
+resource "aws_iam_policy" "parameter_reader" {
+  for_each = data.aws_iam_policy_document.parameter_reader
+
+  name        = "homelab-ssm-parameter-reader-${each.key}"
+  description = "Read one deterministic chunk of exact homelab SSM parameter ARNs."
+  policy      = each.value.json
+  tags        = var.tags
+
+  lifecycle {
+    precondition {
+      condition     = length(each.value.json) <= 6144
+      error_message = "An SSM parameter reader managed policy exceeds AWS IAM's 6,144-character policy limit. Reduce the deterministic chunk size."
+    }
+  }
+}
+
+resource "aws_iam_group_policy_attachment" "parameter_reader" {
+  for_each = aws_iam_policy.parameter_reader
+
+  group      = aws_iam_group.parameter_readers[0].name
+  policy_arn = each.value.arn
+}
+
+# Keep the existing inline policy address and shrink it only after every
+# managed SSM policy is attached. This avoids a reader-permission gap while
+# migrating away from the aggregate group inline-policy size limit.
 resource "aws_iam_group_policy" "parameter_reader" {
   count = length(var.parameter_reader_iam_user_names) > 0 ? 1 : 0
 
   group  = aws_iam_group.parameter_readers[0].name
   name   = "homelab-ssm-parameter-reader"
-  policy = data.aws_iam_policy_document.parameter_reader[0].json
+  policy = data.aws_iam_policy_document.parameter_reader_kms[0].json
+
+  depends_on = [
+    aws_iam_group_policy_attachment.parameter_reader,
+  ]
 }
 
 resource "aws_iam_user_group_membership" "parameter_reader" {

--- a/docs/knowledge-base/architecture/secrets-and-identity.md
+++ b/docs/knowledge-base/architecture/secrets-and-identity.md
@@ -29,6 +29,15 @@ roles need identity-based KMS permissions for both keys.
   ClusterSecretStore namespace allow-list.
 - Add a namespace to that allow-list in the same change that adds its first
   ExternalSecret.
+- The External Secrets IAM reader keeps exact parameter ARNs in sorted,
+  deterministic customer-managed policy chunks of at most 25 names; it does
+  not use a `/homelab/*` wildcard.
+- Reader policy preconditions enforce AWS IAM's 6,144-character limit per
+  customer-managed policy and 10 managed policies per group. The expanding
+  parameter list is not split into group inline policies because their combined
+  aggregate limit is 5,120 characters; the existing fixed-size inline policy
+  retains only exact KMS-key permissions and is updated after the managed
+  policies are attached.
 
 ## Identity Notes
 

--- a/docs/secrets-aws-ssm.md
+++ b/docs/secrets-aws-ssm.md
@@ -37,10 +37,22 @@ registrations.
 
 The `IaC/live/aws-ssm-parameters` stack also attaches the existing
 `external-secrets_aws-ssm-auth` user to the
-`homelab-ssm-parameter-readers` IAM group. The group's
-`homelab-ssm-parameter-reader` policy lets External Secrets read both
-placeholder parameters and listed Entra-managed SSO parameters, and call
-`kms:Decrypt`.
+`homelab-ssm-parameter-readers` IAM group. Deterministic customer-managed
+policies named `homelab-ssm-parameter-reader-00`,
+`homelab-ssm-parameter-reader-01`, and so on let External Secrets read the
+exact repository-listed placeholder and Entra-managed SSO parameter ARNs. The
+small existing `homelab-ssm-parameter-reader` inline policy grants decrypt and
+describe access to the exact SSM KMS key. The module sorts the parameter names
+and places at most 25 in each managed policy; it does not grant a
+`/homelab/*` wildcard.
+
+AWS limits each customer-managed policy to 6,144 non-whitespace characters and
+each IAM group to 10 attached managed policies. Module preconditions guard both
+limits. Splitting the same permissions across group inline policies is not a
+valid workaround because AWS applies a 5,120-character aggregate limit across
+all inline policies on one group. The fixed-size KMS-only inline policy stays
+well below that aggregate limit and is updated only after all managed reader
+policies are attached, preserving access during migration.
 
 Operators applying `IaC/live/aws-ssm-parameters` also need identity-based KMS
 permissions on the resolved `us-west-2` SSM key ARN. An apply role that can
@@ -65,10 +77,10 @@ Bootstrap order:
 1. Apply `IaC/live/aws-ssm-parameters` to create the SSM placeholders.
 2. Replace `/homelab/external-secrets/aws-ssm/access-key-id` and
    `/homelab/external-secrets/aws-ssm/secret-access-key` with an IAM access key
-   that can read `/homelab/*` Parameter Store values in `us-west-2` and decrypt
-   the configured KMS key. The repository-managed
-   `homelab-ssm-parameter-reader` IAM policy grants those permissions through
-   the `homelab-ssm-parameter-readers` IAM group.
+   that can read the exact repository-listed `/homelab/...` Parameter Store
+   values in `us-west-2` and decrypt the configured KMS key. The
+   repository-managed `homelab-ssm-parameter-reader` IAM policy set grants
+   those permissions through the `homelab-ssm-parameter-readers` IAM group.
 3. Apply `IaC/live/kubernetes-secrets/external-secrets-aws-ssm-auth`.
 
 The Kubernetes Secret stack refuses to apply while either SSM value is empty or


### PR DESCRIPTION
## Problem

The production Terragrunt Apply triggered by the AFFiNE deployment stopped while updating the `homelab-ssm-parameter-readers` group. AWS rejected the growing inline group policy because its aggregate document exceeded the 5,120-character group limit. That left the AFFiNE SSM parameters created but prevented the External Secrets reader from receiving access, so the application rollout and public route could not complete.

## Root cause

The SSM module placed every exact parameter ARN in one inline IAM group policy. Adding the three AFFiNE parameters pushed that policy over AWS's fixed group-inline-policy quota. Splitting the same document into additional inline policies would not help because AWS applies the quota to their combined size.

## Fix

- Sort the exact reader parameter names and split them into deterministic chunks of at most 25 ARNs.
- Create one customer-managed IAM policy per chunk and attach those policies to the existing reader group.
- Enforce AWS's 6,144-character managed-policy and 10-policies-per-group limits with OpenTofu preconditions.
- Retain the existing inline policy address as a fixed-size, exact-KMS-key policy and update it only after all managed policies are attached, avoiding a reader-access gap during migration.
- Remove `ssm:DescribeParameters`, which cannot be scoped to the exact parameter ARNs and is not needed by the repository's exact `remoteRef` ExternalSecrets.
- Document the exact-ARN design and IAM quota behavior in the SSM runbook and knowledge base.

The 57 current parameter names render as three policies of 25, 25, and 7 ARNs. Their compact sizes are 2,303, 2,231, and 747 characters; the KMS-only inline policy is 227 characters.

## Validation

- `tofu fmt -check IaC/modules/aws-ssm-parameters`
- `tofu validate -no-color`
- `terragrunt hcl fmt --check IaC/live/aws-ssm-parameters/terragrunt.hcl`
- targeted Checkov: 45 passed, 0 failed, 3 documented skips
- `bash scripts/ci/static-checks.sh`
- `bash scripts/ci/conftest-policies.sh`: 6,351 passed
- scoped `pre-commit run --files ...`: all hooks passed
- signed commit verified locally

After merge, the production apply should reconcile the managed policies, let External Secrets materialize the AFFiNE Secret, and allow the remaining Argo CD, Octelium catalog, and public DNS rollout steps to complete.


<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `09a02eea333d96575ef1744086a10fcb43d75af1`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.

> AzureAD application registration plans were skipped because the plan environment did not provide `ARM_CLIENT_ID`, `ARM_CLIENT_SECRET`, and `ARM_TENANT_ID`. Production apply still fails fast when `IaC/live/azuread-applications` changes and those credentials are absent.


<!-- terragrunt-plan:end -->
