### PR TITLE
refactor: share argocd app source defaults

### DIFF
--- a/IaC/live/argocd-apps/affine/terragrunt.hcl
+++ b/IaC/live/argocd-apps/affine/terragrunt.hcl
@@ -22,8 +22,7 @@ dependencies {
 }
 
 locals {
-  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
-  target_revision = "main"
+  app_defaults = read_terragrunt_config(find_in_parent_folders("defaults.hcl")).locals
 }
 
 inputs = {
@@ -51,8 +50,8 @@ inputs = {
 
       sources = [
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           path           = "clusters/homelab/apps/affine"
           kustomize      = {}
         }

--- a/IaC/live/argocd-apps/argocd-image-updater/terragrunt.hcl
+++ b/IaC/live/argocd-apps/argocd-image-updater/terragrunt.hcl
@@ -15,8 +15,7 @@ dependencies {
 }
 
 locals {
-  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
-  target_revision = "main"
+  app_defaults = read_terragrunt_config(find_in_parent_folders("defaults.hcl")).locals
 }
 
 inputs = {
@@ -54,8 +53,8 @@ inputs = {
           }
         },
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           ref            = "values"
           path           = "."
           directory = {
@@ -63,8 +62,8 @@ inputs = {
           }
         },
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           path           = "clusters/homelab/apps/argocd-image-updater"
           kustomize      = {}
         }

--- a/IaC/live/argocd-apps/cert-manager/terragrunt.hcl
+++ b/IaC/live/argocd-apps/cert-manager/terragrunt.hcl
@@ -15,8 +15,7 @@ dependencies {
 }
 
 locals {
-  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
-  target_revision = "main"
+  app_defaults = read_terragrunt_config(find_in_parent_folders("defaults.hcl")).locals
 }
 
 inputs = {
@@ -54,8 +53,8 @@ inputs = {
           }
         },
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           ref            = "values"
           path           = "."
           directory = {
@@ -63,8 +62,8 @@ inputs = {
           }
         },
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           path           = "clusters/homelab/apps/cert-manager"
           kustomize      = {}
         }

--- a/IaC/live/argocd-apps/compass/terragrunt.hcl
+++ b/IaC/live/argocd-apps/compass/terragrunt.hcl
@@ -19,8 +19,7 @@ dependencies {
 }
 
 locals {
-  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
-  target_revision = "main"
+  app_defaults = read_terragrunt_config(find_in_parent_folders("defaults.hcl")).locals
 }
 
 inputs = {
@@ -58,8 +57,8 @@ inputs = {
           }
         },
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           ref            = "values"
           path           = "."
           directory = {
@@ -67,8 +66,8 @@ inputs = {
           }
         },
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           path           = "clusters/homelab/apps/compass"
           kustomize      = {}
         }

--- a/IaC/live/argocd-apps/cordium/terragrunt.hcl
+++ b/IaC/live/argocd-apps/cordium/terragrunt.hcl
@@ -18,8 +18,7 @@ dependencies {
 }
 
 locals {
-  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
-  target_revision = "main"
+  app_defaults = read_terragrunt_config(find_in_parent_folders("defaults.hcl")).locals
 }
 
 inputs = {
@@ -47,8 +46,8 @@ inputs = {
 
       sources = [
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           path           = "clusters/homelab/apps/cordium"
           kustomize      = {}
         }

--- a/IaC/live/argocd-apps/defaults.hcl
+++ b/IaC/live/argocd-apps/defaults.hcl
@@ -1,0 +1,4 @@
+locals {
+  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
+  target_revision = "main"
+}

--- a/IaC/live/argocd-apps/deluge/terragrunt.hcl
+++ b/IaC/live/argocd-apps/deluge/terragrunt.hcl
@@ -20,8 +20,7 @@ dependencies {
 }
 
 locals {
-  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
-  target_revision = "main"
+  app_defaults = read_terragrunt_config(find_in_parent_folders("defaults.hcl")).locals
 }
 
 inputs = {
@@ -59,8 +58,8 @@ inputs = {
           }
         },
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           ref            = "values"
           path           = "."
           directory = {
@@ -68,8 +67,8 @@ inputs = {
           }
         },
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           path           = "clusters/homelab/apps/deluge"
           kustomize      = {}
         }

--- a/IaC/live/argocd-apps/descheduler/terragrunt.hcl
+++ b/IaC/live/argocd-apps/descheduler/terragrunt.hcl
@@ -15,8 +15,7 @@ dependencies {
 }
 
 locals {
-  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
-  target_revision = "main"
+  app_defaults = read_terragrunt_config(find_in_parent_folders("defaults.hcl")).locals
 }
 
 inputs = {
@@ -54,8 +53,8 @@ inputs = {
           }
         },
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           ref            = "values"
           path           = "."
           directory = {
@@ -63,8 +62,8 @@ inputs = {
           }
         },
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           path           = "clusters/homelab/apps/descheduler"
           kustomize      = {}
         }

