### PR TITLE
fix(media): stage postgres local storage cutover

### DIFF
--- a/clusters/homelab/apps/media-postgres/README.md
+++ b/clusters/homelab/apps/media-postgres/README.md
@@ -1,8 +1,9 @@
 # Media PostgreSQL
 
 `media-postgres` is the shared PostgreSQL 14 instance for Sonarr, Radarr, and
-Prowlarr. It runs in the `media` namespace, persists data on the `nfs-default`
-StorageClass, and exposes only the in-cluster Service
+Prowlarr. It runs in the `media` namespace. During the first cutover phase, it
+cold-copies its active database to the static `media-postgres-local` volume
+pinned to `acer`, serves it read-only, and exposes only the in-cluster Service
 `media-postgres.media.svc.cluster.local:5432`.
 
 ## Secret Contract
@@ -22,22 +23,55 @@ first initialization. This is intentional here because the Servarr Prowlarr
 PostgreSQL guide states that Prowlarr housekeeping needs a superuser for vacuum
 work. Revisit this before adding unrelated apps to this database instance.
 
-`PGDATA` points at a `pgdata` subdirectory inside the PVC. The pod runs as
-UID/GID 65534 because the QNAP NFS export squashes writes to its anonymous user
-and denies `chown`; PostgreSQL requires the server process to own the data
-directory.
+`PGDATA` points at a `pgdata` subdirectory inside the PVC. PostgreSQL continues
+to run as UID/GID 65534 so the one-time NFS copy preserves ownership without
+rewriting every database file.
+
+## Local Storage Cutover
+
+Repeated QNAP NFSv3 stalls made PostgreSQL accept connections while ordinary
+queries took tens of seconds or failed. The active database therefore uses a
+20 Gi static volume backed by `/var/lib/media-postgres` on `acer`'s Talos
+`EPHEMERAL` filesystem. The Kubernetes PV has `Retain` policy and hostname node
+affinity. The requested 20 Gi capacity is descriptive because `hostPath` does
+not enforce a quota; verify `acer` filesystem capacity during rollout and
+monitor it directly in steady state.
+
+On the first rollout, StatefulSet ordering stops the old pod before the new pod
+starts. `migrate-nfs-data` then copies the stopped NFS `pgdata` directory into
+an atomic staging directory on the local volume, verifies PostgreSQL major
+version 14, removes only the copied stale `postmaster.pid`, and renames the
+completed copy into place. Later starts skip the copy when local `PG_VERSION`
+already exists.
+
+The first phase starts PostgreSQL with
+`listen_addresses=''` and `default_transaction_read_only=on`. Disabling TCP is
+the hard fence for Sonarr, Radarr, and Prowlarr writes. The pinned
+`media-postgres-cutover-backup` Job connects through a Unix socket shared on the
+local volume and writes verified logical dumps of all six databases to the
+retained NFS claim.
+
+After the copy and backup are verified, the second phase must scale the legacy
+StatefulSet to zero and create a clean replacement StatefulSet that mounts only
+`media-postgres-local`, with neither the legacy `volumeClaimTemplates` nor the
+migration init container. Only that replacement re-enables writes. Removing
+the init container from the existing StatefulSet is insufficient because its
+immutable claim template would still mount the old NFS claim.
+
+This local volume survives ordinary Talos reboots and upgrades because `/var`
+is the Talos `EPHEMERAL` system volume, but it is node-bound and is lost if
+`acer` is reset or its system disk fails. Move it to a dedicated Talos
+UserVolume if the database grows materially or node-local recovery becomes
+unacceptable.
 
 ## Recovery Probes
 
 The startup probe allows PostgreSQL up to 30 minutes to finish crash recovery
-before Kubernetes enables its liveness and readiness probes. This prevents a
-slow NFS recovery from becoming a restart loop where the liveness probe kills
-PostgreSQL before it can accept connections. The readiness probe still removes
-the database from the Service until `pg_isready` succeeds. After startup, the
-liveness probe also requires 30 minutes of continuous failures before
-restarting PostgreSQL. This keeps an intermittent NFS stall from turning a
-temporarily unavailable database into repeated crash recovery while dependent
-apps remain protected by readiness.
+before Kubernetes enables its liveness and readiness probes. Readiness executes
+`SELECT 1`, so a process that merely accepts a socket while database work is
+stalled is removed from the Service. Liveness remains the recovery-tolerant
+`pg_isready` check and requires 30 minutes of continuous failures before
+restarting PostgreSQL.
 
 The pod also has a 120-second termination grace period so PostgreSQL has more
 time to finish a fast shutdown without being forcibly killed. If startup
@@ -80,31 +114,50 @@ Upstream migration references:
 
 ## Validation
 
