### PR TITLE
chore(argocd): restore application revisions to main

### DIFF
--- a/IaC/live/argocd-apps/deluge/terragrunt.hcl
+++ b/IaC/live/argocd-apps/deluge/terragrunt.hcl
@@ -20,9 +20,8 @@ dependencies {
 }
 
 locals {
-  repo_url = "https://github.com/Stuhlmuller/homelab.git"
-  # Temporary recovery branch so Argo CD can deploy the Deluge fix before merge.
-  target_revision = "codex/deluge-stabilize-metrics"
+  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
+  target_revision = "main"
 }
 
 inputs = {

--- a/IaC/live/argocd-apps/octelium-public/terragrunt.hcl
+++ b/IaC/live/argocd-apps/octelium-public/terragrunt.hcl
@@ -21,8 +21,7 @@ dependencies {
 locals {
   repo_url = "https://github.com/Stuhlmuller/homelab.git"
 
-  # Temporary recovery reference; restore main immediately after this rollout lands.
-  target_revision = "codex/deluge-stabilize-metrics"
+  target_revision = "main"
 }
 
 inputs = {

--- a/IaC/live/argocd-apps/octelium-storage/terragrunt.hcl
+++ b/IaC/live/argocd-apps/octelium-storage/terragrunt.hcl
@@ -18,9 +18,8 @@ dependencies {
 }
 
 locals {
-  repo_url = "https://github.com/Stuhlmuller/homelab.git"
-  # Temporary recovery branch while the PostgreSQL liveness fix is awaiting merge.
-  target_revision = "codex/deluge-stabilize-metrics"
+  repo_url        = "https://github.com/Stuhlmuller/homelab.git"
+  target_revision = "main"
 }
 
 inputs = {


### PR DESCRIPTION
Restores the temporary Deluge and Octelium recovery Application source revisions to main after PR #597 merged.

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `faf02ad94a794422fc98f216b13267319ed311c6`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.

> AzureAD application registration plans were skipped because the plan environment did not provide `ARM_CLIENT_ID`, `ARM_CLIENT_SECRET`, and `ARM_TENANT_ID`. Production apply still fails fast when `IaC/live/azuread-applications` changes and those credentials are absent.


<!-- terragrunt-plan:end -->
