### PR TITLE
fix(media): recover Deluge catalog after NFS stalls

### DIFF
--- a/clusters/homelab/apps/deluge/README.md
+++ b/clusters/homelab/apps/deluge/README.md
@@ -168,12 +168,26 @@ Repeated `libtorrent::libtorrent_exception` messages such as
 connection refusals, mean the Deluge daemon could not restore its persisted
 session state. Deluge 2.0.5 attempts to load both `session.state` and
 `session.state.bak`; individually valid files can still be incompatible when
-loaded sequentially. The liveness probe restarts the app container after three
-failed RPC checks. Startup reproduces Deluge's sequential load, archives an
+loaded sequentially. Startup reproduces that sequential load, archives an
 invalid current file or incompatible backup, and restores or refreshes only
-from a state file that passes libtorrent validation. This leaves `.torrent`
-files and downloaded data untouched. When neither state file exists on a new
-config volume, the wrapper lets Deluge perform its normal first-run setup.
+from a state file that passes libtorrent validation.
+
+The separate `/config/state/torrents.state` file is Deluge's active torrent
+catalog. If that catalog is empty or invalid while `.torrent` metadata remains,
+startup first restores a non-empty validated catalog backup. When both catalog
+copies are unusable, the repo-owned recovery script rebuilds the catalog only
+if every `.torrent` info hash has an exact fast-resume match and every recovered
+save path stays under `/downloads`. It checks the live fast-resume file first,
+then retained `/config/archive/*.tar.xz` snapshots from newest to oldest. It
+archives the old catalogs, atomically restores the complete fast-resume data
+and catalog, and stops without changing state if validation fails. Downloaded
+data and `.torrent` files remain untouched.
+
+The startup probe gives NFS-backed initialization and guarded state recovery up
+to 30 minutes before liveness begins. After startup, three failed daemon RPC
+checks still restart a persistently unhealthy app container. When no persisted
+state exists on a new config volume, the wrapper lets Deluge perform its normal
+first-run setup.
 
 Before Deluge Web starts, the same wrapper normalizes legacy daemon hostlist
 entries from `localhost` to Deluge's default `127.0.0.1`. Sonarr's Deluge
@@ -184,8 +198,9 @@ connecting Web to the healthy daemon.
 If automatic recovery cannot validate the backup, the app container stops
 instead of overwriting more state. Preserve torrent metadata and downloaded
 data; do not delete the `.torrent` files under `/config/state` or the
