### PR TITLE
fix(dns): use standard cloudflare resolvers

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -163,8 +163,8 @@ machine:
           - network: 0.0.0.0/0
             gateway: 10.1.0.1
     nameservers:
-      - 1.1.1.3
-      - 1.0.0.3
+      - 1.1.1.1
+      - 1.0.0.1
   install:
     disk: CONTROL_PLANE_INTERNAL_DISK
     image: ghcr.io/siderolabs/installer:v1.11.3
@@ -280,8 +280,8 @@ machine:
           - network: 0.0.0.0/0
             gateway: 10.1.0.1
     nameservers:
-      - 1.1.1.3
-      - 1.0.0.3
+      - 1.1.1.1
+      - 1.0.0.1
   install:
     disk: /dev/mmcblk0
     image: ghcr.io/siderolabs/installer:v1.11.3

--- a/clusters/homelab/platform/dns/README.md
+++ b/clusters/homelab/platform/dns/README.md
@@ -4,12 +4,20 @@ This overlay manages only the CoreDNS `ConfigMap` in `kube-system`. CoreDNS is
 installed by the cluster bootstrap path, but this repository owns the resolver
 policy so in-cluster controllers do not inherit an unstable node-local upstream.
 
-External lookups are forwarded to the same Cloudflare family resolvers used in
-the Talos onboarding examples: `1.1.1.3` and `1.0.0.3`. On 2026-05-25, CoreDNS
-was observed forwarding through `169.254.116.108:53`, which timed out for AWS
+External lookups are forwarded to Cloudflare's standard resolvers: `1.1.1.1`
+and `1.0.0.1`. These resolvers intentionally do not apply Cloudflare Family
+category filtering. On 2026-07-19, the Family resolvers returned `0.0.0.0` and
+`::` for a configured Prowlarr indexer while the standard resolvers returned
+the authoritative public addresses. The sinkhole response surfaced as a
+misleading HTTPS connection-refused error in Prowlarr.
+
+Explicit public resolvers remain necessary because CoreDNS was observed on
+2026-05-25 forwarding through `169.254.116.108:53`, which timed out for AWS
 SSM, GitHub, and Tailscale names. Those failures surfaced as External Secrets
 errors for `cert-manager-cloudflare-api-token`, which can block future
-cert-manager DNS-01 issuance and renewal.
+cert-manager DNS-01 issuance and renewal. If category filtering is needed in
+the future, add a reviewed policy that does not silently sinkhole required
+workload destinations.
 
 Verify after rollout:
 
@@ -20,7 +28,10 @@ kubectl logs -n kube-system -l k8s-app=kube-dns --tail=50
 kubectl get externalsecret cert-manager-cloudflare-api-token -n cert-manager
 kubectl get clusterissuer letsencrypt-cloudflare
 kubectl get certificate stinkyboi-wildcard -n istio-system
+kubectl -n media exec deployment/prowlarr -c app -- getent ahostsv4 iptorrents.com
 ```
+
+The Prowlarr lookup should return public addresses rather than `0.0.0.0`.
 
 Rollback by reverting this overlay and the `platform-dns` Argo CD Application
 registration, then applying the affected Terragrunt stack. Do not manually patch

--- a/clusters/homelab/platform/dns/coredns-configmap.yaml
+++ b/clusters/homelab/platform/dns/coredns-configmap.yaml
@@ -27,7 +27,7 @@ data:
             fallthrough in-addr.arpa ip6.arpa
             ttl 30
         }
-        forward . 1.1.1.3 1.0.0.3 {
+        forward . 1.1.1.1 1.0.0.1 {
            max_concurrent 1000
         }
         cache 30 {

--- a/docs/knowledge-base/operations/continuous-improvement.md
+++ b/docs/knowledge-base/operations/continuous-improvement.md
@@ -58,6 +58,22 @@ policy`.
 
 ## Open Findings
 
+- **Status:** fixed
+- **Area:** networking / DNS
+- **Evidence:** Read-only checks on 2026-07-19 showed that the configured
+  Cloudflare Family resolvers (`1.1.1.3` and `1.0.0.3`) returned `0.0.0.0` and
+  `::` for a required Prowlarr indexer while standard Cloudflare DNS returned
+  its public IPv4 addresses. Prowlarr general HTTPS egress remained healthy,
+  proving the connection refusal came from DNS sinkholing rather than TLS,
+  IPv6, or workload egress. `platform-dns` now uses `1.1.1.1` and `1.0.0.1`.
+- **Risk:** cluster DNS no longer receives Cloudflare Family malware and adult
+  category filtering. Silent category sinkholes are incompatible with required
+  media indexers and can present as application transport failures.
+- **Next step:** keep explicit public resolvers and monitor CoreDNS errors. If
+  category filtering is required later, introduce a reviewed allow/deny policy
+  with observable denial behavior instead of switching the shared resolver back
+  to an opaque sinkhole response.
+
 - **Status:** mitigated for `media-postgres`; open for the other PostgreSQL workloads
 - **Area:** storage / database recovery
 - **Evidence:** Read-only inspection on 2026-07-19 found simultaneous probe

