### PR TITLE
fix(argocd): grant operator admin access

### DIFF
--- a/IaC/bootstrap/argocd/README.md
+++ b/IaC/bootstrap/argocd/README.md
@@ -57,6 +57,11 @@ omit the `email_verified` claim from ID tokens; the connector sets
 `insecureSkipEmailVerified: true` for this trusted upstream while preserving
 client-secret and RBAC controls.
 
+Argo CD grants `role:admin` to the homelab-specific `argocd-admins` group and
+directly to `rodman@stuhlmuller.net`. The direct email binding uses the existing
+RBAC `email` scope and keeps the named operator's access independent of Entra
+group-claim configuration.
+
 The `terraform.source` value points directly at the Terragrunt catalog
 `helm-release` module pinned to version `0.3.0`. There are no repository-local
 OpenTofu modules in this bootstrap stack.

--- a/IaC/bootstrap/argocd/terragrunt.hcl
+++ b/IaC/bootstrap/argocd/terragrunt.hcl
@@ -8,6 +8,7 @@ locals {
   oidc_sso_secret_name                 = "argocd-oidc-sso"
   oidc_sso_issuer                      = "https://login.microsoftonline.com/2aee152b-5281-40d0-8f4b-60faf40514ab/v2.0"
   oidc_sso_admin_group                 = "argocd-admins"
+  oidc_sso_admin_email                 = "rodman@stuhlmuller.net"
   argocd_metrics = {
     enabled = true
   }
@@ -63,7 +64,7 @@ inputs = {
 
         rbac = {
           "policy.default" = "role:readonly"
-          "policy.csv"     = "g, ${local.oidc_sso_admin_group}, role:admin\n"
+          "policy.csv"     = "g, ${local.oidc_sso_admin_group}, role:admin\ng, ${local.oidc_sso_admin_email}, role:admin\n"
           scopes           = "[groups, email]"
         }
       }

--- a/docs/knowledge-base/architecture/secrets-and-identity.md
+++ b/docs/knowledge-base/architecture/secrets-and-identity.md
@@ -49,7 +49,9 @@ roles need identity-based KMS permissions for both keys.
   behavior, not a requested OAuth scope: keep Dex scopes to `openid`,
   `profile`, and `email`, configure Entra to emit the `groups` claim for Argo
   CD RBAC, and keep `insecureSkipEmailVerified: true` because Entra may omit
-  the `email_verified` claim.
+  the `email_verified` claim. The bootstrap RBAC policy also binds
+  `rodman@stuhlmuller.net` directly to `role:admin` through the configured
+  `email` scope so operator access does not depend on group-claim setup.
 - Argo CD Image Updater uses the `argocd-image-updater-git` ExternalSecret for
   GitHub App credentials that open image update pull requests through Git
   write-back. It refreshes on ExternalSecret changes; bump the non-secret


### PR DESCRIPTION
## Summary

- bind `rodman@stuhlmuller.net` directly to Argo CD's built-in `role:admin`
- preserve the existing `argocd-admins` group binding and `role:readonly` default
- document the operator-specific identity boundary in the bootstrap README and knowledge base

## Why

The existing RBAC policy only mapped the literal `argocd-admins` group. The operator's Microsoft Entra identity was not emitted as that subject, so Argo CD fell back to `role:readonly`. The direct email binding uses the already-configured `[groups, email]` RBAC scopes without adding a custom role or broadening permissions for other users.

## Impact

`rodman@stuhlmuller.net` receives Argo CD administrator access. Other SSO users remain read-only unless they match the existing admin group. No secret material or new authentication mechanism is introduced.

The reviewed Terragrunt plan was applied to the homelab before this PR was opened; Helm release revision 13 is live.

## Validation

- `terragrunt hcl fmt --check IaC/bootstrap/argocd/terragrunt.hcl`
- `terragrunt hcl validate IaC/bootstrap/argocd/terragrunt.hcl`
- focused Terragrunt plan: `0 to add, 1 to change, 0 to destroy`
- Terragrunt apply: `0 added, 1 changed, 0 destroyed`
- live `argocd-rbac-cm` contains the email-to-admin binding
- all Argo CD pods report `Running` and `1/1` ready
- commit hooks passed, including Terragrunt formatting, Checkov, secrets scanning, and codespell