### PR TITLE
fix(media): protect postgres crash recovery

### DIFF
--- a/clusters/homelab/apps/media-postgres/README.md
+++ b/clusters/homelab/apps/media-postgres/README.md
@@ -27,6 +27,19 @@ UID/GID 65534 because the QNAP NFS export squashes writes to its anonymous user
 and denies `chown`; PostgreSQL requires the server process to own the data
 directory.
 
+## Recovery Probes
+
+The startup probe allows PostgreSQL up to 30 minutes to finish crash recovery
+before Kubernetes enables its liveness and readiness probes. This prevents a
+slow NFS recovery from becoming a restart loop where the liveness probe kills
+PostgreSQL before it can accept connections. The readiness probe still removes
+the database from the Service until `pg_isready` succeeds.
+
+The pod also has a 120-second termination grace period so PostgreSQL has more
+time to finish a fast shutdown without being forcibly killed. If startup
+recovery reaches the 30-minute limit, verify QNAP and NFS health before changing
+the probe thresholds or rolling dependent applications.
+
 ## Databases
 
 The init script creates the logical databases that Servarr expects:

--- a/clusters/homelab/apps/media-postgres/statefulset.yaml
+++ b/clusters/homelab/apps/media-postgres/statefulset.yaml
@@ -24,6 +24,7 @@ spec:
         app.kubernetes.io/part-of: homelab-media
     spec:
       automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 120
       securityContext:
         fsGroup: 65534
         fsGroupChangePolicy: OnRootMismatch
@@ -81,6 +82,17 @@ spec:
           ports:
             - name: postgres
               containerPort: 5432
+          startupProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - media_apps
+                - -d
+                - media_apps
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 180
           readinessProbe:
             exec:
               command:

--- a/docs/knowledge-base/architecture/storage-and-state.md
+++ b/docs/knowledge-base/architecture/storage-and-state.md
@@ -51,6 +51,12 @@ This prevents per-second AOF `fsync` calls and snapshot/AOF rewrite bursts from
 reaching the QNAP. PostgreSQL remains durable on NFS with WAL compression and
 checkpoint pacing; synchronous commit remains enabled.
 
+`media-postgres` protects NFS-backed crash recovery with a 30-minute startup
+probe and a 120-second termination grace period. Readiness still requires
+`pg_isready`, so Prowlarr, Radarr, and Sonarr cannot reach PostgreSQL until
+recovery completes. See `clusters/homelab/apps/media-postgres/README.md` for the
+failure mode and operator response.
+
 ## Source Files
 
 - `docs/storage-nfs.md`

--- a/docs/knowledge-base/operations/continuous-improvement.md
+++ b/docs/knowledge-base/operations/continuous-improvement.md
@@ -58,6 +58,25 @@ policy`.
 
 ## Open Findings
 
+- **Status:** mitigated for `media-postgres`; open for the other PostgreSQL workloads
+- **Area:** storage / database recovery
+- **Evidence:** Read-only inspection on 2026-07-19 found simultaneous probe
+  failures across NFS-backed workloads on multiple healthy Kubernetes nodes.
+  `media-postgres` remained in crash recovery longer than its liveness window,
+  so kubelet repeatedly terminated it with exit code 137 before it could become
+  ready. Prowlarr then returned PostgreSQL connection-refused errors while Argo
+  CD still reported the app healthy. The QNAP NFS exports and RPC services were
+  reachable when checked after the initial stall. The repository now gives
+  `media-postgres` a 30-minute startup window and a 120-second termination grace
+  period.
+- **Risk:** `affine-postgres`, `n8n-postgres`, and `octelium-postgres` retain the
+  same readiness/liveness-only probe pattern and can enter equivalent recovery
+  loops after another shared-storage stall.
+- **Next step:** validate the `media-postgres` rollout and recovery, inspect QNAP
+  pool, disk, and network history for the incident window, then add equivalent
+  recovery-aware startup behavior to the remaining PostgreSQL StatefulSets in
+  separately reviewed workload changes.
+
 - **Status:** mitigated; 30-minute rollout validation passed
 - **Area:** AFFiNE / storage I/O
 - **Evidence:** The operator reported that QNAP responsiveness returned several

--- a/docs/knowledge-base/workloads/inventory.md
+++ b/docs/knowledge-base/workloads/inventory.md
@@ -25,6 +25,10 @@ utility, not as an app, callback, or CI access path.
 | `media-postgres` | support | `media` | `clusters/homelab/apps/media-postgres` | `IaC/live/argocd-apps/media-postgres` | external-secrets, platform-storage |
 | `n8n-postgres` | support | `automation` | `clusters/homelab/apps/n8n-postgres` | `IaC/live/argocd-apps/n8n-postgres` | external-secrets, platform-storage |
 
+`media-postgres` has a recovery-aware 30-minute startup probe and 120-second
+termination grace period so an NFS stall does not trap Prowlarr, Radarr, and
+Sonarr's shared database in a liveness restart loop.
+
 ## Requested Applications
 
 | App | Namespace | GitOps path | Terragrunt path | State | Depends on |


### PR DESCRIPTION
## Summary

- give `media-postgres` a 30-minute startup probe so crash recovery can finish before liveness checks begin
- extend the pod termination grace period to 120 seconds to reduce forced PostgreSQL shutdowns on slow NFS
- document the incident, recovery behavior, and remaining probe risk for other PostgreSQL workloads

## Root cause

A shared NFS stall left `media-postgres` in crash recovery longer than its liveness window. Kubelet repeatedly terminated PostgreSQL with exit code 137 before it became ready, leaving the Service without a ready endpoint and causing Prowlarr database connection failures.

## Impact

After merge, Argo CD will roll out the StatefulSet template. PostgreSQL will have up to 30 minutes for startup/crash recovery while its readiness probe continues to keep the Service endpoint withdrawn until connections are accepted.

## Validation

- `kubectl kustomize clusters/homelab/apps/media-postgres`
- repository-wide Kustomize render through `scripts/ci/static-checks.sh`
- Terragrunt HCL validation and operator OpenTofu validation
- Checkov Kubernetes: 2,779 passed, 0 failed
- Conftest: 6,148 passed, 0 failed
- server-side Kubernetes diff confirmed the intended startup probe and termination grace changes
- working-tree secret scan and commit pre-hooks passed

The full static script stopped on 12 pre-existing Git-history secret-scan findings from unrelated older commits; the working-tree secret scan passed.

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

> Live Terragrunt plan skipped because this pull request did not change `IaC/**`, flake inputs, OpenTofu/Terragrunt policy inputs, or live-plan helper scripts.

Rendered Conftest policies still ran for workflows and Kubernetes manifests in this required check.

<!-- terragrunt-plan:end -->