-`/downloads` tree. After explicit operator approval, inspect the archived files
-before using the manual fallback:
+`/downloads` tree. Catalog recovery archives are written under
+`/config/archive/torrent-catalog-recovery-*`. After explicit operator approval,
+inspect the archived files before using the manual session-state fallback:
 
 ```sh
 kubectl -n media exec deploy/deluge -c app -- /bin/sh -c '
@@ -216,8 +231,9 @@ kubectl -n media exec deploy/deluge -c gluetun -- \
 
 The expected port state is `listen_ports: (5983, 5983)` and
 `random_outgoing_ports: True`. Both `deluge_daemon_rpc_healthy` and
-`deluge_vpn_healthy` should be `1`. The archived `session.state.broken-*` file
-is the rollback reference if the backup state is worse.
+`deluge_vpn_healthy` should be `1`; `deluge_torrents_total` should match the
+expected catalog count. The archived `session.state.broken-*` file is the
+rollback reference if the backup state is worse.
 
 If `deluge-vpn` is ready and the Kubernetes Secret exists but the Gluetun
 container repeatedly fails startup health checks with DNS lookup timeouts, treat

--- a/clusters/homelab/apps/deluge/kustomization.yaml
+++ b/clusters/homelab/apps/deluge/kustomization.yaml
@@ -1,7 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: media
 resources:
   - namespace.yaml
   - externalsecret.yaml
   - media-storage.yaml
   - virtualservice.yaml
+configMapGenerator:
+  - name: deluge-catalog-recovery
+    files:
+      - recover-torrent-catalog.py
+generatorOptions:
+  disableNameSuffixHash: true

--- a/clusters/homelab/apps/deluge/recover-torrent-catalog.py
+++ b/clusters/homelab/apps/deluge/recover-torrent-catalog.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Recover Deluge's torrent catalog from intact metadata and fast-resume data."""
+
+import datetime
+import os
+import pickle
+import shutil
+import tarfile
+from pathlib import Path, PurePosixPath
+
+import libtorrent as lt
+from deluge.core.torrentmanager import TorrentManagerState, TorrentState
+
+
+STATE_DIR = Path(os.environ.get("DELUGE_STATE_DIR", "/config/state"))
+ARCHIVE_DIR = Path(os.environ.get("DELUGE_ARCHIVE_DIR", "/config/archive"))
+CATALOG = STATE_DIR / "torrents.state"
+CATALOG_BACKUP = STATE_DIR / "torrents.state.bak"
+FASTRESUME = STATE_DIR / "torrents.fastresume"
+
+
+def read_catalog(path):
+    with path.open("rb") as state_file:
+        state = pickle.load(state_file)
+    torrents = list(state.torrents)
+    torrent_ids = [torrent.torrent_id for torrent in torrents]
+    if len(torrent_ids) != len(set(torrent_ids)):
+        raise ValueError(f"{path} contains duplicate torrent IDs")
+    metadata_ids = {torrent_file.stem for torrent_file in STATE_DIR.glob("*.torrent")}
+    if set(torrent_ids) != metadata_ids:
+        raise ValueError(
+            f"{path} has {len(torrent_ids)} entries for "
+            f"{len(metadata_ids)} torrent metadata files"
+        )
+    return state
+
+
+def inspect_catalog(path):
+    if not path.is_file():
+        return None
+    try:
+        return read_catalog(path)
+    except Exception as error:
+        print(f"Torrent catalog {path} is invalid: {error}")
+        return None
+
+
+def atomic_write(source, destination):
+    temporary = destination.with_name(f".{destination.name}.recovery.tmp")
+    with temporary.open("wb") as output:
+        if isinstance(source, Path):
+            with source.open("rb") as input_file:
+                shutil.copyfileobj(input_file, output)
+        elif isinstance(source, bytes):
+            output.write(source)
+        else:
+            pickle.dump(source, output, protocol=2)
+        output.flush()
+        os.fsync(output.fileno())
+    os.replace(temporary, destination)
+    directory = os.open(str(destination.parent), os.O_DIRECTORY)
+    try:
+        os.fsync(directory)
+    finally:
+        os.close(directory)
+
+
+def archive_catalogs():
+    timestamp = datetime.datetime.now(datetime.timezone.utc).strftime(
+        "%Y%m%dT%H%M%SZ"
+    )
+    archive = ARCHIVE_DIR / f"torrent-catalog-recovery-{timestamp}"
+    archive.mkdir(parents=True, exist_ok=True)
+    for path in (CATALOG, CATALOG_BACKUP, FASTRESUME):
+        if path.is_file():
+            shutil.copy2(path, archive / path.name)
+    print(f"Archived pre-recovery torrent catalogs at {archive}")
+
+
+def decode_text(value, field):
+    if isinstance(value, bytes):
+        value = value.decode("utf-8")
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"resume data has an invalid {field}")
+    return value
+
+
+def validated_download_path(value):
+    path = PurePosixPath(decode_text(value, "save_path"))
+    downloads = PurePosixPath("/downloads")
+    if not path.is_absolute() or (path != downloads and downloads not in path.parents):
+        raise ValueError(f"resume data save_path is outside /downloads: {path}")
+    return str(path)
+
+
+def decode_resume_data(data):
+    encoded_resume = lt.bdecode(data)
+    if not isinstance(encoded_resume, dict):
+        raise ValueError("torrents.fastresume is not a dictionary")
+
+    return {
+        key.decode("ascii") if isinstance(key, bytes) else str(key): value
+        for key, value in encoded_resume.items()
+    }
+
+
+def load_complete_resume_data(torrent_ids):
+    candidates = []
+    if FASTRESUME.is_file():
+        candidates.append((str(FASTRESUME), FASTRESUME.read_bytes()))
+
+    archives = sorted(
+        ARCHIVE_DIR.glob("*.tar.xz"), key=lambda path: path.stat().st_mtime, reverse=True
+    )
+    for archive_path in archives:
+        try:
+            with tarfile.open(archive_path, "r:xz") as archive:
+                member = next(
+                    (
+                        item
+                        for item in archive.getmembers()
+                        if Path(item.name).name == "torrents.fastresume"
+                    ),
+                    None,
+                )
+                if member is not None:
+                    candidates.append(
+                        (str(archive_path), archive.extractfile(member).read())
+                    )
+        except (OSError, tarfile.TarError) as error:
+            print(f"Skipping unreadable recovery archive {archive_path}: {error}")
+
+    for source, data in candidates:
+        try:
+            resume_by_id = decode_resume_data(data)
+        except Exception as error:
+            print(f"Skipping invalid fast-resume source {source}: {error}")
+            continue
+        if set(resume_by_id) == torrent_ids:
+            print(f"Using complete fast-resume data from {source}")
+            return resume_by_id, data
+
+    raise ValueError(
+        "torrent metadata has no complete fast-resume source; refusing partial recovery"
+    )
+
+
+def rebuild_catalog(torrent_files):
+    torrent_ids = {path.stem for path in torrent_files}
+    resume_by_id, resume_data = load_complete_resume_data(torrent_ids)
+
+    recovered = []
+    for queue, torrent_file in enumerate(torrent_files):
+        torrent_id = torrent_file.stem
+        metadata = lt.torrent_info(lt.bdecode(torrent_file.read_bytes()))
+        if str(metadata.info_hash()) != torrent_id:
+            raise ValueError(f"{torrent_file} does not match its info hash")
+
+        resume = lt.bdecode(resume_by_id[torrent_id])
+        resume_hash = resume.get(b"info-hash")
+        if not isinstance(resume_hash, bytes) or resume_hash.hex() != torrent_id:
+            raise ValueError(f"fast-resume data does not match {torrent_file}")
+
+        recovered.append(
+            TorrentState(
+                torrent_id=torrent_id,
+                filename=torrent_file.name,
+                paused=bool(resume.get(b"paused", 0)),
+                save_path=validated_download_path(resume.get(b"save_path")),
+                sequential_download=bool(resume.get(b"sequential_download", 0)),
+                file_priorities=[
+                    int(priority) for priority in resume.get(b"file_priority", [])
+                ],
+                queue=queue,
+                auto_managed=bool(resume.get(b"auto_managed", 1)),
+                is_finished=bool(resume.get(b"completed_time", 0)),
+                super_seeding=bool(resume.get(b"super_seeding", 0)),
+            )
+        )
+
+    state = TorrentManagerState()
+    state.torrents = recovered
+    return state, resume_data
+
+
+def main():
+    current = inspect_catalog(CATALOG)
+    if current is not None and current.torrents:
+        print(f"Validated torrent catalog with {len(current.torrents)} entries")
+        return
+
+    torrent_files = sorted(STATE_DIR.glob("*.torrent"))
+    if not torrent_files:
+        if CATALOG.is_file() and current is None:
+            raise ValueError("torrent catalog is invalid without recoverable metadata")
+        print("No torrent metadata found; allowing Deluge to initialize its catalog")
+        return
+
+    backup = inspect_catalog(CATALOG_BACKUP)
+    if backup is not None and backup.torrents:
+        archive_catalogs()
+        atomic_write(CATALOG_BACKUP, CATALOG)
+        print(f"Restored torrent catalog backup with {len(backup.torrents)} entries")
+        return
+
+    rebuilt, resume_data = rebuild_catalog(torrent_files)
+    archive_catalogs()
+    atomic_write(resume_data, FASTRESUME)
+    atomic_write(rebuilt, CATALOG)
+    print(f"Rebuilt torrent catalog with {len(rebuilt.torrents)} entries")
+
+
+if __name__ == "__main__":
+    main()

--- a/clusters/homelab/apps/deluge/values.yaml
+++ b/clusters/homelab/apps/deluge/values.yaml
@@ -256,6 +256,7 @@ controllers:
               fi
             fi
 
+            python3 /scripts/recover-torrent-catalog.py
             normalize_web_daemon_host
             exec /init
         env:
@@ -270,6 +271,18 @@ controllers:
                 - -c
                 - s6-svc -d /var/run/s6/services/deluged && timeout 20s s6-svwait -d /var/run/s6/services/deluged || true
         probes:
+          startup:
+            enabled: true
+            custom: true
+            spec:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - timeout 10s deluge-console -c /config status >/dev/null 2>&1
+              failureThreshold: 180
+              periodSeconds: 10
+              timeoutSeconds: 12
           liveness:
             enabled: true
             custom: true
@@ -438,6 +451,15 @@ persistence:
         app:
           - path: /downloads
             subPath: downloads
+  recovery-script:
+    enabled: true
+    type: configMap
+    name: deluge-catalog-recovery
+    advancedMounts:
+      deluge:
+        app:
+          - path: /scripts
+            readOnly: true
   tun:
     enabled: true
     type: hostPath

--- a/clusters/homelab/apps/media-postgres/README.md
+++ b/clusters/homelab/apps/media-postgres/README.md
@@ -33,12 +33,17 @@ The startup probe allows PostgreSQL up to 30 minutes to finish crash recovery
 before Kubernetes enables its liveness and readiness probes. This prevents a
 slow NFS recovery from becoming a restart loop where the liveness probe kills
 PostgreSQL before it can accept connections. The readiness probe still removes
-the database from the Service until `pg_isready` succeeds.
+the database from the Service until `pg_isready` succeeds. After startup, the
+liveness probe also requires 30 minutes of continuous failures before
+restarting PostgreSQL. This keeps an intermittent NFS stall from turning a
+temporarily unavailable database into repeated crash recovery while dependent
+apps remain protected by readiness.
 
 The pod also has a 120-second termination grace period so PostgreSQL has more
 time to finish a fast shutdown without being forcibly killed. If startup
-recovery reaches the 30-minute limit, verify QNAP and NFS health before changing
-the probe thresholds or rolling dependent applications.
+recovery or a runtime liveness failure reaches the 30-minute limit, verify QNAP
+and NFS health before changing the probe thresholds or rolling dependent
+applications.
 
 ## Databases
 

--- a/clusters/homelab/apps/media-postgres/statefulset.yaml
+++ b/clusters/homelab/apps/media-postgres/statefulset.yaml
@@ -116,7 +116,7 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 30
             timeoutSeconds: 5
-            failureThreshold: 3
+            failureThreshold: 60
           resources:
             requests:
               cpu: 100m

--- a/docs/knowledge-base/architecture/storage-and-state.md
+++ b/docs/knowledge-base/architecture/storage-and-state.md
@@ -63,11 +63,12 @@ validation passed with zero pod restarts. The incident-only hook is now removed
 from desired state, while the explicit retained claim, 30-minute startup and
 liveness windows, and 120-second termination grace remain.
 
-`media-postgres` protects NFS-backed crash recovery with a 30-minute startup
-probe and a 120-second termination grace period. Readiness still requires
-`pg_isready`, so Prowlarr, Radarr, and Sonarr cannot reach PostgreSQL until
-recovery completes. See `clusters/homelab/apps/media-postgres/README.md` for the
-failure mode and operator response.
+`media-postgres` protects NFS-backed recovery with 30-minute startup and runtime
+liveness windows plus a 120-second termination grace period. Readiness still
+requires `pg_isready`, so Prowlarr, Radarr, and Sonarr cannot reach PostgreSQL
+until recovery completes. See
+`clusters/homelab/apps/media-postgres/README.md` for the failure mode and
+operator response.
 
 ## Source Files
 

--- a/docs/knowledge-base/operations/continuous-improvement.md
+++ b/docs/knowledge-base/operations/continuous-improvement.md
@@ -122,14 +122,37 @@ policy`.
   retained pgvector `0.8.1` and the committed settings, and returned AFFiNE to a
   synced, healthy Argo CD state. HTTPS, native-client CORS, server discovery,
   and the anonymous-workspace denial checks all passed. The incident-only hook
