### PR TITLE
fix(deluge): clear stale WireGuard rules

### DIFF
--- a/clusters/homelab/apps/deluge/README.md
+++ b/clusters/homelab/apps/deluge/README.md
@@ -139,6 +139,11 @@ kubectl -n media exec deploy/deluge -c gluetun -- /gluetun-entrypoint healthchec
 If Gluetun is unhealthy, Deluge should lose readiness and torrent traffic should
 fail closed instead of bypassing the VPN.
 
+The Gluetun container also removes stale IPv4 and IPv6 WireGuard policy rules
+in a `postStart` hook. This follows the upstream Kubernetes recovery for
+`adding IPv6 rule ... file exists`, where an abrupt container exit can leave a
+pod-shared rule behind before the restartable sidecar starts again.
+
 ## Troubleshooting
 
 If the Pod is `Ready` and Gluetun is healthy but Deluge is not usable, check

--- a/clusters/homelab/apps/deluge/values.yaml
+++ b/clusters/homelab/apps/deluge/values.yaml
@@ -134,6 +134,13 @@ controllers:
           repository: ghcr.io/qdm12/gluetun
           tag: v3.41.1@sha256:1a5bf4b4820a879cdf8d93d7ef0d2d963af56670c9ebff8981860b6804ebc8ab
         restartPolicy: Always
+        lifecycle:
+          postStart:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - (ip rule del table 51820; ip -6 rule del table 51820) || true
         env:
           TZ: America/Los_Angeles
           VPN_SERVICE_PROVIDER: custom


### PR DESCRIPTION
## What changed

- clear stale IPv4 and IPv6 WireGuard policy-routing rules in Gluetun's `postStart` lifecycle hook
- document why the cleanup is required for this shared-network pod

## Why

Deluge is unavailable because Gluetun repeatedly exits while adding WireGuard table `51820`; the stale IPv6 rule survives abrupt sidecar restarts in the pod network namespace. Clearing both rules before Gluetun initializes makes startup idempotent.

## Impact

Argo CD will recreate the Deluge pod from Git once this reaches `main`. No torrent data or application configuration is removed.

## Validation

- pinned Deluge Helm chart rendered successfully
- YAML validation passed
- pre-commit hooks passed, including Checkov and secret scanning

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

> Live Terragrunt plan skipped because this pull request did not change `IaC/**`, flake inputs, OpenTofu/Terragrunt policy inputs, or live-plan helper scripts.

Rendered Conftest policies still ran for workflows and Kubernetes manifests in this required check.

<!-- terragrunt-plan:end -->