--- a/IaC/live/argocd-apps/dispatcharr/terragrunt.hcl
+++ b/IaC/live/argocd-apps/dispatcharr/terragrunt.hcl
@@ -20,8 +20,7 @@ dependencies {
 }
 
 locals {
-  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
-  target_revision = "main"
+  app_defaults = read_terragrunt_config(find_in_parent_folders("defaults.hcl")).locals
 }
 
 inputs = {
@@ -59,8 +58,8 @@ inputs = {
           }
         },
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           ref            = "values"
           path           = "."
           directory = {
@@ -68,8 +67,8 @@ inputs = {
           }
         },
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           path           = "clusters/homelab/apps/dispatcharr"
           kustomize      = {}
         }

--- a/IaC/live/argocd-apps/external-secrets/terragrunt.hcl
+++ b/IaC/live/argocd-apps/external-secrets/terragrunt.hcl
@@ -15,8 +15,7 @@ dependencies {
 }
 
 locals {
-  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
-  target_revision = "main"
+  app_defaults = read_terragrunt_config(find_in_parent_folders("defaults.hcl")).locals
 }
 
 inputs = {
@@ -54,8 +53,8 @@ inputs = {
           }
         },
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           ref            = "values"
           path           = "."
           directory = {
@@ -63,8 +62,8 @@ inputs = {
           }
         },
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           path           = "clusters/homelab/apps/external-secrets"
           kustomize      = {}
         }

