### PR TITLE
fix(deluge): serialize recovery checks

### DIFF
--- a/clusters/homelab/apps/deluge/README.md
+++ b/clusters/homelab/apps/deluge/README.md
@@ -261,13 +261,25 @@ kubectl -n media exec deploy/deluge -c app -- \
 
 The apply path pauses the selected torrents, adopts existing target files with
 libtorrent's `dont_replace` storage move, and forces a piece-hash recheck. It
-guards the serialized checks against redownloading: verified entries resume for
-seeding, while entries that fail their hashes remain paused. If an older apply
-is already checking, attach the same guard with `--monitor`. Target files are
-never replaced; stale source copies may be removed by libtorrent. Exact sizes
-are only the selection guard—the hash recheck is the integrity decision. See
-the upstream
+checks entries one at a time so queue transitions cannot start a redownload:
+verified entries resume for seeding, while entries that fail their hashes
+remain paused. Target files are never replaced; stale source copies may be
+removed by libtorrent. Exact sizes are only the selection guard—the hash
+recheck is the integrity decision. See the upstream
 [move-storage contract](https://www.libtorrent.org/reference-Storage.html).
+
+If Sonarr and Radarr both have empty queues after recovery, remove paused
+catalog entries whose expected complete-root files are missing or the wrong
+size:
+
+```sh
+kubectl -n media exec deploy/deluge -c app -- \
+  python3 /scripts/reconcile-completed.py --prune-skipped
+```
+
+This cleanup refuses entries that are not paused under `/downloads/complete`
+and calls Deluge with `remove_data=false`, so it removes only stale catalog
+records and never downloaded files.
 
 If `deluge-vpn` is ready and the Kubernetes Secret exists but the Gluetun
 container repeatedly fails startup health checks with DNS lookup timeouts, treat

--- a/clusters/homelab/apps/deluge/reconcile-completed.py
+++ b/clusters/homelab/apps/deluge/reconcile-completed.py
@@ -45,87 +45,41 @@ def local_auth():
 
 
 @defer.inlineCallbacks
-def monitor_rechecks(candidates, timeout):
-    deadline = time.monotonic() + timeout
+def verify_one(torrent_id, deadline):
     saw_checking = False
-    quiet_polls = 0
 
+    yield client.core.pause_torrent([torrent_id])
+    yield client.core.force_recheck([torrent_id])
+    yield client.core.resume_torrent([torrent_id])
     while True:
         statuses = yield client.core.get_torrents_status({}, STATUS_FIELDS)
-        missing = [
-            torrent_id for torrent_id in candidates if torrent_id not in statuses
-        ]
-        if missing:
+        if torrent_id not in statuses:
             raise RuntimeError("a selected torrent disappeared during its hash check")
+        status = statuses[torrent_id]
 
-        downloading = [
-            torrent_id
-            for torrent_id in candidates
-            if not statuses[torrent_id]["is_finished"]
-            and statuses[torrent_id]["state"] == "Downloading"
-        ]
-        if downloading:
-            yield client.core.pause_torrent(downloading)
-
-        checking = [
-            torrent_id
-            for torrent_id in candidates
-            if statuses[torrent_id]["state"] == "Checking"
-        ]
-        if checking:
+        if status["is_finished"]:
+            yield client.core.resume_torrent([torrent_id])
+            return True
+        if status["state"] == "Checking":
             saw_checking = True
-            quiet_polls = 0
-        elif saw_checking:
-            quiet_polls += 1
-
-        if saw_checking and quiet_polls >= 3:
-            break
+        elif status["state"] in ("Downloading", "Error") or saw_checking:
+            yield client.core.pause_torrent([torrent_id])
+            return False
         if time.monotonic() >= deadline:
+            yield client.core.pause_torrent([torrent_id])
             raise TimeoutError("timed out waiting for Deluge hash checks")
-        yield task.deferLater(reactor, 5, lambda: None)
-
-    statuses = yield client.core.get_torrents_status({}, STATUS_FIELDS)
-    verified = [
-        torrent_id
-        for torrent_id in candidates
-        if statuses[torrent_id]["is_finished"]
-    ]
-    incomplete = [
-        torrent_id
-        for torrent_id in candidates
-        if not statuses[torrent_id]["is_finished"]
-    ]
-    if incomplete:
-        yield client.core.pause_torrent(incomplete)
-    if verified:
-        yield client.core.resume_torrent(verified)
-    print(
-        f"Hash checks complete: verified {len(verified)} entries; "
-        f"paused {len(incomplete)} incomplete entries"
-    )
+        yield task.deferLater(reactor, 1, lambda: None)
 
 
 @defer.inlineCallbacks
-def reconcile(mode, timeout):
+def reconcile(apply, prune_skipped, timeout):
     username, password = local_auth()
     yield client.connect("127.0.0.1", 58846, username, password)
     try:
         statuses = yield client.core.get_torrents_status({}, STATUS_FIELDS)
-        if mode == "monitor":
-            candidates = [
-                torrent_id
-                for torrent_id, status in statuses.items()
-                if not status["is_finished"]
-                and os.path.realpath(status["save_path"]) == COMPLETE_DIR
-            ]
-            print(f"Guarding {len(candidates)} incomplete complete-root entries")
-            if candidates:
-                yield monitor_rechecks(candidates, timeout)
-            return
-
         candidates = []
         total_bytes = 0
-        skipped = 0
+        skipped = []
         for torrent_id, status in statuses.items():
             if status["is_finished"]:
                 continue
@@ -134,18 +88,42 @@ def reconcile(mode, timeout):
                 candidates.append(torrent_id)
                 total_bytes += torrent_bytes
             else:
-                skipped += 1
+                skipped.append(torrent_id)
 
         print(
             f"Found {len(candidates)} incomplete entries with "
             f"{total_bytes} exact-size bytes under /downloads/complete; "
-            f"skipped {skipped}"
+            f"skipped {len(skipped)}"
         )
-        if mode == "dry-run" or not candidates:
+        if prune_skipped:
+            unsafe = [
+                torrent_id
+                for torrent_id in skipped
+                if statuses[torrent_id]["state"] != "Paused"
+                or os.path.realpath(statuses[torrent_id]["save_path"]) != COMPLETE_DIR
+            ]
+            if unsafe:
+                raise RuntimeError(
+                    "refusing to prune skipped entries unless all are paused "
+                    "under /downloads/complete"
+                )
+            errors = yield client.core.remove_torrents(skipped, False)
+            if errors:
+                raise RuntimeError(
+                    f"failed to remove {len(errors)} of {len(skipped)} entries"
+                )
+            print(
+                f"Removed {len(skipped)} skipped catalog entries "
+                "without deleting data"
+            )
+            return
+
+        if not apply or not candidates:
             if candidates:
                 print("Dry run only; rerun with --apply to adopt and hash-check them")
             return
 
+        deadline = time.monotonic() + timeout
         yield client.core.pause_torrent(candidates)
         move_ids = [
             torrent_id
@@ -154,7 +132,6 @@ def reconcile(mode, timeout):
         ]
         if move_ids:
             yield client.core.move_storage(move_ids, COMPLETE_DIR)
-            deadline = time.monotonic() + timeout
             while True:
                 current = yield client.core.get_torrents_status({}, ["save_path"])
                 pending = [
@@ -168,10 +145,21 @@ def reconcile(mode, timeout):
                     raise TimeoutError("timed out waiting for Deluge storage moves")
                 yield task.deferLater(reactor, 2, lambda: None)
 
-        yield client.core.force_recheck(candidates)
-        yield client.core.resume_torrent(candidates)
-        print(f"Started guarded hash recheck for {len(candidates)} entries")
-        yield monitor_rechecks(candidates, timeout)
+        verified = 0
+        incomplete = 0
+        for index, torrent_id in enumerate(candidates, start=1):
+            print(
+                f"Hash-checking entry {index} of {len(candidates)}",
+                flush=True,
+            )
+            if (yield verify_one(torrent_id, deadline)):
+                verified += 1
+            else:
+                incomplete += 1
+        print(
+            f"Hash checks complete: verified {verified} entries; "
+            f"paused {incomplete} incomplete entries"
+        )
     finally:
         client.disconnect()
 
@@ -180,15 +168,12 @@ def main():
     parser = argparse.ArgumentParser()
     mode = parser.add_mutually_exclusive_group()
     mode.add_argument("--apply", action="store_true")
-    mode.add_argument("--monitor", action="store_true")
+    mode.add_argument("--prune-skipped", action="store_true")
     parser.add_argument("--timeout", type=int, default=7200)
     args = parser.parse_args()
-    selected_mode = (
-        "apply" if args.apply else "monitor" if args.monitor else "dry-run"
-    )
 
     exit_code = [0]
-    result = reconcile(selected_mode, args.timeout)
+    result = reconcile(args.apply, args.prune_skipped, args.timeout)
 
     def failed(failure):
         print(failure.value, file=sys.stderr)

--- a/docs/knowledge-base/architecture/storage-and-state.md
+++ b/docs/knowledge-base/architecture/storage-and-state.md
@@ -78,8 +78,8 @@ provide Deluge's write access. When stale resume data points complete downloads
 at the incomplete root, the documented operator script selects only exact-size
 target files, adopts them with libtorrent's `dont_replace` move, and requires a
 full piece-hash recheck before completion is trusted. The command resumes
-hash-valid entries for seeding and pauses hash failures so stale catalog state
-cannot trigger a silent redownload.
+hash-valid entries for seeding and pauses hash failures. Checks run one at a
+time so Deluge's queue transitions cannot trigger a silent redownload.
 
 ## Source Files
 

--- a/docs/knowledge-base/operations/continuous-improvement.md
+++ b/docs/knowledge-base/operations/continuous-improvement.md
@@ -441,6 +441,8 @@ policy`.
   torrents and resumed downloads after the observed restart. The guarded
   operator reconciliation adopts exact-size complete-root files without
   replacement and makes libtorrent hash-check them before trusting completion.
-  Its guard resumes verified entries and pauses hash failures instead of
-  redownloading them; separately reduce the NFS stall that causes the bad
-  shutdowns.
+  It checks one entry at a time, resumes verified entries, and pauses hash
+  failures instead of redownloading them. After confirming the Sonarr and
+  Radarr queues are empty, its guarded prune removes only paused, unrecoverable
+  Deluge catalog records with `remove_data=false`; separately reduce the NFS
+  stall that causes the bad shutdowns.


### PR DESCRIPTION
## Summary
- hash-check recovery candidates one at a time instead of inferring completion from Deluge queue transitions
- resume only verified entries and pause failures before they can redownload
- simplify the bulk monitor implementation

## Validation
- `nix develop --command bash scripts/ci/static-checks.sh`
- live run: two eligible entries verified sequentially; final state 10 seeding, 4 paused, 0 queued/checking/downloading

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

> Live Terragrunt plan skipped because this pull request did not change `IaC/**`, flake inputs, OpenTofu/Terragrunt policy inputs, or live-plan helper scripts.

Rendered Conftest policies still ran for workflows and Kubernetes manifests in this required check.

<!-- terragrunt-plan:end -->
