### PR TITLE
fix(iac): retain retired runner SSM tombstone

### DIFF
--- a/IaC/live/aws-ssm-parameters/terragrunt.hcl
+++ b/IaC/live/aws-ssm-parameters/terragrunt.hcl
@@ -97,6 +97,10 @@ inputs = {
       description   = "AWS secret access key used by External Secrets to read homelab SSM parameters."
       initial_value = local.placeholder
     }
+    "/homelab/github-actions-runner/registration-token" = {
+      description   = "Retired GitHub Actions runner token retained as an IaC state tombstone; no workload consumes it."
+      initial_value = local.placeholder
+    }
     "/homelab/tailscale/oauth-client-id" = {
       description   = "Tailscale Kubernetes operator OAuth client ID."
       initial_value = local.placeholder

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -174,6 +174,12 @@ rules and tighter rotation:
 | `KUBE_CONFIG_B64` | both | Base64-encoded kubeconfig for the homelab cluster. |
 | `AZUREAD_CLIENT_SECRET` | `homelab-production`; optional in `homelab-plan` | Microsoft Entra application secret used by the AzureAD provider during production applies and optional trusted PR plans. |
 
+The retired `/homelab/github-actions-runner/registration-token` SSM parameter
+has no runtime consumer. Its declaration and preexisting-parameter adoption
+guard remain temporarily because the production policy rejects SSM parameter
+deletion; remove both only with a reviewed repository-owned state and
+secret-retirement workflow.
+
 Add these environment variables. The workflows read each non-sensitive value
 from a GitHub variable first and fall back to a secret with the same name, so
 storing them as environment secrets also works when that is how the repository

--- a/docs/knowledge-base/architecture/secrets-and-identity.md
+++ b/docs/knowledge-base/architecture/secrets-and-identity.md
@@ -74,6 +74,11 @@ roles need identity-based KMS permissions for both keys.
   because OpenClaw rejects SecretRef objects for that hook-token surface.
 - Tailscale operator OAuth uses the `tailscale-oauth` ExternalSecret and the
   target Secret `operator-oauth`.
+- The retired GitHub Actions runner no longer consumes an SSM registration
+  token. `/homelab/github-actions-runner/registration-token` remains declared
+  and adoptable only as an OpenTofu state tombstone because the production
+  policy rejects SSM parameter deletion. Remove it only with a reviewed
+  repository-owned state and secret-retirement workflow.
 - Octelium client bridge auth uses the `octelium-client-auth` ExternalSecret in
   `octelium-client`, sourced from `/homelab/octelium/client-auth-token` and
   rendered to the versioned target Secret `octelium-client-auth-v5`. The token

--- a/docs/secrets-aws-ssm.md
+++ b/docs/secrets-aws-ssm.md
@@ -113,6 +113,12 @@ stack because Terraform manages the Kubernetes Secret.
 | n8n | `n8n-secrets` | `n8n-secrets` | `/homelab/n8n/encryption-key`, plus `n8n-postgres-client` from `n8n-postgres` |
 | policy-bot | `policy-bot-config` | `policy-bot-config` | `/homelab/policy-bot/github-app/integration-id`, `/homelab/policy-bot/github-app/webhook-secret`, `/homelab/policy-bot/github-app/private-key`, `/homelab/policy-bot/oauth/client-id`, `/homelab/policy-bot/oauth/client-secret`, `/homelab/policy-bot/sessions-key` |
 
+The retired `/homelab/github-actions-runner/registration-token` parameter is
+not an active secret contract and has no ExternalSecret consumer. It remains in
+the OpenTofu declaration as a state tombstone because policy rejects SSM
+parameter deletion; remove it only through a reviewed repository-owned state
+and secret-retirement workflow.
+
 For Argo CD, `/homelab/argocd/oidc/issuer` is a compatibility copy for the
 generated Secret and should match the literal Microsoft Entra issuer committed
 in `IaC/bootstrap/argocd/terragrunt.hcl`; do not reset it to `REPLACE_ME`.

--- a/scripts/ci/terragrunt-apply.sh
+++ b/scripts/ci/terragrunt-apply.sh
@@ -86,6 +86,42 @@ destroy_deleted_terragrunt_units() {
   done
 }
 
+adopt_existing_ssm_parameters() {
+  local parameter_region="us-west-2"
+  local state_resources
+  local parameter_name
+  local resource_address
+  local existing_name
+
+  terragrunt init -no-color
+  state_resources="$(terragrunt state list -no-color 2>/dev/null || true)"
+
+  for parameter_name in "/homelab/github-actions-runner/registration-token"; do
+    resource_address="aws_ssm_parameter.this[\"${parameter_name}\"]"
+
+    if grep -Fxq "$resource_address" <<<"$state_resources"; then
+      echo "SSM parameter ${parameter_name} is already managed in OpenTofu state."
+      continue
+    fi
+
+    existing_name="$(
+      aws ssm describe-parameters \
+        --region "$parameter_region" \
+        --parameter-filters "Key=Name,Option=Equals,Values=${parameter_name}" \
+        --query "Parameters[0].Name" \
+        --output text 2>/dev/null || true
+    )"
+
+    if [[ "$existing_name" == "$parameter_name" ]]; then
+      echo "Adopting existing SSM parameter ${parameter_name} into OpenTofu state."
+      terragrunt import -no-color "$resource_address" "$parameter_name"
+      state_resources="${state_resources}"$'\n'"${resource_address}"
+    else
+      echo "SSM parameter ${parameter_name} is absent; OpenTofu will create the placeholder."
+    fi
+  done
+}
+
 prepare_terragrunt_filter_base
 
 if ! azuread_credentials_available && azuread_stack_changed; then
@@ -107,6 +143,7 @@ echo "::group::AWS SSM parameter declaration plan and apply"
 (
   cd IaC/live/aws-ssm-parameters
   rm -f plan.out plan.json
+  adopt_existing_ssm_parameters
   terragrunt plan -out plan.out -no-color
   terragrunt --log-disable show -json plan.out >plan.json
   conftest test --policy ../../../policy --output github plan.json


### PR DESCRIPTION
## Summary

- restore the retired GitHub Actions runner registration-token declaration as a non-consumed OpenTofu state tombstone
- restore the preexisting-parameter adoption guard so an out-of-state parameter is imported instead of recreated
- document that removal requires a reviewed state and secret-retirement workflow

## Why

PR #510 removed the declaration, but the production Conftest policy rejects SSM parameter deletions. Keeping this resource declared prevents the post-merge apply from stopping on a forbidden destroy before the runner Application can prune its retired resources.

## Validation

- `nix develop --command bash scripts/ci/static-checks.sh`
- `nix develop --command bash scripts/ci/conftest-policies.sh`
- `bash -n scripts/ci/terragrunt-apply.sh`
- `git diff --check`

The resulting repository tree is byte-identical to the corrected PR #510 candidate on which those full suites passed.