--- a/IaC/live/argocd-apps/github-actions-runner/terragrunt.hcl
+++ b/IaC/live/argocd-apps/github-actions-runner/terragrunt.hcl
@@ -11,8 +11,7 @@ terraform {
 }
 
 locals {
-  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
-  target_revision = "main"
+  app_defaults = read_terragrunt_config(find_in_parent_folders("defaults.hcl")).locals
 }
 
 inputs = {
@@ -40,8 +39,8 @@ inputs = {
 
       sources = [
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           path           = "clusters/homelab/apps/github-actions-runner"
           kustomize      = {}
         }

--- a/IaC/live/argocd-apps/grafana-alert-cleanup/terragrunt.hcl
+++ b/IaC/live/argocd-apps/grafana-alert-cleanup/terragrunt.hcl
@@ -18,8 +18,7 @@ dependencies {
 }
 
 locals {
-  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
-  target_revision = "main"
+  app_defaults = read_terragrunt_config(find_in_parent_folders("defaults.hcl")).locals
 }
 
 inputs = {
@@ -47,8 +46,8 @@ inputs = {
 
       sources = [
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           path           = "clusters/homelab/apps/grafana-alert-cleanup"
           kustomize      = {}
         }

--- a/IaC/live/argocd-apps/grafana/terragrunt.hcl
+++ b/IaC/live/argocd-apps/grafana/terragrunt.hcl
@@ -21,8 +21,7 @@ dependencies {
 }
 
 locals {
-  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
-  target_revision = "main"
+  app_defaults = read_terragrunt_config(find_in_parent_folders("defaults.hcl")).locals
 }
 
 inputs = {
@@ -63,8 +62,8 @@ inputs = {
           }
         },
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           ref            = "values"
           path           = "."
           directory = {
@@ -72,8 +71,8 @@ inputs = {
           }
         },
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           path           = "clusters/homelab/apps/grafana"
           kustomize      = {}
         }

--- a/IaC/live/argocd-apps/istio/terragrunt.hcl
+++ b/IaC/live/argocd-apps/istio/terragrunt.hcl
@@ -15,8 +15,7 @@ dependencies {
 }
 
 locals {
-  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
-  target_revision = "main"
+  app_defaults = read_terragrunt_config(find_in_parent_folders("defaults.hcl")).locals
 }
 
 inputs = {
@@ -99,8 +98,8 @@ inputs = {
           }
         },
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           ref            = "values"
           path           = "."
           directory = {
@@ -108,8 +107,8 @@ inputs = {
           }
         },
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           path           = "clusters/homelab/apps/istio"
           kustomize      = {}
         }

--- a/IaC/live/argocd-apps/kiali/terragrunt.hcl
+++ b/IaC/live/argocd-apps/kiali/terragrunt.hcl
@@ -19,8 +19,7 @@ dependencies {
 }
 
 locals {
-  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
-  target_revision = "main"
+  app_defaults = read_terragrunt_config(find_in_parent_folders("defaults.hcl")).locals
 }
 
 inputs = {
@@ -58,8 +57,8 @@ inputs = {
           }
         },
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           ref            = "values"
           path           = "."
           directory = {
@@ -67,8 +66,8 @@ inputs = {
           }
         },
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           path           = "clusters/homelab/apps/kiali"
           kustomize      = {}
         }

--- a/IaC/live/argocd-apps/litellm/terragrunt.hcl
+++ b/IaC/live/argocd-apps/litellm/terragrunt.hcl
@@ -20,8 +20,7 @@ dependencies {
 }
 
 locals {
-  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
-  target_revision = "main"
+  app_defaults = read_terragrunt_config(find_in_parent_folders("defaults.hcl")).locals
 }
 
 inputs = {
@@ -59,8 +58,8 @@ inputs = {
           }
         },
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           ref            = "values"
           path           = "."
           directory = {
@@ -68,8 +67,8 @@ inputs = {
           }
         },
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           path           = "clusters/homelab/apps/litellm"
           kustomize      = {}
         }