-After Argo CD syncs `media-postgres`, verify the secret, StatefulSet, PVC, and
-database list:
+After Argo CD syncs the first cutover phase, verify the secret, local volume,
+StatefulSet, migration marker, read-only fence, database list, query latency,
+and completed backup:
 
 ```sh
 kubectl -n media get externalsecret media-postgres-auth media-postgres-arr-env
 kubectl -n media get secret media-postgres-auth media-postgres-arr-env
+kubectl get storageclass,persistentvolume media-postgres-local
 kubectl -n media get statefulset,pod,pvc,svc -l app.kubernetes.io/name=media-postgres
+kubectl -n media get pod media-postgres-0 -o wide
+kubectl -n media exec statefulset/media-postgres -- \
+  test -f /var/lib/postgresql/data/pgdata/.nfs-migration-complete
 kubectl -n media exec statefulset/media-postgres -- psql -U media_apps -d media_apps -c '\l'
+kubectl -n media exec statefulset/media-postgres -- \
+  psql -U media_apps -d media_apps -c 'SELECT 1'
+kubectl -n media exec statefulset/media-postgres -- \
+  psql -U media_apps -d media_apps -Atqc 'SHOW default_transaction_read_only'
+kubectl -n media exec statefulset/media-postgres -- \
+  psql -U media_apps -d media_apps -Atqc 'SHOW listen_addresses'
+kubectl -n media get job media-postgres-cutover-backup
 ```
 
 The database list should include `sonarr-main`, `sonarr-log`, `radarr-main`,
-`radarr-log`, `prowlarr-main`, and `prowlarr-log`.
+`radarr-log`, `prowlarr-main`, and `prowlarr-log`. The pod must run on `acer`,
+the read-only setting must report `on`, repeated `SELECT 1` calls should
+complete without the NFS-correlated stalls, `listen_addresses` must be empty,
+and the backup Job must complete.
 
 ## Backup And Restore
 
-NFS snapshots protect the PostgreSQL volume, but application-ready restore
-requires logical dumps. Before upgrades or storage maintenance, dump each app
-database and keep the dump with the matching app config backup:
+`media-postgres-cutover-backup` writes one verified recovery set containing
+custom-format dumps for all six databases, role globals, and checksums under
+`logical-backups/` on the retained NFS claim. This is a first-phase cutover
+gate, not the steady-state backup schedule. The writable replacement phase must
+replace it with a nightly CronJob before the cutover is complete.
 
 ```sh
-kubectl -n media exec statefulset/media-postgres -- pg_dump -U media_apps sonarr-main
-kubectl -n media exec statefulset/media-postgres -- pg_dump -U media_apps radarr-main
-kubectl -n media exec statefulset/media-postgres -- pg_dump -U media_apps prowlarr-main
+kubectl -n media get job media-postgres-cutover-backup
+kubectl -n media logs job/media-postgres-cutover-backup
 ```
 
-For a full restore, restore the PostgreSQL PVC or recreate the databases from
-logical dumps, restore each app's `/config` PVC backup, then re-sync Sonarr,
-Radarr, and Prowlarr through Argo CD.
+For a full restore, declare a fresh local volume in Git, restore globals and
+the six matching dumps through a repository-owned recovery Job, restore each
+app's `/config` backup, then re-sync Sonarr, Radarr, and Prowlarr. The retained
+NFS `pgdata` copy is a valid immediate rollback point only before writes reach
+the local database; afterward, rollback requires a fresh logical dump and
+restore rather than reattaching the stale NFS copy.

--- a/clusters/homelab/apps/media-postgres/cutover-backup-job.yaml
+++ b/clusters/homelab/apps/media-postgres/cutover-backup-job.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: media
   annotations:
     argocd.argoproj.io/sync-wave: "1"
+    checkov.io/skip1: CKV2_K8S_6=The cutover Job is covered by networkpolicy.yaml; diff-only scans do not include sibling manifests.
   labels:
     app.kubernetes.io/name: media-postgres-cutover-backup
     app.kubernetes.io/part-of: homelab-media
@@ -46,6 +47,7 @@ spec:
                 --host=/local \
                 --port=5432 \
                 --username=media_apps \
+                --no-role-passwords \
                 --globals-only > "${partial}/globals.sql"
 
               for database in \

--- a/clusters/homelab/apps/media-postgres/cutover-backup-job.yaml
+++ b/clusters/homelab/apps/media-postgres/cutover-backup-job.yaml
@@ -74,6 +74,7 @@ spec:
                 cd "$complete"
                 sha256sum --check SHA256SUMS
               )
+              echo "completed backup ${timestamp}: ${complete}"
           resources:
             requests:
               cpu: 25m

