### PR TITLE
fix: restore octelium postgres

### DIFF
--- a/clusters/homelab/apps/octelium-storage/postgres.yaml
+++ b/clusters/homelab/apps/octelium-storage/postgres.yaml
@@ -28,7 +28,7 @@ metadata:
     app.kubernetes.io/part-of: octelium
 spec:
   serviceName: octelium-postgres
-  replicas: 0
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: octelium-postgres

--- a/docs/knowledge-base/operations/continuous-improvement.md
+++ b/docs/knowledge-base/operations/continuous-improvement.md
@@ -58,7 +58,7 @@ policy`.
 
 ## Open Findings
 
-- **Status:** desired-state mitigation prepared; live recovery in progress
+- **Status:** desired-state recovery complete; live verification pending
 - **Area:** Octelium / access recovery
 - **Evidence:** On 2026-07-29, an NFS-backed `octelium-postgres` stall made the
   public login origin return HTTP 502 while repeated CLI retries accumulated
@@ -72,7 +72,7 @@ policy`.
   remained pending. The storage manifest now uses `SELECT 1` for readiness and
   liveness instead of the shallow `pg_isready` check. The first recovery phase
   temporarily fences the StatefulSet at zero replicas without deleting its
-  retained PVC; the required follow-up restores one replica on the new revision.
+  retained PVC; this follow-up restores one replica on the new revision.
 - **Risk:** The larger ceiling restores recovery headroom but does not make the
   QNAP NFS path reliable; another retry storm could still fill 32 sessions.
 - **Next step:** Keep the existing PostgreSQL availability alert and NFS


### PR DESCRIPTION
## Summary
- restore one `octelium-postgres` replica after the declarative fencing phase
- keep the retained PVC and new `SELECT 1` readiness/liveness probes
- mark desired-state recovery complete pending live verification

## Validation
- `kubectl kustomize clusters/homelab/apps/octelium-storage`
- `git diff --check`
- `nix develop --command bash scripts/ci/conftest-policies.sh` (5,751 passed)

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

> Live Terragrunt plan skipped because this pull request did not change `IaC/**`, flake inputs, OpenTofu/Terragrunt policy inputs, or live-plan helper scripts.

Rendered Conftest policies still ran for workflows and Kubernetes manifests in this required check.

<!-- terragrunt-plan:end -->