-  was removed from steady-state desired state after those checks.
-- **Risk:** `media-postgres` still has a short post-start liveness window, while
-  `n8n-postgres` and `octelium-postgres` retain the readiness/liveness-only probe
-  pattern. Another shared-storage stall can still restart those databases and
-  lengthen recovery.
-- **Next step:** inspect QNAP pool, disk, and network history for both incident
-  windows, then add equivalent recovery-aware behavior to the remaining
-  PostgreSQL StatefulSets in separately reviewed workload changes.
+  was removed from steady-state desired state after those checks. Read-only
+  inspection on 2026-07-24 confirmed another broad recurrence:
+  `media-postgres` had restarted 148 times in four days, Deluge's app and
+  Gluetun containers had restarted 669 and 413 times in ten days, and Radarr
+  had restarted 147 times in three and a half days. Sonarr and Prowlarr had
+  zero restarts in their current pods but logged repeated PostgreSQL connection
+  refusals and read timeouts. Prometheus recorded about 22,465 I/O-wait
+  task-seconds for `media-postgres`, 11,062 for Radarr, 5,677 for Deluge, 5,141
+  for Sonarr, and 2,476 for Prowlarr over the preceding 24 hours, with no media
+  container OOM events. The NFSv3 client statistics shared by the affected
+  mounts on `acer` recorded 7,732,718 WRITE RPC timeouts and roughly 69 seconds
+  of average write execution time over the mount lifetime, compared with 12
+  and 24 WRITE timeouts and roughly 46 and 87 milliseconds average execution
+  time on `zimaboard-0` and `zimaboard-1`. Deluge's VPN metric was healthy
+  99.8% of the last 24 hours while daemon RPC health was only 65.3%; its
+  previous app instance stalled during `/config` ownership initialization
+  before the liveness probe restarted it. All affected persistent volumes
+  target the QNAP at `10.1.0.2` over NFSv3.
+- **Risk:** probe hardening limits crash-recovery loops but cannot make the
+  shared storage path responsive. Sonarr and Prowlarr can remain Kubernetes
+  `Running` while database calls fail, while Deluge and Radarr turn sustained
+  I/O stalls into restart loops. The same failure domain affects unrelated
+  NFS-backed workloads across the cluster.
+- **Next step:** the media PostgreSQL liveness window now matches its
+  30-minute startup recovery window, which prevents brief NFS outages from
+  immediately starting another crash-recovery cycle. Treat the QNAP and
+  especially the `acer` NFS client path as the primary incident. Inspect QNAP
+  pool, disk, NFS-service, and network history for the 2026-07-23/24 window;
+  collect Talos kernel NFS diagnostics with a populated Talos client config;
+  and benchmark NFS latency from each wired node. Evaluate moving PostgreSQL
+  and other high-churn state to storage designed for database synchronous I/O.
 
 - **Status:** PostgreSQL alert path mitigated; kube-state-metrics scrape open
 - **Area:** monitoring / PostgreSQL availability