--- a/clusters/homelab/apps/media-postgres/cutover-backup-job.yaml
+++ b/clusters/homelab/apps/media-postgres/cutover-backup-job.yaml
@@ -1,0 +1,101 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: media-postgres-cutover-backup
+  namespace: media
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+  labels:
+    app.kubernetes.io/name: media-postgres-cutover-backup
+    app.kubernetes.io/part-of: homelab-media
+spec:
+  activeDeadlineSeconds: 1800
+  backoffLimit: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: media-postgres-cutover-backup
+        app.kubernetes.io/part-of: homelab-media
+    spec:
+      automountServiceAccountToken: false
+      nodeSelector:
+        kubernetes.io/hostname: acer
+      restartPolicy: Never
+      securityContext:
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: backup
+          image: postgres:14.23-bookworm@sha256:70b9c8977b5fb87bd55c9e29472d778d76d56a6266143d47259da13d78a72afa
+          imagePullPolicy: Always
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              umask 0077
+              timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+              backup_root=/backup/logical-backups
+              partial="${backup_root}/.${timestamp}.partial"
+              complete="${backup_root}/${timestamp}"
+              mkdir -p "$partial"
+
+              pg_dumpall \
+                --host=/local \
+                --port=5432 \
+                --username=media_apps \
+                --globals-only > "${partial}/globals.sql"
+
+              for database in \
+                sonarr-main sonarr-log \
+                radarr-main radarr-log \
+                prowlarr-main prowlarr-log
+              do
+                pg_dump \
+                  --host=/local \
+                  --port=5432 \
+                  --username=media_apps \
+                  --format=custom \
+                  --file="${partial}/${database}.dump" \
+                  "$database"
+                pg_restore --list "${partial}/${database}.dump" >/dev/null
+              done
+
+              (
+                cd "$partial"
+                sha256sum globals.sql ./*.dump > SHA256SUMS
+              )
+              mv "$partial" "$complete"
+              (
+                cd "$complete"
+                sha256sum --check SHA256SUMS
+              )
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: local-data
+              mountPath: /local
+              readOnly: true
+            - name: legacy-data
+              mountPath: /backup
+      volumes:
+        - name: local-data
+          persistentVolumeClaim:
+            claimName: media-postgres-local
+            readOnly: true
+        - name: legacy-data
+          persistentVolumeClaim:
+            claimName: data-media-postgres-0

--- a/clusters/homelab/apps/media-postgres/kustomization.yaml
+++ b/clusters/homelab/apps/media-postgres/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - cutover-backup-job.yaml
   - externalsecret.yaml
   - initdb-configmap.yaml
+  - local-storage.yaml
   - networkpolicy.yaml
   - service.yaml
   - statefulset.yaml

--- a/clusters/homelab/apps/media-postgres/local-storage.yaml
+++ b/clusters/homelab/apps/media-postgres/local-storage.yaml
@@ -1,0 +1,67 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: media-postgres-local
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+provisioner: kubernetes.io/no-provisioner
+reclaimPolicy: Retain
+volumeBindingMode: Immediate
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: media-postgres-local
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
+    argocd.argoproj.io/sync-wave: "-2"
+  labels:
+    app.kubernetes.io/name: media-postgres
+    app.kubernetes.io/part-of: homelab-media
+    homelab.stuhlmuller.dev/storage-backend: talos-ephemeral-local
+spec:
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: 20Gi
+  claimRef:
+    name: media-postgres-local
+    namespace: media
+  hostPath:
+    # ponytail: one static volume avoids a cluster-wide provisioner; move this
+    # to a dedicated Talos UserVolume if node-local recovery or growth demands it.
+    path: /var/lib/media-postgres
+    type: DirectoryOrCreate
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/hostname
+              operator: In
+              values:
+                - acer
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: media-postgres-local
+  volumeMode: Filesystem
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: media-postgres-local
+  namespace: media
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
+    argocd.argoproj.io/sync-wave: "-2"
+  labels:
+    app.kubernetes.io/name: media-postgres
+    app.kubernetes.io/part-of: homelab-media
+    homelab.stuhlmuller.dev/storage-backend: talos-ephemeral-local
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+  storageClassName: media-postgres-local
+  volumeMode: Filesystem
+  volumeName: media-postgres-local

--- a/clusters/homelab/apps/media-postgres/networkpolicy.yaml
+++ b/clusters/homelab/apps/media-postgres/networkpolicy.yaml
@@ -17,3 +17,16 @@ spec:
       ports:
         - protocol: TCP
           port: 5432
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: media-postgres-cutover-backup
+  namespace: media
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: media-postgres-cutover-backup
+  policyTypes:
+    - Ingress
+    - Egress

--- a/clusters/homelab/apps/media-postgres/statefulset.yaml
+++ b/clusters/homelab/apps/media-postgres/statefulset.yaml
@@ -4,10 +4,13 @@ metadata:
   name: media-postgres
   namespace: media
   annotations:
-    checkov.io/skip1: CKV_K8S_40=The pod runs as the QNAP NFS anonymous UID 65534 so PostgreSQL owns the squashed data directory without root.
+    checkov.io/skip1: CKV_K8S_40=PostgreSQL runs as UID 65534 to preserve the migrated database ownership.
     checkov.io/skip2: CKV_K8S_22=PostgreSQL requires writable image-managed runtime paths; persistent data is isolated on the data PVC.
     checkov.io/skip3: CKV_K8S_43=Image tags are pinned for GitOps review; digest pinning is tracked separately for homelab images.
     checkov.io/skip4: CKV2_K8S_6=media-postgres is covered by networkpolicy.yaml; diff-only scans do not include sibling manifests.
+    checkov.io/skip5: CKV_K8S_23=The local-volume ownership init container runs as root; PostgreSQL and the migration remain non-root.
+    checkov.io/skip6: CKV_K8S_37=The ownership init container receives only CHOWN for the dedicated local volume.
+    checkov.io/skip7: CKV_K8S_25=The ownership init container receives only CHOWN for the dedicated local volume.
   labels:
     app.kubernetes.io/name: media-postgres
     app.kubernetes.io/part-of: homelab-media
@@ -66,10 +69,94 @@ spec:
             - name: auth
               mountPath: /run/secrets/media-postgres
               readOnly: true
+        - name: prepare-local-data
+          image: postgres:14.23-bookworm@sha256:70b9c8977b5fb87bd55c9e29472d778d76d56a6266143d47259da13d78a72afa
+          imagePullPolicy: Always
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              chown 65534:65534 /target
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 32Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              add:
+                - CHOWN
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 0
+            runAsNonRoot: false
+            runAsUser: 0
+          volumeMounts:
+            - name: local-data
+              mountPath: /target
+        - name: migrate-nfs-data
+          image: postgres:14.23-bookworm@sha256:70b9c8977b5fb87bd55c9e29472d778d76d56a6266143d47259da13d78a72afa
+          imagePullPolicy: Always
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              source=/source/pgdata
+              target=/target/pgdata
+              partial=/target/pgdata.migrating
+
+              if [ -e "$target" ]; then
+                test -f "$target/.nfs-migration-complete"
+                test "$(cat "$target/PG_VERSION")" = "14"
+                echo "local PostgreSQL data already exists; skipping NFS copy"
+                exit 0
+              fi
+
+              test "$(cat "$source/PG_VERSION")" = "14"
+              rm -rf -- "$partial"
+              mkdir "$partial"
+              cp -a --no-preserve=ownership "$source"/. "$partial"/
+              test "$(cat "$partial/PG_VERSION")" = "14"
+              rm -f -- "$partial/postmaster.pid"
+              touch "$partial/.nfs-migration-complete"
+              mv "$partial" "$target"
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+          volumeMounts:
+            - name: data
+              mountPath: /source
+              readOnly: true
+            - name: local-data
+              mountPath: /target
       containers:
         - name: postgres
           image: postgres:14.23-bookworm@sha256:70b9c8977b5fb87bd55c9e29472d778d76d56a6266143d47259da13d78a72afa
           imagePullPolicy: Always
+          args:
+            - -c
+            - listen_addresses=
+            - -c
+            - default_transaction_read_only=on
+            - -c
+            - unix_socket_directories=/var/run/postgresql,/var/lib/postgresql/data
           env:
             - name: POSTGRES_USER_FILE
               value: /run/secrets/media-postgres/POSTGRES_USER
@@ -96,11 +183,9 @@ spec:
           readinessProbe:
             exec:
               command:
-                - pg_isready
-                - -U
-                - media_apps
-                - -d
-                - media_apps
+                - /bin/sh
+                - -ec
+                - psql -U media_apps -d media_apps -Atqc 'SELECT 1' >/dev/null
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
@@ -133,7 +218,7 @@ spec:
             - name: auth
               mountPath: /run/secrets/media-postgres
               readOnly: true
-            - name: data
+            - name: local-data
               mountPath: /var/lib/postgresql/data
             - name: initdb
               mountPath: /docker-entrypoint-initdb.d
@@ -145,6 +230,9 @@ spec:
         - name: initdb
           configMap:
             name: media-postgres-initdb
+        - name: local-data
+          persistentVolumeClaim:
+            claimName: media-postgres-local
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/docs/knowledge-base/architecture/storage-and-state.md
+++ b/docs/knowledge-base/architecture/storage-and-state.md
@@ -18,6 +18,14 @@ Kubernetes persistent storage is backed by a QNAP NFS export.
 `platform-storage` owns the parent Argo CD Application, and the child
 `nfs-subdir-external-provisioner` Application owns the StorageClass.
 
+`media-postgres` is an explicit exception. Its active 20 Gi volume is a
+retained static `hostPath` PV at `/var/lib/media-postgres`, pinned to `acer`;
+the former NFS data claim remains retained for the cutover recovery point and
+logical backups. The first cutover phase is read-only and takes an immediate
+verified backup; the writable replacement phase adds the nightly schedule. The
+local volume removes QNAP latency from the live database but couples recovery
+to the single control-plane node and its system disk.
+
 Media-library paths are intentionally separate from app state. Deluge, Radarr,
 and Sonarr use static PV/PVC pairs against the QNAP `/media` export for
 downloads, movies, and TV library data. Read-only `showmount -e 10.1.0.2`
@@ -63,10 +71,13 @@ validation passed with zero pod restarts. The incident-only hook is now removed
 from desired state, while the explicit retained claim, 30-minute startup and
 liveness windows, and 120-second termination grace remain.
 
-`media-postgres` protects NFS-backed recovery with 30-minute startup and runtime
-liveness windows plus a 120-second termination grace period. Readiness still
-requires `pg_isready`, so Prowlarr, Radarr, and Sonarr cannot reach PostgreSQL
-until recovery completes. See
+`media-postgres` uses 30-minute startup and runtime liveness windows plus a
+120-second termination grace period. Its readiness probe executes `SELECT 1`
+instead of treating socket acceptance as usable database service. The first
+local-volume rollout cold-copies the stopped NFS `pgdata`, serves it read-only,
+disables TCP, and takes a verified logical backup through a local Unix socket.
+After validation, a clean replacement StatefulSet without the legacy immutable
+claim template or migration init container re-enables writes. See
 `clusters/homelab/apps/media-postgres/README.md` for the failure mode and
 operator response.
 

--- a/docs/knowledge-base/operations/continuous-improvement.md
+++ b/docs/knowledge-base/operations/continuous-improvement.md
@@ -124,8 +124,8 @@ policy`.
   with observable denial behavior instead of switching the shared resolver back
   to an opaque sinkhole response.
 
-- **Status:** `affine-postgres` restored, partially mitigated for
-  `media-postgres`, and open for the other PostgreSQL workloads
+- **Status:** `affine-postgres` restored; `media-postgres` local cutover
+  implemented and awaiting live validation; open for other NFS workloads
 - **Area:** storage / database recovery
 - **Evidence:** Read-only inspection on 2026-07-19 found simultaneous probe
   failures across NFS-backed workloads on multiple healthy Kubernetes nodes.
@@ -171,19 +171,29 @@ policy`.
   previous app instance stalled during `/config` ownership initialization
   before the liveness probe restarted it. All affected persistent volumes
   target the QNAP at `10.1.0.2` over NFSv3.
+  A new recurrence on 2026-07-29 provided a 20-second kernel mount-stat delta:
+  311 `media-postgres` NFS writes completed with about 26.9 seconds average
+  queue time, 8.1 seconds RPC round-trip, and 35.0 seconds execution per write.
+  PostgreSQL readiness failed immediately before Prowlarr timed out and then
+  received connection refusals. Concurrent probe failures affected NFS-backed
+  workloads on `acer`, `zimaboard-0`, and `zimaboard-1`, while every node
+  remained Ready and physical NIC error counters stayed at zero. Desired state
+  now cold-copies `media-postgres` to an `acer`-pinned local volume, uses real
+  SQL for readiness, disables TCP to fence writes, retains the NFS copy, and
+  writes an immediate verified logical backup there through a local Unix
+  socket.
 - **Risk:** probe hardening limits crash-recovery loops but cannot make the
   shared storage path responsive. Sonarr and Prowlarr can remain Kubernetes
   `Running` while database calls fail, while Deluge and Radarr turn sustained
   I/O stalls into restart loops. The same failure domain affects unrelated
   NFS-backed workloads across the cluster.
-- **Next step:** the media PostgreSQL liveness window now matches its
-  30-minute startup recovery window, which prevents brief NFS outages from
-  immediately starting another crash-recovery cycle. Treat the QNAP and
-  especially the `acer` NFS client path as the primary incident. Inspect QNAP
-  pool, disk, NFS-service, and network history for the 2026-07-23/24 window;
-  collect Talos kernel NFS diagnostics with a populated Talos client config;
-  and benchmark NFS latency from each wired node. Evaluate moving PostgreSQL
-  and other high-churn state to storage designed for database synchronous I/O.
+- **Next step:** validate the read-only local `media-postgres` rollout, six
+  databases, sustained SQL latency, and first logical backup. Then scale the
+  legacy StatefulSet to zero and create a clean writable replacement without
+  its immutable NFS claim template or migration init container; add the nightly
+  backup schedule and validate indexer searches. Separately inspect QNAP pool,
+  disk, NFS-service, and network history because the same failure domain still
+  affects other NFS-backed workloads.
 
 - **Status:** PostgreSQL alert path mitigated; kube-state-metrics scrape open
 - **Area:** monitoring / PostgreSQL availability

--- a/docs/knowledge-base/workloads/inventory.md
+++ b/docs/knowledge-base/workloads/inventory.md
@@ -22,16 +22,18 @@ utility, not as an app, callback, or CI access path.
 | `platform-storage` | support | cluster-scoped | `clusters/homelab/platform/storage` | `IaC/live/argocd-apps/platform-storage` | QNAP NFS export |
 | `octelium-storage` | support | `octelium-storage` | `clusters/homelab/apps/octelium-storage` | `IaC/live/argocd-apps/octelium-storage` | external-secrets, platform-storage |
 | `github-actions-runner` | retired/prune placeholder | `github-actions-runner` | `clusters/homelab/apps/github-actions-runner` | `IaC/live/argocd-apps/github-actions-runner` | none |
-| `media-postgres` | support | `media` | `clusters/homelab/apps/media-postgres` | `IaC/live/argocd-apps/media-postgres` | external-secrets, platform-storage |
+| `media-postgres` | support | `media` | `clusters/homelab/apps/media-postgres` | `IaC/live/argocd-apps/media-postgres` | external-secrets, platform-storage for retained NFS backups |
 | `n8n-postgres` | support | `automation` | `clusters/homelab/apps/n8n-postgres` | `IaC/live/argocd-apps/n8n-postgres` | external-secrets, platform-storage |
 
 `platform-dns` forwards public lookups to the unfiltered Cloudflare resolvers
 `1.1.1.1` and `1.0.0.1`. This keeps explicit stable upstreams without
 sinkholing Prowlarr indexer domains through Cloudflare Family category filters.
 
-`media-postgres` has recovery-aware 30-minute startup and runtime liveness
-windows plus a 120-second termination grace period so an NFS stall does not trap
-Prowlarr, Radarr, and Sonarr's shared database in a crash-recovery loop.
+`media-postgres` keeps recovery-aware 30-minute startup and runtime liveness
+windows plus a 120-second termination grace period, but active data now uses a
+retained local volume pinned to `acer`. Readiness executes a real SQL query.
+The read-only cutover phase writes an immediate verified logical backup to the
+former NFS claim; the writable replacement phase adds the nightly schedule.
 
 ## Requested Applications
 
@@ -55,9 +57,9 @@ Prowlarr, Radarr, and Sonarr's shared database in a crash-recovery loop.
 | `descheduler` | `kube-system` | `clusters/homelab/apps/descheduler/values.yaml` | `IaC/live/argocd-apps/descheduler` | controller state only | prometheus |
 | `deluge` | `media` | `clusters/homelab/apps/deluge` | `IaC/live/argocd-apps/deluge` | persistent config on `nfs-default`; shared downloads on QNAP `/media`; SSM-backed WireGuard profile via `deluge-vpn`; guarded recovery for libtorrent session state, the torrent catalog, and already-complete target files; 30-minute startup and runtime liveness windows; root-squash-aware startup without LinuxServer's recursive config ownership pass; `127.0.0.1` Web-to-daemon host compatibility for Sonarr; Prometheus health for the Gluetun VPN and Deluge daemon | cert-manager, istio, platform-storage |
 | `dispatcharr` | `media` | `clusters/homelab/apps/dispatcharr` | `IaC/live/argocd-apps/dispatcharr` | modular IPTV stream and EPG manager with a persistent data claim, dedicated PostgreSQL 17 claim, ephemeral Redis, and Octelium-protected UI; provider credentials and playlist URLs stay outside git | external-secrets, cert-manager, istio, platform-storage |
-| `prowlarr` | `media` | `clusters/homelab/apps/prowlarr` | `IaC/live/argocd-apps/prowlarr` | persistent config and PostgreSQL databases | cert-manager, istio, media-postgres, platform-storage |
-| `radarr` | `media` | `clusters/homelab/apps/radarr` | `IaC/live/argocd-apps/radarr` | persistent config and PostgreSQL databases on `nfs-default`; movies and downloads on QNAP `/media` | cert-manager, istio, deluge, media-postgres, prowlarr, platform-storage |
-| `sonarr` | `media` | `clusters/homelab/apps/sonarr` | `IaC/live/argocd-apps/sonarr` | persistent config and PostgreSQL databases on `nfs-default`; TV and downloads on QNAP `/media` | cert-manager, istio, deluge, media-postgres, prowlarr, platform-storage |
+| `prowlarr` | `media` | `clusters/homelab/apps/prowlarr` | `IaC/live/argocd-apps/prowlarr` | persistent config on `nfs-default`; indexer state in local `media-postgres` | cert-manager, istio, media-postgres, platform-storage |
+| `radarr` | `media` | `clusters/homelab/apps/radarr` | `IaC/live/argocd-apps/radarr` | persistent config on `nfs-default`; database state in local `media-postgres`; movies and downloads on QNAP `/media` | cert-manager, istio, deluge, media-postgres, prowlarr, platform-storage |
+| `sonarr` | `media` | `clusters/homelab/apps/sonarr` | `IaC/live/argocd-apps/sonarr` | persistent config on `nfs-default`; database state in local `media-postgres`; TV and downloads on QNAP `/media` | cert-manager, istio, deluge, media-postgres, prowlarr, platform-storage |
 | `litellm` | `ai` | `clusters/homelab/apps/litellm` | `IaC/live/argocd-apps/litellm` | optional persistent config or DB state | external-secrets, cert-manager, istio, platform-storage |
 | `openclaw` | `ai` | `clusters/homelab/apps/openclaw` | `IaC/live/argocd-apps/openclaw` | persistent runtime state, SSM-backed gateway auth, Discord channel config, SSM-backed GitHub App credentials, Codex OAuth credentials on PVC, explicit agent resource profile, and loopback HTTP readiness/liveness checks that recycle a persistently stalled gateway | external-secrets, cert-manager, istio, litellm, platform-storage |
 | `n8n` | `automation` | `clusters/homelab/apps/n8n` | `IaC/live/argocd-apps/n8n` | persistent workflows, credential metadata, users, and execution history in n8n-postgres; instance settings and file-backed runtime data on PVC; SSM key bootstraps fresh PVCs only; public callbacks use `https://n8n-webhook.stinkyboi.com` through `octelium-public` and are limited to webhook prefixes; authenticated self-API calls use the plain-HTTP in-cluster Service and are limited to the n8n workload identity; database-aware readiness and liveness recycle n8n when a PostgreSQL interruption leaves its connection pool stale | external-secrets, cert-manager, istio, platform-storage, n8n-postgres |

--- a/docs/rollback-argocd-apps.md
+++ b/docs/rollback-argocd-apps.md
@@ -40,6 +40,13 @@ For `media-postgres`, take PostgreSQL logical dumps before rollback whenever
 Sonarr, Radarr, or Prowlarr have already written data to PostgreSQL. Preserve
 the PostgreSQL PVC unless intentionally rebuilding the media apps from backups.
 
+During the local-storage cutover, preserve both `media-postgres-local` and
+`data-media-postgres-0`. Before any write reaches the local database, reverting
+the StatefulSet mount can return to the stopped NFS copy. After local writes
+begin, that copy is stale: use a repository-owned reverse dump/restore workflow
+instead of mounting it directly. Never run the local and NFS PostgreSQL copies
+at the same time behind the `media-postgres` Service.
+
 For `n8n-postgres`, take a PostgreSQL logical dump before rollback whenever n8n
 has already written workflows, users, credentials metadata, or execution
 history to PostgreSQL. Preserve both the PostgreSQL PVC and the n8n

--- a/docs/storage-nfs.md
+++ b/docs/storage-nfs.md
@@ -3,6 +3,11 @@
 Stateful apps use a default QNAP-backed NFS StorageClass named `nfs-default`
 unless an app-specific exception is documented here.
 
+`media-postgres` is the first database exception: the cutover copies active
+PostgreSQL data to a static node-local volume on `acer`, while the retained NFS
+claim receives an immediate verified logical backup. The final writable phase
+must add the nightly backup schedule.
+
 ## NAS Configuration
 
 | Setting | Value |
@@ -98,12 +103,16 @@ The parent `platform-storage` Application auto-syncs by default. Treat it as a
 readiness gate anyway: verify the QNAP export is visible and the child
 provisioner Application is healthy before relying on stateful workload PVCs.
 
-## Media Library Static Volumes
+## Static And Local Volume Exceptions
 
 The default `nfs-default` StorageClass remains the path for application config,
-PostgreSQL data, dashboards, metrics, and other app-owned state. Deluge, Radarr,
-and Sonarr media-library data uses static PV/PVC pairs that mount the QNAP
-`/media` export directly:
+most PostgreSQL data, dashboards, metrics, and other app-owned state. The
+exceptions are:
+
+- `media-postgres-local`, a retained static `hostPath` PV pinned to `acer` and
+  backed by `/var/lib/media-postgres` on the Talos `EPHEMERAL` filesystem.
+- Deluge, Radarr, and Sonarr media-library static PV/PVC pairs that mount the
+  QNAP `/media` export directly.
 
 | Claim | Owned by | Mounted in apps | Media subdirectory |
 | --- | --- | --- | --- |
@@ -179,7 +188,7 @@ app has acceptable backup and restore coverage.
 | affine | PostgreSQL/pgvector database, uploaded blobs, instance config; ephemeral Redis cache/jobs | `nfs-default` for durable state; node-local `emptyDir` for Redis | Coordinated NFS backup plus `pg_dump` before upgrades; Redis is excluded | Restore PostgreSQL and blob/config claims from one recovery point; Redis rebuilds empty and queued work may be lost | Preserve durable claims and the ECDSA signing key; preserve the inactive former Redis AOF claim during the tuning rollback window |
 | deluge | config on `nfs-default`, shared downloads on `media-downloads` backed by `/media` | `nfs-default` plus static `/media` PV | NFS backup for config and `/media/downloads` | Restore config PVC and `/media/downloads` before app sync | Preserve PVCs and `/media/downloads` |
 | dispatcharr | file-backed runtime data plus dedicated `dispatcharr-postgres` database | `nfs-default` | NFS backup for data PVC and `dispatcharr-postgres` PVC plus PostgreSQL logical dump | Restore data PVC and `dispatcharr-postgres` PVC or logical dump before app sync | Preserve PVCs and database unless intentionally resetting IPTV state |
-| media-postgres | Sonarr, Radarr, and Prowlarr PostgreSQL databases | `nfs-default` | NFS backup plus `pg_dump` logical dumps before upgrades | Restore PostgreSQL PVC or logical dumps before media app sync | Preserve PVC unless intentionally rebuilding from dumps |
+| media-postgres | Sonarr, Radarr, and Prowlarr PostgreSQL databases | static `media-postgres-local` on `acer`; retained `nfs-default` rollback/backup claim | First phase: immediate globals, six custom-format dumps, and checksums on retained NFS; final phase: nightly schedule | Recreate a local PV and restore globals plus all six matching dumps before media app sync | Preserve both claims; the NFS physical copy is rollback-safe only before local writes begin |
 | prowlarr | config, indexer refs, PostgreSQL app/log databases | `nfs-default` | NFS backup for config plus PostgreSQL logical dump | Restore config PVC and PostgreSQL databases before app sync and re-test app integrations | Preserve PVCs |
 | radarr | config and PostgreSQL refs on `nfs-default`, movies on `media-movies`, shared downloads on `media-downloads` | `nfs-default` plus static `/media` PVs | NFS backup for config, PostgreSQL logical dump, `/media/movies`, and `/media/downloads` | Restore config PVC and PostgreSQL databases, then verify `/media/movies` and `/media/downloads` | Preserve PVCs and `/media` subdirectories |
 | sonarr | config and PostgreSQL refs on `nfs-default`, TV on `media-tv`, shared downloads on `media-downloads` | `nfs-default` plus static `/media` PVs | NFS backup for config, PostgreSQL logical dump, `/media/tv`, and `/media/downloads` | Restore config PVC and PostgreSQL databases, then verify `/media/tv` and `/media/downloads` | Preserve PVCs and `/media` subdirectories |
@@ -211,3 +220,10 @@ app has acceptable backup and restore coverage.
   only to `10.1.0.199`, `10.1.0.200`, `10.1.0.201`, and `10.1.0.202`. The same
   audit found NFSv2 still advertised through RPC; disable it in QTS because the
   Kubernetes StorageClass mounts with NFSv3.
+- Read-only inspection on 2026-07-29 measured 311 `media-postgres` NFS writes
+  over 20 seconds with roughly 26.9 seconds queued, 8.1 seconds RPC round-trip,
+  and 35.0 seconds total execution per write. Concurrent failures affected
+  NFS-backed workloads on every active node while all nodes remained Ready and
+  physical NIC errors stayed at zero. This evidence drove the local
+  `media-postgres` cutover; QNAP remains the backup rather than active database
+  path.

--- a/docs/validation-runbook.md
+++ b/docs/validation-runbook.md
@@ -145,6 +145,32 @@ the persistent `/config/config.xml` contains the Servarr-documented
 `PostgresMainDb`, and `PostgresLogDb` entries before running any SQLite
 migration.
 
+For the local database cutover, also require all of the following:
+
+```sh
+kubectl get storageclass,persistentvolume media-postgres-local
+kubectl -n media get pvc media-postgres-local data-media-postgres-0
+kubectl -n media get pod media-postgres-0 -o wide
+kubectl -n media exec statefulset/media-postgres -- \
+  test -f /var/lib/postgresql/data/pgdata/.nfs-migration-complete
+kubectl -n media exec statefulset/media-postgres -- \
+  psql -U media_apps -d media_apps -Atqc 'SELECT 1'
+kubectl -n media exec statefulset/media-postgres -- \
+  psql -U media_apps -d media_apps -Atqc 'SHOW default_transaction_read_only'
+kubectl -n media exec statefulset/media-postgres -- \
+  psql -U media_apps -d media_apps -Atqc 'SHOW listen_addresses'
+kubectl -n media get job media-postgres-cutover-backup
+```
+
+The local claim and PV must be `Bound`, the pod must run on `acer`, the
+migration marker must exist, and repeated SQL probes must complete without the
+NFS-correlated stalls. The first phase must remain read-only with TCP disabled,
+and the cutover backup Job must complete through the shared local Unix socket.
+The follow-up phase scales the legacy StatefulSet to zero and creates a clean
+writable replacement without its immutable NFS claim template or migration
+init container. Revalidate that replacement before treating PostgreSQL
+restarts as independent of NFS.
+
 For Radarr access lockout checks, validate that the auth-normalized
 `config.xml` contains exactly one `AuthenticationMethod=External` entry and
 one `AuthenticationRequired=DisabledForLocalAddresses` entry, with no


### PR DESCRIPTION
## Summary

- move a retained copy of media PostgreSQL from the stalled QNAP NFS path to Acer's Talos EPHEMERAL disk
- start the copied database read-only with TCP disabled so phase 1 cannot accept application writes
- create and verify a one-shot logical backup of all six media databases plus password-free globals on the existing NFS backup path
- document the measured NFS queue/RPC latency root cause and the required two-phase rollout gate

## Root cause

During the incident, 311 PostgreSQL NFS writes over 20 seconds averaged 26.9 seconds queued, 8.1 seconds in RPC, and 35.0 seconds total execution. The nodes remained Ready and the Acer NIC showed no errors. PostgreSQL readiness failures then surfaced in Prowlarr, Sonarr, and Radarr as Npgsql timeouts and connection refusals; tracker DNS and HTTPS remained healthy.

## Phase gate

This PR is phase 1 only. After merge, the local copy must be Ready on Acer, read-only, TCP-disabled, contain all six databases, and produce a verified backup identifier. Phase 2 will not be published until those live checks pass.

## Validation

- `kubectl kustomize clusters/homelab/apps/media-postgres`
- server-side dry-run of the rendered phase-1 overlay
- 6,291 Conftest policy checks passed
- Checkov Kubernetes: 2,952 passed, 0 failed
- Checkov secrets: 0 failed
- changed-file pre-commit hooks passed
- Grafana Helm chart 10.5.15 rendered
- all replayed commits have good signatures


<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

> Live Terragrunt plan skipped because this pull request did not change `IaC/**`, flake inputs, OpenTofu/Terragrunt policy inputs, or live-plan helper scripts.

Rendered Conftest policies still ran for workflows and Kubernetes manifests in this required check.

<!-- terragrunt-plan:end -->
