### PR TITLE
ci: extract live terragrunt wrapper

### DIFF
--- a/.github/workflows/terragrunt-apply.yml
+++ b/.github/workflows/terragrunt-apply.yml
@@ -134,20 +134,7 @@ jobs:
           KUBE_CONFIG_B64: ${{ secrets.KUBE_CONFIG_B64 }}
           KUBE_API_SERVER_URL: ${{ env.KUBE_API_SERVER_URL }}
           KUBE_TLS_SERVER_NAME: ${{ env.KUBE_TLS_SERVER_NAME }}
-        run: |
-          nix develop --command bash <<'EOF'
-          set -euo pipefail
-          cleanup() {
-            bash scripts/ci/disconnect-octelium.sh
-          }
-          trap cleanup EXIT
-
-          bash scripts/ci/connect-octelium.sh
-          bash scripts/ci/install-kubeconfig.sh
-          curl -ksS --max-time 10 -o /dev/null "${KUBE_API_SERVER_URL}/version"
-          kubectl --request-timeout=15s version
-          bash scripts/ci/terragrunt-apply.sh
-          EOF
+        run: nix develop --command bash scripts/ci/live-terragrunt.sh apply
 
       - name: Disconnect Octelium
         if: always()

--- a/.github/workflows/terragrunt-plan.yml
+++ b/.github/workflows/terragrunt-plan.yml
@@ -118,7 +118,7 @@ jobs:
               IaC/*|flake.nix|flake.lock|policy/*)
                 requires_live_plan=true
                 ;;
-              scripts/ci/connect-octelium.sh|scripts/ci/disconnect-octelium.sh|scripts/ci/install-kubeconfig.sh|scripts/ci/install-octelium-client.sh|scripts/ci/terragrunt-*|scripts/ci/update-pr-plan-description.sh)
+              scripts/ci/connect-octelium.sh|scripts/ci/disconnect-octelium.sh|scripts/ci/install-kubeconfig.sh|scripts/ci/install-octelium-client.sh|scripts/ci/live-terragrunt.sh|scripts/ci/terragrunt-*|scripts/ci/update-pr-plan-description.sh)
                 requires_live_plan=true
                 ;;
             esac
@@ -162,20 +162,7 @@ jobs:
           KUBE_API_SERVER_URL: ${{ env.KUBE_API_SERVER_URL }}
           KUBE_TLS_SERVER_NAME: ${{ env.KUBE_TLS_SERVER_NAME }}
           TERRAGRUNT_PLAN_MARKDOWN: ${{ runner.temp }}/terragrunt-plan.md
-        run: |
-          nix develop --command bash <<'EOF'
-          set -euo pipefail
-          cleanup() {
-            bash scripts/ci/disconnect-octelium.sh
-          }
-          trap cleanup EXIT
-
-          bash scripts/ci/connect-octelium.sh
-          bash scripts/ci/install-kubeconfig.sh
-          curl -ksS --max-time 10 -o /dev/null "${KUBE_API_SERVER_URL}/version"
-          kubectl --request-timeout=15s version
-          bash scripts/ci/terragrunt-plan.sh
-          EOF
+        run: nix develop --command bash scripts/ci/live-terragrunt.sh plan
 
       - name: Write Live Plan Skip Note
         if: steps.live-plan-scope.outputs.requires-live-plan != 'true'

--- a/docs/knowledge-base/operations/validation-gates.md
+++ b/docs/knowledge-base/operations/validation-gates.md
@@ -127,8 +127,8 @@ Pass `--octelium-context` and `--homelab-context` when the Octelium control
 plane and homelab connector live in different Kubernetes clusters.
 
 CI/CD Octelium changes should also pass shell syntax checks for
-`scripts/ci/install-octelium-client.sh`, `scripts/ci/connect-octelium.sh`, and
-`scripts/ci/install-kubeconfig.sh`. Validate that
+`scripts/ci/install-octelium-client.sh`, `scripts/ci/live-terragrunt.sh`, and
+the Octelium/kubeconfig helpers it calls. Validate that
 `docs/examples/octelium/homelab-services.yaml` parses and contains Service
 `kubernetes-api.ci` before applying it with `octeliumctl`.
 

--- a/policy/workflows.rego
+++ b/policy/workflows.rego
@@ -35,6 +35,7 @@ deny contains msg if {
 deny contains msg if {
 	live_homelab_workflow
 	not workflow_run_contains("scripts/ci/connect-octelium.sh")
+	not workflow_run_contains("scripts/ci/live-terragrunt.sh")
 	name := object.get(input, "name", "<unnamed workflow>")
 	msg := sprintf("workflow %q touches live homelab access but does not connect through Octelium first", [name])
 }
@@ -42,6 +43,7 @@ deny contains msg if {
 deny contains msg if {
 	live_homelab_workflow
 	not workflow_run_contains("scripts/ci/disconnect-octelium.sh")
+	not workflow_run_contains("scripts/ci/live-terragrunt.sh")
 	name := object.get(input, "name", "<unnamed workflow>")
 	msg := sprintf("workflow %q touches live homelab access but does not tear down Octelium sessions", [name])
 }
@@ -97,6 +99,10 @@ live_homelab_workflow if {
 
 live_homelab_workflow if {
 	workflow_run_contains("scripts/ci/terragrunt-apply.sh")
+}
+
+live_homelab_workflow if {
+	workflow_run_contains("scripts/ci/live-terragrunt.sh")
 }
 
 live_homelab_workflow if {

--- a/scripts/ci/live-terragrunt.sh
+++ b/scripts/ci/live-terragrunt.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+command_name="${1:?usage: scripts/ci/live-terragrunt.sh plan|apply}"
+
+case "$command_name" in
+  plan | apply) ;;
+  *)
+    echo "usage: scripts/ci/live-terragrunt.sh plan|apply" >&2
+    exit 2
+    ;;
+esac
+
+cleanup() {
+  bash scripts/ci/disconnect-octelium.sh
+}
+trap cleanup EXIT
+
+bash scripts/ci/connect-octelium.sh
+bash scripts/ci/install-kubeconfig.sh
+curl -ksS --max-time 10 -o /dev/null "${KUBE_API_SERVER_URL:?KUBE_API_SERVER_URL is required}/version"
+kubectl --request-timeout=15s version
+bash "scripts/ci/terragrunt-${command_name}.sh"


### PR DESCRIPTION
## Summary
- add a small live Terragrunt CI wrapper for Octelium connect, kubeconfig install, API readiness, and plan/apply dispatch
- replace duplicated plan/apply workflow heredocs with the wrapper
- update workflow policy and knowledge-base validation guidance for the wrapper

## Validation
- bash -n scripts/ci/live-terragrunt.sh scripts/ci/terragrunt-plan.sh scripts/ci/terragrunt-apply.sh
- scripts/ci/conftest-policies.sh
- git diff --check