@@ -381,11 +404,29 @@ policy`.
   `libtorrent::libtorrent_exception: invalid type requested from entry`.
   `deluge_daemon_rpc_healthy` was `0` until the documented
   `session.state` recovery restored `/config/session.state.bak` and archived
-  the broken state file as `session.state.broken-20260615T040836Z`.
+  the broken state file as `session.state.broken-20260615T040836Z`. On
+  2026-07-24, Deluge reported zero loaded torrents even though
+  `/config/state` still contained 14 `.torrent` files and a 37,454-byte
+  `torrents.fastresume`. Both the live `torrents.state` and its backup were
+  only 80 bytes. The two retained `torrent-recovery-20260720` archives
+  preserved all 14 metadata files but their 2,287-byte catalogs each referenced
+  only one torrent, so neither was a complete rollback source. The daemon
+  logged `Bad shutdown detected` followed by `Finished loading 0 torrents`.
+  The startup wrapper validated `/config/session.state`, which holds libtorrent
+  session settings, but did not validate or restore
+  `/config/state/torrents.state`, which is the actual Deluge torrent catalog.
+  During recovery validation, the still-running daemon rewrote the live catalog
+  and fast-resume file to one entry, but nine retained `state-*.tar.xz`
+  snapshots still held all 14 fast-resume records.
 - **Risk:** Deluge can be unavailable while Kubernetes readiness, Gluetun, and
   Argo CD still look healthy, and the same persisted-state corruption may
-  recur after future pod or daemon restarts.
-- **Next step:** investigate a durable fix for recurring Deluge
-  `session.state` corruption, such as a safer shutdown path, a newer Deluge or
-  libtorrent image, or an automated guarded recovery that preserves
-  `/config/state/*.torrent` and `/downloads`.
+  recur after future pod or daemon restarts. Repeated bad-shutdown archives now
+  preserve the empty catalog and can age out the last known-good recovery
+  copies even though the individual torrent metadata files remain.
+- **Next step:** guarded startup recovery now treats an empty
+  `torrents.state` as invalid when `.torrent` files exist. It requires matching
+  fast-resume records from the live file or a retained archive plus
+  `/downloads`-scoped save paths before atomically restoring fast-resume data
+  and rebuilding the catalog, and it archives the pre-recovery files. Validate
+  that Deluge reloads all 14 torrents and survives a clean restart; separately
+  reduce the NFS stall that causes the bad shutdowns.

--- a/docs/knowledge-base/workloads/inventory.md
+++ b/docs/knowledge-base/workloads/inventory.md
@@ -29,9 +29,9 @@ utility, not as an app, callback, or CI access path.
 `1.1.1.1` and `1.0.0.1`. This keeps explicit stable upstreams without
 sinkholing Prowlarr indexer domains through Cloudflare Family category filters.
 
-`media-postgres` has a recovery-aware 30-minute startup probe and 120-second
-termination grace period so an NFS stall does not trap Prowlarr, Radarr, and
-Sonarr's shared database in a liveness restart loop.
+`media-postgres` has recovery-aware 30-minute startup and runtime liveness
+windows plus a 120-second termination grace period so an NFS stall does not trap
+Prowlarr, Radarr, and Sonarr's shared database in a crash-recovery loop.
 
 ## Requested Applications
 
@@ -53,7 +53,7 @@ Sonarr's shared database in a liveness restart loop.
 | `kiali` | `monitoring` | `clusters/homelab/apps/kiali` | `IaC/live/argocd-apps/kiali` | controller state only; read-only mesh UI through Octelium app access | istio, prometheus, grafana |
 | `compass` | `monitoring` | `clusters/homelab/apps/compass` | `IaC/live/argocd-apps/compass` | stateless Kubernetes service discovery dashboard with Octelium service-name launch links from the `ghcr.io/adinhodovic/charts` OCI Helm source | cert-manager, istio, prometheus |
 | `descheduler` | `kube-system` | `clusters/homelab/apps/descheduler` | `IaC/live/argocd-apps/descheduler` | controller state only | prometheus |
-| `deluge` | `media` | `clusters/homelab/apps/deluge` | `IaC/live/argocd-apps/deluge` | persistent config on `nfs-default`; shared downloads on QNAP `/media`; SSM-backed WireGuard profile via `deluge-vpn`; automatic validated `session.state.bak` recovery; `127.0.0.1` Web-to-daemon host compatibility for Sonarr; Prometheus health for the Gluetun VPN and Deluge daemon | cert-manager, istio, platform-storage |
+| `deluge` | `media` | `clusters/homelab/apps/deluge` | `IaC/live/argocd-apps/deluge` | persistent config on `nfs-default`; shared downloads on QNAP `/media`; SSM-backed WireGuard profile via `deluge-vpn`; guarded recovery for libtorrent session state and the torrent catalog; a 30-minute startup window for NFS-backed initialization; `127.0.0.1` Web-to-daemon host compatibility for Sonarr; Prometheus health for the Gluetun VPN and Deluge daemon | cert-manager, istio, platform-storage |
 | `dispatcharr` | `media` | `clusters/homelab/apps/dispatcharr` | `IaC/live/argocd-apps/dispatcharr` | modular IPTV stream and EPG manager with a persistent data claim, dedicated PostgreSQL 17 claim, ephemeral Redis, and Octelium-protected UI; provider credentials and playlist URLs stay outside git | external-secrets, cert-manager, istio, platform-storage |
 | `prowlarr` | `media` | `clusters/homelab/apps/prowlarr` | `IaC/live/argocd-apps/prowlarr` | persistent config and PostgreSQL databases | cert-manager, istio, media-postgres, platform-storage |
 | `radarr` | `media` | `clusters/homelab/apps/radarr` | `IaC/live/argocd-apps/radarr` | persistent config and PostgreSQL databases on `nfs-default`; movies and downloads on QNAP `/media` | cert-manager, istio, deluge, media-postgres, prowlarr, platform-storage |


### PR DESCRIPTION
## Summary

- rebuild Deluge's torrent catalog only from a complete one-to-one match between persisted `.torrent` metadata and fast-resume records
- fall back to the newest complete retained Deluge state archive, validate download paths, archive pre-recovery state, and replace the live fast-resume data and catalog atomically
- give Deluge NFS-backed startup and recovery up to 30 minutes before liveness begins
- extend media PostgreSQL's runtime liveness window to 30 minutes so transient NFS stalls do not repeatedly force crash recovery for Sonarr, Radarr, and Prowlarr
- record the incident evidence, remaining QNAP/NFS risk, storage behavior, and recovery workflow in the workload docs and knowledge base

## Incident context

The shared NFS path intermittently stalled across the media workloads. `media-postgres` restarted 148 times in four days, and Sonarr and Prowlarr logged repeated database timeouts and connection refusals. Deluge's live catalog fell to zero and then one torrent while 14 matching `.torrent` files remained. Nine retained state archives still held the complete 14-entry fast-resume set, so the recovery does not embed or publish private tracker data.

This change limits the restart loops and repairs Deluge's derived catalog. It does not claim to repair the underlying QNAP or `acer` NFS-client fault; that investigation remains documented follow-up work.

## Validation

- `nix flake check --no-build --all-systems`
- `nix develop --command bash scripts/ci/static-checks.sh`
- pre-commit YAML, Checkov diff/secrets, codespell, and whitespace hooks
- pinned `app-template` 4.4.0 Helm render
- `kubectl kustomize` for Deluge and media PostgreSQL
- live `kubectl diff` for the Deluge Helm workload, Deluge Kustomize source, and media PostgreSQL StatefulSet
- isolated execution in the running Deluge image against copies of the real truncated catalog and the retained complete archive: rebuilt 14 entries, then validated idempotently on a second run

## Rollout and verification

After merge, Argo CD should reconcile `media-postgres` and Deluge. Verify PostgreSQL readiness, Deluge startup logs, a 14-torrent catalog, daemon/VPN metrics, Sonarr and Prowlarr health, and stable restart counts.


<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

> Live Terragrunt plan skipped because this pull request did not change `IaC/**`, flake inputs, OpenTofu/Terragrunt policy inputs, or live-plan helper scripts.

Rendered Conftest policies still ran for workflows and Kubernetes manifests in this required check.

<!-- terragrunt-plan:end -->
