### PR TITLE
fix: restart stalled octelium postgres

### DIFF
--- a/clusters/homelab/apps/octelium-storage/README.md
+++ b/clusters/homelab/apps/octelium-storage/README.md
@@ -21,13 +21,12 @@ then deletes the temporary file.
 PostgreSQL uses a 20Gi `nfs-default` PVC. Redis uses a 5Gi `nfs-default` PVC
 with AOF enabled. The QNAP NFS export squashes ownership, so both pods run as
 UID/GID 65534 like the other file-backed PostgreSQL workloads in this repo.
-PostgreSQL has 30-minute startup and liveness windows plus a 120-second
-termination grace period so NFS recovery is allowed to complete without a
-crash-recovery loop. Readiness and liveness execute `SELECT 1` instead of only
-checking that PostgreSQL accepts a socket connection, so a query-stalled server
-is not reported healthy. The pod is pinned to `zimaboard-1`, whose NFS client
-remained responsive during the 2026-07-29 incident that repeatedly stalled the
-same retained claim on `acer`.
+PostgreSQL has a 30-minute startup window, a 90-second runtime liveness window,
+and a 120-second termination grace period. Readiness and liveness execute
+`SELECT 1` instead of only checking that PostgreSQL accepts a socket connection,
+so a query-stalled server is removed from service and restarted promptly. The
+pod is pinned to `zimaboard-1`; this avoids the worst observed NFS client but
+does not make QNAP NFS reliable database storage.
 
 ## Validation
 

--- a/clusters/homelab/apps/octelium-storage/postgres.yaml
+++ b/clusters/homelab/apps/octelium-storage/postgres.yaml
@@ -133,7 +133,7 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 30
             timeoutSeconds: 5
-            failureThreshold: 60
+            failureThreshold: 3
           resources:
             requests:
               cpu: 100m

--- a/docs/knowledge-base/architecture/storage-and-state.md
+++ b/docs/knowledge-base/architecture/storage-and-state.md
@@ -70,12 +70,13 @@ until recovery completes. See
 `clusters/homelab/apps/media-postgres/README.md` for the failure mode and
 operator response.
 
-`octelium-postgres` uses the same recovery window. Its readiness and liveness
-checks execute `SELECT 1`, preventing a server that accepts connections but
-cannot execute queries from remaining falsely healthy. It is pinned to
-`zimaboard-1` to avoid the repeatedly stalled `acer` NFS client path. Its
-availability is required for Octelium service publication, including the CI
-Kubernetes API tunnel.
+`octelium-postgres` keeps the 30-minute startup window but uses a 90-second
+runtime liveness window. Its readiness and liveness checks execute `SELECT 1`,
+preventing a server that accepts connections but cannot execute queries from
+remaining falsely healthy. It is pinned to `zimaboard-1` to avoid the worst
+observed NFS client path, but QNAP NFS remains a database availability risk.
+Its availability is required for Octelium service publication, including the
+CI Kubernetes API tunnel.
 
 Deluge also uses 30-minute startup and runtime liveness windows so transient NFS
 stalls do not force repeated libtorrent state reloads. Its pod runs on

--- a/docs/knowledge-base/operations/continuous-improvement.md
+++ b/docs/knowledge-base/operations/continuous-improvement.md
@@ -58,7 +58,7 @@ policy`.
 
 ## Open Findings
 
-- **Status:** placement fix prepared; live verification pending
+- **Status:** mitigated; local database storage still required
 - **Area:** Octelium / access recovery
 - **Evidence:** On 2026-07-29, an NFS-backed `octelium-postgres` stall made the
   public login origin return HTTP 502 while repeated CLI retries accumulated
@@ -75,13 +75,19 @@ policy`.
   retained PVC; the follow-up restores one replica on the new revision. That
   fresh pod stalled again on `acer`, while earlier node-level NFS evidence
   showed millions of write timeouts there and almost none on the ZimaBoards.
-  Desired state now pins only `octelium-postgres` to `zimaboard-1`.
+  Desired state now pins only `octelium-postgres` to `zimaboard-1`. Live
+  verification then caught the same retained NFS claim query-stalling again on
+  `zimaboard-1`; the SQL liveness probe correctly marked the pod unready. The
+  runtime liveness window is now 90 seconds so this failure restarts instead of
+  leaving Octelium authentication unavailable for 30 minutes.
 - **Risk:** The larger ceiling restores recovery headroom but does not make the
   QNAP NFS path reliable; another retry storm could still fill 32 sessions.
-- **Next step:** Keep the existing PostgreSQL availability alert and NFS
-  investigation active. Delete disconnected sessions through
-  `octeliumctl delete session`, and treat renewed PostgreSQL probe failures as
-  the storage incident rather than an Octelium routing failure.
+- **Next step:** Move PostgreSQL to reviewed local block storage; the cluster
+  currently exposes only `nfs-default`, so that migration needs a declared
+  Talos volume and Kubernetes storage path. Keep the availability alert active,
+  delete disconnected sessions through `octeliumctl delete session`, and treat
+  renewed probe failures as the storage incident rather than an Octelium
+  routing failure.
 
 - **Status:** open; alert semantics fixed, scrape failure unresolved
 - **Area:** observability / kube-state-metrics


### PR DESCRIPTION
## Summary
- restart Octelium PostgreSQL after 90 seconds of failed SQL liveness checks
- retain the 30-minute startup recovery window and 120-second termination grace
- record that QNAP NFS remains the root availability risk and local block storage is still required

## Validation
- kubectl kustomize clusters/homelab/apps/octelium-storage
- kubectl apply --dry-run=client -f rendered.yaml
- nix develop --command bash scripts/ci/conftest-policies.sh (5751 passed)
- git diff --check

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

> Live Terragrunt plan skipped because this pull request did not change `IaC/**`, flake inputs, OpenTofu/Terragrunt policy inputs, or live-plan helper scripts.

Rendered Conftest policies still ran for workflows and Kubernetes manifests in this required check.

<!-- terragrunt-plan:end -->
