### PR TITLE
fix: move octelium postgres off acer

### DIFF
--- a/clusters/homelab/apps/octelium-storage/README.md
+++ b/clusters/homelab/apps/octelium-storage/README.md
@@ -25,7 +25,9 @@ PostgreSQL has 30-minute startup and liveness windows plus a 120-second
 termination grace period so NFS recovery is allowed to complete without a
 crash-recovery loop. Readiness and liveness execute `SELECT 1` instead of only
 checking that PostgreSQL accepts a socket connection, so a query-stalled server
-is not reported healthy.
+is not reported healthy. The pod is pinned to `zimaboard-1`, whose NFS client
+remained responsive during the 2026-07-29 incident that repeatedly stalled the
+same retained claim on `acer`.
 
 ## Validation
 

--- a/clusters/homelab/apps/octelium-storage/postgres.yaml
+++ b/clusters/homelab/apps/octelium-storage/postgres.yaml
@@ -39,6 +39,8 @@ spec:
         app.kubernetes.io/part-of: octelium
     spec:
       automountServiceAccountToken: false
+      nodeSelector:
+        kubernetes.io/hostname: zimaboard-1
       terminationGracePeriodSeconds: 120
       securityContext:
         fsGroup: 65534

--- a/docs/knowledge-base/architecture/storage-and-state.md
+++ b/docs/knowledge-base/architecture/storage-and-state.md
@@ -72,9 +72,10 @@ operator response.
 
 `octelium-postgres` uses the same recovery window. Its readiness and liveness
 checks execute `SELECT 1`, preventing a server that accepts connections but
-cannot execute queries from remaining falsely healthy. Its availability is
-required for Octelium service publication, including the CI Kubernetes API
-tunnel.
+cannot execute queries from remaining falsely healthy. It is pinned to
+`zimaboard-1` to avoid the repeatedly stalled `acer` NFS client path. Its
+availability is required for Octelium service publication, including the CI
+Kubernetes API tunnel.
 
 Deluge also uses 30-minute startup and runtime liveness windows so transient NFS
 stalls do not force repeated libtorrent state reloads. Its pod runs on

--- a/docs/knowledge-base/operations/continuous-improvement.md
+++ b/docs/knowledge-base/operations/continuous-improvement.md
@@ -58,7 +58,7 @@ policy`.
 
 ## Open Findings
 
-- **Status:** desired-state recovery complete; live verification pending
+- **Status:** placement fix prepared; live verification pending
 - **Area:** Octelium / access recovery
 - **Evidence:** On 2026-07-29, an NFS-backed `octelium-postgres` stall made the
   public login origin return HTTP 502 while repeated CLI retries accumulated
@@ -72,7 +72,10 @@ policy`.
   remained pending. The storage manifest now uses `SELECT 1` for readiness and
   liveness instead of the shallow `pg_isready` check. The first recovery phase
   temporarily fences the StatefulSet at zero replicas without deleting its
-  retained PVC; this follow-up restores one replica on the new revision.
+  retained PVC; the follow-up restores one replica on the new revision. That
+  fresh pod stalled again on `acer`, while earlier node-level NFS evidence
+  showed millions of write timeouts there and almost none on the ZimaBoards.
+  Desired state now pins only `octelium-postgres` to `zimaboard-1`.
 - **Risk:** The larger ceiling restores recovery headroom but does not make the
   QNAP NFS path reliable; another retry storm could still fill 32 sessions.
 - **Next step:** Keep the existing PostgreSQL availability alert and NFS


### PR DESCRIPTION
## Summary
- pin `octelium-postgres` to `zimaboard-1`
- keep the retained NFS PVC and deep `SELECT 1` probes
- document why the workload must avoid the unhealthy `acer` NFS client path

## Evidence
The fresh PostgreSQL pod stalled again immediately on `acer`. Earlier node-level NFS telemetry recorded millions of WRITE RPC timeouts on `acer`, versus only tens on `zimaboard-0` and `zimaboard-1`. `zimaboard-1` currently has 29% requested CPU and 38% requested memory, with no taints.

## Validation
- `kubectl kustomize clusters/homelab/apps/octelium-storage`
- `git diff --check`
- `nix develop --command bash scripts/ci/conftest-policies.sh` (5,751 passed)

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

> Live Terragrunt plan skipped because this pull request did not change `IaC/**`, flake inputs, OpenTofu/Terragrunt policy inputs, or live-plan helper scripts.

Rendered Conftest policies still ran for workflows and Kubernetes manifests in this required check.

<!-- terragrunt-plan:end -->