--- a/IaC/live/argocd-apps/media-postgres/terragrunt.hcl
+++ b/IaC/live/argocd-apps/media-postgres/terragrunt.hcl
@@ -18,8 +18,7 @@ dependencies {
 }
 
 locals {
-  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
-  target_revision = "main"
+  app_defaults = read_terragrunt_config(find_in_parent_folders("defaults.hcl")).locals
 }
 
 inputs = {
@@ -47,8 +46,8 @@ inputs = {
 
       sources = [
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           path           = "clusters/homelab/apps/media-postgres"
           kustomize      = {}
         }

--- a/IaC/live/argocd-apps/n8n-postgres/terragrunt.hcl
+++ b/IaC/live/argocd-apps/n8n-postgres/terragrunt.hcl
@@ -18,8 +18,7 @@ dependencies {
 }
 
 locals {
-  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
-  target_revision = "main"
+  app_defaults = read_terragrunt_config(find_in_parent_folders("defaults.hcl")).locals
 }
 
 inputs = {
@@ -47,8 +46,8 @@ inputs = {
 
       sources = [
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           path           = "clusters/homelab/apps/n8n-postgres"
           kustomize      = {}
         }

--- a/IaC/live/argocd-apps/n8n/terragrunt.hcl
+++ b/IaC/live/argocd-apps/n8n/terragrunt.hcl
@@ -21,8 +21,7 @@ dependencies {
 }
 
 locals {
-  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
-  target_revision = "main"
+  app_defaults = read_terragrunt_config(find_in_parent_folders("defaults.hcl")).locals
 }
 
 inputs = {
@@ -60,8 +59,8 @@ inputs = {
           }
         },
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           ref            = "values"
           path           = "."
           directory = {
@@ -69,8 +68,8 @@ inputs = {
           }
         },
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           path           = "clusters/homelab/apps/n8n"
           kustomize      = {}
         }

--- a/IaC/live/argocd-apps/octelium-cluster/terragrunt.hcl
+++ b/IaC/live/argocd-apps/octelium-cluster/terragrunt.hcl
@@ -19,8 +19,7 @@ dependencies {
 }
 
 locals {
-  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
-  target_revision = "main"
+  app_defaults = read_terragrunt_config(find_in_parent_folders("defaults.hcl")).locals
 }
 
 inputs = {
@@ -48,8 +47,8 @@ inputs = {
 
       sources = [
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           path           = "clusters/homelab/apps/octelium-cluster"
           kustomize      = {}
         }

--- a/IaC/live/argocd-apps/octelium-enterprise/terragrunt.hcl
+++ b/IaC/live/argocd-apps/octelium-enterprise/terragrunt.hcl
@@ -18,8 +18,7 @@ dependencies {
 }
 
 locals {
-  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
-  target_revision = "main"
+  app_defaults = read_terragrunt_config(find_in_parent_folders("defaults.hcl")).locals
 }
 
 inputs = {
@@ -47,8 +46,8 @@ inputs = {
 
       sources = [
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           path           = "clusters/homelab/apps/octelium-enterprise"
           kustomize      = {}
         }

--- a/IaC/live/argocd-apps/octelium-public/terragrunt.hcl
+++ b/IaC/live/argocd-apps/octelium-public/terragrunt.hcl
@@ -19,8 +19,7 @@ dependencies {
 }
 
 locals {
-  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
-  target_revision = "main"
+  app_defaults = read_terragrunt_config(find_in_parent_folders("defaults.hcl")).locals
 }
 
 inputs = {
@@ -48,8 +47,8 @@ inputs = {
 
       sources = [
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           path           = "clusters/homelab/apps/octelium-public"
           kustomize      = {}
         }

--- a/IaC/live/argocd-apps/octelium-storage/terragrunt.hcl
+++ b/IaC/live/argocd-apps/octelium-storage/terragrunt.hcl
@@ -18,8 +18,7 @@ dependencies {
 }
 
 locals {
-  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
-  target_revision = "main"
+  app_defaults = read_terragrunt_config(find_in_parent_folders("defaults.hcl")).locals
 }
 
 inputs = {
@@ -47,8 +46,8 @@ inputs = {
 
       sources = [
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           path           = "clusters/homelab/apps/octelium-storage"
           kustomize      = {}
         }

--- a/IaC/live/argocd-apps/octelium/terragrunt.hcl
+++ b/IaC/live/argocd-apps/octelium/terragrunt.hcl
@@ -18,8 +18,7 @@ dependencies {
 }
 
 locals {
-  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
-  target_revision = "main"
+  app_defaults = read_terragrunt_config(find_in_parent_folders("defaults.hcl")).locals
 }
 
 inputs = {
@@ -47,8 +46,8 @@ inputs = {
 
       sources = [
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           path           = "clusters/homelab/apps/octelium"
           kustomize      = {}
         }

--- a/IaC/live/argocd-apps/octobot/terragrunt.hcl
+++ b/IaC/live/argocd-apps/octobot/terragrunt.hcl
@@ -19,8 +19,7 @@ dependencies {
 }
 
 locals {
-  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
-  target_revision = "main"
+  app_defaults = read_terragrunt_config(find_in_parent_folders("defaults.hcl")).locals
 }
 
 inputs = {
@@ -58,8 +57,8 @@ inputs = {
           }
         },
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           ref            = "values"
           path           = "."
           directory = {
@@ -67,8 +66,8 @@ inputs = {
           }
         },
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           path           = "clusters/homelab/apps/octobot"
           kustomize      = {}
         }

--- a/IaC/live/argocd-apps/openclaw/terragrunt.hcl
+++ b/IaC/live/argocd-apps/openclaw/terragrunt.hcl
@@ -21,8 +21,7 @@ dependencies {
 }
 
 locals {
-  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
-  target_revision = "main"
+  app_defaults = read_terragrunt_config(find_in_parent_folders("defaults.hcl")).locals
 }
 
 inputs = {
@@ -60,8 +59,8 @@ inputs = {
           }
         },
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           ref            = "values"
           path           = "."
           directory = {
@@ -69,8 +68,8 @@ inputs = {
           }
         },
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           path           = "clusters/homelab/apps/openclaw"
           kustomize      = {}
         }

--- a/IaC/live/argocd-apps/platform-dns/terragrunt.hcl
+++ b/IaC/live/argocd-apps/platform-dns/terragrunt.hcl
@@ -15,8 +15,7 @@ dependencies {
 }
 
 locals {
-  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
-  target_revision = "main"
+  app_defaults = read_terragrunt_config(find_in_parent_folders("defaults.hcl")).locals
 }
 
 inputs = {
@@ -44,8 +43,8 @@ inputs = {
 
       sources = [
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           path           = "clusters/homelab/platform/dns"
           kustomize      = {}
         }

--- a/IaC/live/argocd-apps/platform-multus/terragrunt.hcl
+++ b/IaC/live/argocd-apps/platform-multus/terragrunt.hcl
@@ -11,8 +11,7 @@ terraform {
 }
 
 locals {
-  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
-  target_revision = "main"
+  app_defaults = read_terragrunt_config(find_in_parent_folders("defaults.hcl")).locals
 }
 
 inputs = {
@@ -40,8 +39,8 @@ inputs = {
 
       sources = [
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           path           = "clusters/homelab/platform/multus"
           kustomize      = {}
         }

--- a/IaC/live/argocd-apps/platform-storage/terragrunt.hcl
+++ b/IaC/live/argocd-apps/platform-storage/terragrunt.hcl
@@ -15,8 +15,7 @@ dependencies {
 }
 
 locals {
-  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
-  target_revision = "main"
+  app_defaults = read_terragrunt_config(find_in_parent_folders("defaults.hcl")).locals
 }
 
 inputs = {
@@ -44,8 +43,8 @@ inputs = {
 
       sources = [
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           path           = "clusters/homelab/platform/storage"
           kustomize      = {}
         }

--- a/IaC/live/argocd-apps/policy-bot/terragrunt.hcl
+++ b/IaC/live/argocd-apps/policy-bot/terragrunt.hcl
@@ -19,8 +19,7 @@ dependencies {
 }
 
 locals {
-  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
-  target_revision = "main"
+  app_defaults = read_terragrunt_config(find_in_parent_folders("defaults.hcl")).locals
 }
 
 inputs = {
@@ -48,8 +47,8 @@ inputs = {
 
       sources = [
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           path           = "clusters/homelab/apps/policy-bot"
           kustomize      = {}
         }

--- a/IaC/live/argocd-apps/prometheus/terragrunt.hcl
+++ b/IaC/live/argocd-apps/prometheus/terragrunt.hcl
@@ -18,8 +18,7 @@ dependencies {
 }
 
 locals {
-  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
-  target_revision = "main"
+  app_defaults = read_terragrunt_config(find_in_parent_folders("defaults.hcl")).locals
 }
 
 inputs = {
@@ -57,8 +56,8 @@ inputs = {
           }
         },
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           ref            = "values"
           path           = "."
           directory = {
@@ -66,8 +65,8 @@ inputs = {
           }
         },
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           path           = "clusters/homelab/apps/prometheus"
           kustomize      = {}
         }

--- a/IaC/live/argocd-apps/prowlarr/terragrunt.hcl
+++ b/IaC/live/argocd-apps/prowlarr/terragrunt.hcl
@@ -20,8 +20,7 @@ dependencies {
 }
 
 locals {
-  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
-  target_revision = "main"
+  app_defaults = read_terragrunt_config(find_in_parent_folders("defaults.hcl")).locals
 }
 
 inputs = {
@@ -59,8 +58,8 @@ inputs = {
           }
         },
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           ref            = "values"
           path           = "."
           directory = {
@@ -68,8 +67,8 @@ inputs = {
           }
         },
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           path           = "clusters/homelab/apps/prowlarr"
           kustomize      = {}
         }

--- a/IaC/live/argocd-apps/radarr/terragrunt.hcl
+++ b/IaC/live/argocd-apps/radarr/terragrunt.hcl
@@ -22,8 +22,7 @@ dependencies {
 }
 
 locals {
-  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
-  target_revision = "main"
+  app_defaults = read_terragrunt_config(find_in_parent_folders("defaults.hcl")).locals
 }
 
 inputs = {
@@ -61,8 +60,8 @@ inputs = {
           }
         },
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           ref            = "values"
           path           = "."
           directory = {
@@ -70,8 +69,8 @@ inputs = {
           }
         },
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           path           = "clusters/homelab/apps/radarr"
           kustomize      = {}
         }

--- a/IaC/live/argocd-apps/sonarr/terragrunt.hcl
+++ b/IaC/live/argocd-apps/sonarr/terragrunt.hcl
@@ -22,8 +22,7 @@ dependencies {
 }
 
 locals {
-  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
-  target_revision = "main"
+  app_defaults = read_terragrunt_config(find_in_parent_folders("defaults.hcl")).locals
 }
 
 inputs = {
@@ -61,8 +60,8 @@ inputs = {
           }
         },
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           ref            = "values"
           path           = "."
           directory = {
@@ -70,8 +69,8 @@ inputs = {
           }
         },
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           path           = "clusters/homelab/apps/sonarr"
           kustomize      = {}
         }

--- a/IaC/live/argocd-apps/tailscale/terragrunt.hcl
+++ b/IaC/live/argocd-apps/tailscale/terragrunt.hcl
@@ -18,8 +18,7 @@ dependencies {
 }
 
 locals {
-  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
-  target_revision = "main"
+  app_defaults = read_terragrunt_config(find_in_parent_folders("defaults.hcl")).locals
 }
 
 inputs = {
@@ -57,8 +56,8 @@ inputs = {
           }
         },
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           ref            = "values"
           path           = "."
           directory = {
@@ -66,8 +65,8 @@ inputs = {
           }
         },
         {
-          repoURL        = local.repo_url
-          targetRevision = local.target_revision
+          repoURL        = local.app_defaults.repo_url
+          targetRevision = local.app_defaults.target_revision
           path           = "clusters/homelab/apps/tailscale"
           kustomize      = {}
         }

--- a/docs/knowledge-base/architecture/gitops-flow.md
+++ b/docs/knowledge-base/architecture/gitops-flow.md
@@ -47,9 +47,10 @@ See [[runbooks/argocd-bootstrap]], [[runbooks/argocd-app-onboarding]], and
 Argo CD Applications are registered through the repository-local
 `IaC/modules/argocd-application-kubernetes` module. Terragrunt passes a raw
 CRD-shaped `manifest`, so Application fields use their native names such as
-`repoURL`, `targetRevision`, and `syncPolicy`. For Git-backed sources that point
-at this repository, set `targetRevision` to `main` unless a temporary
-non-default branch is explicitly documented for testing or recovery.
+`repoURL`, `targetRevision`, and `syncPolicy`. Git-backed source defaults for
+this repository live in `IaC/live/argocd-apps/defaults.hcl`; keep
+`targetRevision` on `main` unless a temporary non-default branch is explicitly
+documented for testing or recovery.
 
 The module delegates the CRD schema to `kubernetes_manifest` while retaining
 repository policy for encrypted state, field-manager ownership, and the small


### PR DESCRIPTION
## Summary
- add one Argo CD app defaults file for this repo URL and target revision
- replace repeated per-app repo_url and target_revision locals with app_defaults reads
- update the GitOps knowledge-base note to point at the shared defaults

## Validation
- terragrunt hcl fmt --check
- terragrunt hcl validate from IaC/live/argocd-apps
- git diff --check