### PR TITLE
fix: recover octelium connections

### DIFF
--- a/clusters/homelab/apps/octelium-storage/README.md
+++ b/clusters/homelab/apps/octelium-storage/README.md
@@ -23,14 +23,16 @@ with AOF enabled. The QNAP NFS export squashes ownership, so both pods run as
 UID/GID 65534 like the other file-backed PostgreSQL workloads in this repo.
 PostgreSQL has 30-minute startup and liveness windows plus a 120-second
 termination grace period so NFS recovery is allowed to complete without a
-crash-recovery loop.
+crash-recovery loop. Readiness and liveness execute `SELECT 1` instead of only
+checking that PostgreSQL accepts a socket connection, so a query-stalled server
+is not reported healthy.
 
 ## Validation
 
 ```sh
 kubectl -n octelium-storage get externalsecret,secret octelium-storage-auth
 kubectl -n octelium-storage get statefulset,pod,pvc,svc
-kubectl -n octelium-storage exec statefulset/octelium-postgres -- pg_isready -U octelium -d octelium
+kubectl -n octelium-storage exec statefulset/octelium-postgres -- psql -U octelium -d octelium -Atqc 'SELECT 1'
 kubectl -n octelium-storage exec statefulset/octelium-redis -- redis-cli ping
 ```
 

--- a/clusters/homelab/apps/octelium-storage/postgres.yaml
+++ b/clusters/homelab/apps/octelium-storage/postgres.yaml
@@ -107,11 +107,13 @@ spec:
           readinessProbe:
             exec:
               command:
-                - pg_isready
+                - psql
                 - -U
                 - octelium
                 - -d
                 - octelium
+                - -Atqc
+                - SELECT 1
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
@@ -119,11 +121,13 @@ spec:
           livenessProbe:
             exec:
               command:
-                - pg_isready
+                - psql
                 - -U
                 - octelium
                 - -d
                 - octelium
+                - -Atqc
+                - SELECT 1
             initialDelaySeconds: 30
             periodSeconds: 30
             timeoutSeconds: 5

--- a/clusters/homelab/apps/octelium/README.md
+++ b/clusters/homelab/apps/octelium/README.md
@@ -28,6 +28,8 @@ The deployed Kubernetes pieces are:
 The Octelium resource catalog for the external Octelium Cluster is
 `docs/examples/octelium/homelab-services.yaml`. It defines:
 
+- Core `ClusterConfig` `default` with a 32-session human limit so stale CLI
+  retries cannot exhaust the default 16-session allowance before expiry.
 - Octelium Namespace `homelab` for apps and Namespace `ci` for CI-only
   transport.
 - Policy `homelab-human-web-access`, which allows authenticated human client
@@ -83,8 +85,12 @@ transport.
 Apply the external Octelium resources to the Octelium Cluster:
 
 ```sh
+octeliumctl apply --include ClusterConfig docs/examples/octelium/homelab-services.yaml
 octeliumctl apply docs/examples/octelium/homelab-services.yaml
 ```
+
+The first command is separate because `--include ClusterConfig` replaces
+`octeliumctl apply`'s normal resource-kind include list.
 
 Configure Microsoft Entra as the portal login provider after
 `IaC/live/azuread-applications/octelium` has applied:
@@ -199,6 +205,7 @@ octelium login --domain stinkyboi.com
 scripts/octelium-entra-oidc.sh \
   --admin-user-name homelab-owner \
   --admin-email '<entra-user-principal-name>'
+octeliumctl apply --include ClusterConfig docs/examples/octelium/homelab-services.yaml
 octeliumctl apply docs/examples/octelium/homelab-services.yaml
 octeliumctl create cred \
   --user homelab-octelium-client \

--- a/docs/examples/octelium/homelab-services.yaml
+++ b/docs/examples/octelium/homelab-services.yaml
@@ -1,3 +1,11 @@
+kind: ClusterConfig
+metadata:
+  name: default
+spec:
+  session:
+    human:
+      maxPerUser: 32
+---
 kind: Policy
 metadata:
   name: homelab-human-web-access

--- a/docs/knowledge-base/architecture/storage-and-state.md
+++ b/docs/knowledge-base/architecture/storage-and-state.md
@@ -70,8 +70,11 @@ until recovery completes. See
 `clusters/homelab/apps/media-postgres/README.md` for the failure mode and
 operator response.
 
-`octelium-postgres` uses the same recovery window. Its availability is required
-for Octelium service publication, including the CI Kubernetes API tunnel.
+`octelium-postgres` uses the same recovery window. Its readiness and liveness
+checks execute `SELECT 1`, preventing a server that accepts connections but
+cannot execute queries from remaining falsely healthy. Its availability is
+required for Octelium service publication, including the CI Kubernetes API
+tunnel.
 
 Deluge also uses 30-minute startup and runtime liveness windows so transient NFS
 stalls do not force repeated libtorrent state reloads. Its pod runs on

