### PR TITLE
refactor: share azuread sso parameter template

### DIFF
--- a/IaC/live/azuread-applications/grafana/terragrunt.hcl
+++ b/IaC/live/azuread-applications/grafana/terragrunt.hcl
@@ -44,17 +44,16 @@ EOF
 generate "sso_parameters" {
   path      = "sso-parameters.tf"
   if_exists = "overwrite_terragrunt"
-  contents  = <<EOF
-data "azuread_client_config" "current" {}
-
-resource "azuread_application_password" "sso" {
-  application_id    = azuread_application.this.id
-  display_name      = "homelab-grafana-sso"
-  end_date_relative = "8760h"
-}
-
-locals {
-  azuread_sso_parameters = {
+  contents = templatefile("../sso-parameters.tftpl", {
+    aws_region                    = local.aws_region
+    kms_key_id                    = local.kms_key_id
+    credential_display_name       = "homelab-grafana-sso"
+    credential_output_description = "Key ID for the generated Grafana Microsoft Entra application password."
+    parameter_local_name          = "azuread_sso_parameters"
+    parameter_output_description  = "AWS SSM parameter names populated from the Grafana Microsoft Entra application."
+    tags_json                     = jsonencode(local.tags)
+    parameters_hcl                = <<PARAMETERS
+{
     "/homelab/grafana/azuread/client-id" = {
       description = "Grafana Microsoft Entra OAuth client ID from the managed application registration."
       value       = azuread_application.this.client_id
@@ -75,32 +74,9 @@ locals {
       description = "Grafana allowed Microsoft Entra tenant ID."
       value       = data.azuread_client_config.current.tenant_id
     }
-  }
 }
-
-resource "aws_ssm_parameter" "sso" {
-  for_each = local.azuread_sso_parameters
-
-  region      = "${local.aws_region}"
-  name        = each.key
-  description = each.value.description
-  type        = "SecureString"
-  value       = each.value.value
-  key_id      = "${local.kms_key_id}"
-  tier        = "Standard"
-  tags        = ${jsonencode(local.tags)}
-}
-
-output "sso_parameter_names" {
-  description = "AWS SSM parameter names populated from the Grafana Microsoft Entra application."
-  value       = keys(aws_ssm_parameter.sso)
-}
-
-output "sso_password_key_id" {
-  description = "Key ID for the generated Grafana Microsoft Entra application password."
-  value       = azuread_application_password.sso.key_id
-}
-EOF
+PARAMETERS
+  })
 }
 
 inputs = {

--- a/IaC/live/azuread-applications/octelium/terragrunt.hcl
+++ b/IaC/live/azuread-applications/octelium/terragrunt.hcl
@@ -45,17 +45,16 @@ EOF
 generate "sso_parameters" {
   path      = "sso-parameters.tf"
   if_exists = "overwrite_terragrunt"
-  contents  = <<EOF
-data "azuread_client_config" "current" {}
-
-resource "azuread_application_password" "sso" {
-  application_id    = azuread_application.this.id
-  display_name      = "homelab-octelium-entra-oidc"
-  end_date_relative = "8760h"
-}
-
-locals {
-  octelium_entra_parameters = {
+  contents = templatefile("../sso-parameters.tftpl", {
+    aws_region                    = local.aws_region
+    kms_key_id                    = local.kms_key_id
+    credential_display_name       = "homelab-octelium-entra-oidc"
+    credential_output_description = "Key ID for the generated Octelium Microsoft Entra application password."
+    parameter_local_name          = "octelium_entra_parameters"
+    parameter_output_description  = "AWS SSM parameter names populated from the Octelium Microsoft Entra application."
+    tags_json                     = jsonencode(local.tags)
+    parameters_hcl                = <<PARAMETERS
+{
     "/homelab/octelium/entra/client-id" = {
       description = "Octelium Microsoft Entra OIDC client ID from the managed application registration."
       value       = azuread_application.this.client_id
@@ -72,32 +71,9 @@ locals {
       description = "Octelium Microsoft Entra tenant ID."
       value       = data.azuread_client_config.current.tenant_id
     }
-  }
 }
-
-resource "aws_ssm_parameter" "sso" {
-  for_each = local.octelium_entra_parameters
-
-  region      = "${local.aws_region}"
-  name        = each.key
-  description = each.value.description
-  type        = "SecureString"
-  value       = each.value.value
-  key_id      = "${local.kms_key_id}"
-  tier        = "Standard"
-  tags        = ${jsonencode(local.tags)}
-}
-
-output "sso_parameter_names" {
-  description = "AWS SSM parameter names populated from the Octelium Microsoft Entra application."
-  value       = keys(aws_ssm_parameter.sso)
-}
-
-output "sso_password_key_id" {
-  description = "Key ID for the generated Octelium Microsoft Entra application password."
-  value       = azuread_application_password.sso.key_id
-}
-EOF
+PARAMETERS
+  })
 }
 
 inputs = {

--- a/IaC/live/azuread-applications/sso-parameters.tftpl
+++ b/IaC/live/azuread-applications/sso-parameters.tftpl
@@ -1,0 +1,34 @@
+data "azuread_client_config" "current" {}
+
+resource "azuread_application_password" "sso" {
+  application_id    = azuread_application.this.id
+  display_name      = "${credential_display_name}"
+  end_date_relative = "8760h"
+}
+
+locals {
+  ${parameter_local_name} = ${parameters_hcl}
+}
+
+resource "aws_ssm_parameter" "sso" {
+  for_each = local.${parameter_local_name}
+
+  region      = "${aws_region}"
+  name        = each.key
+  description = each.value.description
+  type        = "SecureString"
+  value       = each.value.value
+  key_id      = "${kms_key_id}"
+  tier        = "Standard"
+  tags        = ${tags_json}
+}
+
+output "sso_parameter_names" {
+  description = "${parameter_output_description}"
+  value       = keys(aws_ssm_parameter.sso)
+}
+
+output "sso_password_key_id" {
+  description = "${credential_output_description}"
+  value       = azuread_application_password.sso.key_id
+}

--- a/docs/knowledge-base/architecture/secrets-and-identity.md
+++ b/docs/knowledge-base/architecture/secrets-and-identity.md
@@ -59,7 +59,9 @@ roles need identity-based KMS permissions for both keys.
   credential replacement. Its SSM contract is summarized in
   [[runbooks/image-automation]] and [[runbooks/secrets-aws-ssm]].
 - Grafana Microsoft Entra SSO is managed through
-  `IaC/live/azuread-applications/grafana`.
+  `IaC/live/azuread-applications/grafana`; shared generated password and SSM
+  parameter wiring lives in
+  `IaC/live/azuread-applications/sso-parameters.tftpl`.
 - Alertmanager owns notification delivery credentials for Grafana-managed
   alerts. The Prometheus app materializes `alertmanager-discord-webhook` and
   `alertmanager-openclaw-alert-hook` ExternalSecrets in `monitoring`, sourced


### PR DESCRIPTION
## Summary
- move duplicated generated AzureAD password and SSM parameter Terraform into one shared template
- keep Grafana and Octelium units responsible only for their distinct SSM parameter maps
- update the secrets/identity knowledge-base note with the shared template path

## Validation
- terragrunt hcl fmt --check
- terragrunt hcl validate in IaC/live/azuread-applications/grafana
- terragrunt hcl validate in IaC/live/azuread-applications/octelium
- terragrunt --log-disable init -backend=false -no-color in both AzureAD units
- terragrunt --log-disable validate -no-color in both AzureAD units
- git diff --check

## Notes
- OpenTofu validation passes with the existing AzureAD provider warning that end_date_relative is deprecated.