--- a/docs/knowledge-base/operations/validation-gates.md
+++ b/docs/knowledge-base/operations/validation-gates.md
@@ -83,6 +83,17 @@ kubectl kustomize clusters/homelab/apps/argocd-image-updater
 rg -n "writeBackTarget|imageName|manifestTargets" clusters/homelab/apps/argocd-image-updater/imageupdater.yaml
 ```
 
+For `platform-dns` changes, render the overlay and compare upstream answers
+before rollout. After Argo CD syncs, verify CoreDNS contains the intended
+resolvers and a workload pod receives a public answer rather than a sinkhole:
+
+```sh
+kubectl kustomize clusters/homelab/platform/dns
+dig +short A iptorrents.com @1.1.1.1
+kubectl -n kube-system get configmap coredns -o yaml
+kubectl -n media exec deployment/prowlarr -c app -- getent ahostsv4 iptorrents.com
+```
+
 ## Octelium Cutover Checks
 
 Before running `octops init`, validate the self-hosted Cluster prerequisites:

--- a/docs/knowledge-base/workloads/inventory.md
+++ b/docs/knowledge-base/workloads/inventory.md
@@ -25,6 +25,10 @@ utility, not as an app, callback, or CI access path.
 | `media-postgres` | support | `media` | `clusters/homelab/apps/media-postgres` | `IaC/live/argocd-apps/media-postgres` | external-secrets, platform-storage |
 | `n8n-postgres` | support | `automation` | `clusters/homelab/apps/n8n-postgres` | `IaC/live/argocd-apps/n8n-postgres` | external-secrets, platform-storage |
 
+`platform-dns` forwards public lookups to the unfiltered Cloudflare resolvers
+`1.1.1.1` and `1.0.0.1`. This keeps explicit stable upstreams without
+sinkholing Prowlarr indexer domains through Cloudflare Family category filters.
+
 `media-postgres` has a recovery-aware 30-minute startup probe and 120-second
 termination grace period so an NFS stall does not trap Prowlarr, Radarr, and
 Sonarr's shared database in a liveness restart loop.

--- a/docs/validation-runbook.md
+++ b/docs/validation-runbook.md
@@ -260,7 +260,7 @@ grep -i webhook /tmp/n8n-webhook-body.txt
 | Missing Application module | Stop, fix the local `IaC/modules/argocd-application-kubernetes` module or explicitly document a temporary catalog fallback before applying. |
 | Dependency cycle | Stop, remove the cycle from Terragrunt dependencies before applying. |
 | Existing unmanaged app | Stop, document adoption or delete/recreate strategy before Argo CD takes ownership. |
-| External DNS lookup failures from pods | Verify `platform-dns` is synced and CoreDNS forwards through `1.1.1.3` and `1.0.0.3`; do not manually patch the live CoreDNS `ConfigMap`. |
+| External DNS lookup failures from pods | Verify `platform-dns` is synced and CoreDNS forwards through `1.1.1.1` and `1.0.0.1`; confirm the upstream answer is not a sinkhole response such as `0.0.0.0`; do not manually patch the live CoreDNS `ConfigMap`. |
 | Missing AWS SSM parameter | Create the parameter outside the repo, then re-sync the owning ExternalSecret. |
 | External Secrets unavailable | Hold dependent apps until `external-secrets` is synced and healthy. |
 | NFS provisioner missing | Restore `platform-storage` readiness first; do not rely on stateful apps until PVC validation passes. |


### PR DESCRIPTION
## Summary

- switch the cluster CoreDNS forwarders from Cloudflare Family to the standard Cloudflare resolvers `1.1.1.1` and `1.0.0.1`
- update the Talos onboarding examples to use the same resolvers
- document the runtime verification and the cluster-wide filtering tradeoff in the runbooks and knowledge base

## Root cause

Cloudflare Family DNS resolved the required Prowlarr indexer hostname to `0.0.0.0` and `::`. Prowlarr then attempted a local connection on port 443 and reported `Connection refused`. Direct queries to `1.1.1.1` and `1.0.0.1` return the site's public addresses.

## Impact

This restores DNS resolution for the Prowlarr indexer while retaining explicit public upstreams for CoreDNS. It also removes Cloudflare Family malware/adult category filtering cluster-wide; future filtering should use an explicit, observable policy that permits required workloads.

## Validation

- signed commit and pre-commit hooks passed
- `kubectl kustomize clusters/homelab/platform/dns` passed
- Conftest: 6,148 Kubernetes policy tests passed with zero failures
- Checkov Kubernetes: 2,779 passed with zero failures
- server-side `kubectl diff` showed only the intended CoreDNS forwarder change
- working-tree Gitleaks passed
- the full static gate reached the history scan and stopped on the repository's 12 pre-existing historical findings

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

> Live Terragrunt plan skipped because this pull request did not change `IaC/**`, flake inputs, OpenTofu/Terragrunt policy inputs, or live-plan helper scripts.

Rendered Conftest policies still ran for workflows and Kubernetes manifests in this required check.

<!-- terragrunt-plan:end -->