--- a/docs/knowledge-base/operations/continuous-improvement.md
+++ b/docs/knowledge-base/operations/continuous-improvement.md
@@ -58,6 +58,26 @@ policy`.
 
 ## Open Findings
 
+- **Status:** desired-state mitigation prepared; live recovery in progress
+- **Area:** Octelium / access recovery
+- **Evidence:** On 2026-07-29, an NFS-backed `octelium-postgres` stall made the
+  public login origin return HTTP 502 while repeated CLI retries accumulated
+  15 disconnected `homelab-owner` client sessions alongside its browser
+  session. Octelium then denied new authentication at the default 16-session
+  ceiling even after PostgreSQL recovered. The service catalog now declares
+  core `ClusterConfig` `default` with human `maxPerUser: 32`; the canonical
+  runbook applies that kind separately before the normal catalog resources.
+  During the confirmed live rollout on 2026-07-29, PostgreSQL again accepted
+  sockets while bounded `SELECT 1` queries timed out and the console save
+  remained pending. The storage manifest now uses `SELECT 1` for readiness and
+  liveness instead of the shallow `pg_isready` check.
+- **Risk:** The larger ceiling restores recovery headroom but does not make the
+  QNAP NFS path reliable; another retry storm could still fill 32 sessions.
+- **Next step:** Keep the existing PostgreSQL availability alert and NFS
+  investigation active. Delete disconnected sessions through
+  `octeliumctl delete session`, and treat renewed PostgreSQL probe failures as
+  the storage incident rather than an Octelium routing failure.
+
 - **Status:** open; alert semantics fixed, scrape failure unresolved
 - **Area:** observability / kube-state-metrics
 - **Evidence:** Read-only checks on 2026-07-19 showed all four expected nodes

--- a/docs/knowledge-base/operations/validation-gates.md
+++ b/docs/knowledge-base/operations/validation-gates.md
@@ -130,7 +130,10 @@ CI/CD Octelium changes should also pass shell syntax checks for
 `scripts/ci/install-kubeconfig.sh`, `scripts/octelium-ci-credential.sh`, and
 `scripts/octelium-ci-kubeconfig-secret.sh`. Validate that
 `docs/examples/octelium/homelab-services.yaml` parses and contains Service
-`kubernetes-api-ci` before applying it with `octeliumctl`.
+`kubernetes-api-ci` plus core `ClusterConfig` `default` with human
+`maxPerUser: 32` before applying it with `octeliumctl`. Apply the
+`ClusterConfig` with `--include ClusterConfig` before the normal catalog apply
+because the include flag replaces the default resource-kind list.
 
 The gate checks the Octelium control plane, IdentityProvider `entra`, synced
 workload credential, ready connector replica, Cluster/API/portal TLS responses,

--- a/docs/knowledge-base/runbooks/octelium.md
+++ b/docs/knowledge-base/runbooks/octelium.md
@@ -6,7 +6,9 @@ Canonical runbook: [`docs/octelium.md`](../../octelium.md)
 
 Octelium is the primary human-app, callback, and CI access backbone. Keep
 Cluster bootstrap, Enterprise adoption, public Cloudflare routing, Entra OIDC,
-and the end-to-end gate on their repository-owned scripts and manifests.
+and the end-to-end gate on their repository-owned scripts and manifests. The
+catalog also owns the core human session ceiling; apply its `ClusterConfig`
+include separately before the normal catalog apply.
 
 See [[../architecture/secrets-and-identity]], [[tailnet-ingress]], and
 [[../workloads/inventory]].

--- a/docs/octelium.md
+++ b/docs/octelium.md
@@ -56,6 +56,9 @@ docs/examples/octelium/homelab-services.yaml
 
 They create:
 
+- Core `ClusterConfig` `default`, raising the human session ceiling to 32 so
+  disconnected CLI retries cannot exhaust the default 16-session allowance
+  before its 16-hour sessions expire.
 - Octelium Namespace `homelab` for the demo and Namespace `ci` for CI-only
   transport.
 - Policy `homelab-human-web-access`, allowing authenticated human client
@@ -115,8 +118,14 @@ route directly.
 Apply the service catalog to the Octelium Cluster:
 
 ```sh
+octeliumctl apply --domain stinkyboi.com \
+  --include ClusterConfig \
+  docs/examples/octelium/homelab-services.yaml
 octeliumctl apply --domain stinkyboi.com docs/examples/octelium/homelab-services.yaml
 ```
+
+`--include ClusterConfig` overrides the normal apply include list, so keep the
+second command to apply the catalog's other resource kinds.
 
 Never add `--prune` to that command: this catalog is not an exhaustive list of
 every non-system resource in the Octelium Cluster. When upgrading a Cluster
@@ -303,6 +312,7 @@ octelium login --domain stinkyboi.com
 scripts/octelium-entra-oidc.sh \
   --admin-user-name homelab-owner \
   --admin-email '<entra-user-principal-name>'
+octeliumctl apply --include ClusterConfig docs/examples/octelium/homelab-services.yaml
 octeliumctl apply docs/examples/octelium/homelab-services.yaml
 octeliumctl create cred \
   --user homelab-octelium-client \


### PR DESCRIPTION
## Summary
- raise the human Octelium session ceiling from 16 to 32 for recovery headroom
- make Octelium PostgreSQL readiness and liveness execute `SELECT 1` so a query-stalled database cannot remain falsely healthy
- document the storage failure mode and the separate ClusterConfig apply path

## Root cause
A QNAP NFS stall left `octelium-postgres` accepting sockets while SQL queries timed out. Login retries accumulated 15 disconnected client sessions plus the browser session, reaching Octelium’s default 16-session ceiling and causing `PermissionDenied`.

## Validation
- `kubectl kustomize clusters/homelab/apps/octelium-storage`
- `kubectl kustomize clusters/homelab/apps/octelium`
- `git diff --check`
- `bash -n scripts/octelium-e2e-check.sh`
- `nix develop --command bash scripts/ci/conftest-policies.sh` (5,751 passed)
- working-tree gitleaks scan passed; the full static gate still reports 12 pre-existing historical findings
- client-side `kubectl diff -k clusters/homelab/apps/octelium-storage` shows only the intended probe commands

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

> Live Terragrunt plan skipped because this pull request did not change `IaC/**`, flake inputs, OpenTofu/Terragrunt policy inputs, or live-plan helper scripts.

Rendered Conftest policies still ran for workflows and Kubernetes manifests in this required check.

<!-- terragrunt-plan:end -->
