### PR TITLE
fix: fence stalled octelium postgres

### DIFF
--- a/clusters/homelab/apps/octelium-storage/postgres.yaml
+++ b/clusters/homelab/apps/octelium-storage/postgres.yaml
@@ -28,7 +28,7 @@ metadata:
     app.kubernetes.io/part-of: octelium
 spec:
   serviceName: octelium-postgres
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app.kubernetes.io/name: octelium-postgres

--- a/docs/knowledge-base/operations/continuous-improvement.md
+++ b/docs/knowledge-base/operations/continuous-improvement.md
@@ -70,7 +70,9 @@ policy`.
   During the confirmed live rollout on 2026-07-29, PostgreSQL again accepted
   sockets while bounded `SELECT 1` queries timed out and the console save
   remained pending. The storage manifest now uses `SELECT 1` for readiness and
-  liveness instead of the shallow `pg_isready` check.
+  liveness instead of the shallow `pg_isready` check. The first recovery phase
+  temporarily fences the StatefulSet at zero replicas without deleting its
+  retained PVC; the required follow-up restores one replica on the new revision.
 - **Risk:** The larger ceiling restores recovery headroom but does not make the
   QNAP NFS path reliable; another retry storm could still fill 32 sessions.
 - **Next step:** Keep the existing PostgreSQL availability alert and NFS


### PR DESCRIPTION
## Summary
- temporarily declare zero `octelium-postgres` replicas so Argo CD cleanly stops the wedged old StatefulSet revision
- preserve the retained `data-octelium-postgres-0` PVC
- record the mandatory follow-up that restores one replica on the new `SELECT 1` probe revision

## Why a staged recovery
The merged deep-probe revision cannot replace the old single pod because the StatefulSet waits for that old pod to become Ready first. The old pod accepts sockets but cannot reliably execute SQL, so it remains stuck on the previous revision.

## Validation
- `kubectl kustomize clusters/homelab/apps/octelium-storage`
- `git diff --check`
- `nix develop --command bash scripts/ci/conftest-policies.sh` (5,751 passed)

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

> Live Terragrunt plan skipped because this pull request did not change `IaC/**`, flake inputs, OpenTofu/Terragrunt policy inputs, or live-plan helper scripts.

Rendered Conftest policies still ran for workflows and Kubernetes manifests in this required check.

<!-- terragrunt-plan:end -->
