### PR TITLE
fix(affine): restore automated sync

### DIFF
--- a/IaC/live/argocd-apps/affine/terragrunt.hcl
+++ b/IaC/live/argocd-apps/affine/terragrunt.hcl
@@ -54,6 +54,7 @@ inputs = {
 
   sync_policy = {
     automated = {
+      enabled   = true
       prune     = true
       self_heal = true
     }


### PR DESCRIPTION
Restores the repository-owned Argo CD automated sync setting after the temporary AFFiNE scale-to-zero diagnostic. This lets the merged Redis/PostgreSQL NFS mitigation deploy through the normal Terragrunt and Argo CD path.

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `6f52951ecd76817b04f49c593cb09954c4f061a0`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.

> AzureAD application registration plans were skipped because the plan environment did not provide `ARM_CLIENT_ID`, `ARM_CLIENT_SECRET`, and `ARM_TENANT_ID`. Production apply still fails fast when `IaC/live/azuread-applications` changes and those credentials are absent.


<!-- terragrunt-plan:end -->
