### PR TITLE
fix: update cloudflared grpc transport

### DIFF
--- a/clusters/homelab/apps/octelium-public/README.md
+++ b/clusters/homelab/apps/octelium-public/README.md
@@ -42,6 +42,9 @@ allows both UDP/7844 for QUIC and TCP/7844 for HTTP/2 fallback, plus TCP/443
 for Cloudflare API access. The public rule excludes private and link-local IPv4
 ranges; separate namespace-scoped rules allow only the in-cluster Istio HTTPS
 origin, the Octelium ingress dataplane, and DNS through `kube-system`.
+The connector image is pinned to `2026.7.3`, the version recommended by the
+running `2026.6.1` replicas while authenticated Octelium gRPC calls hung at the
+public Cloudflare hop but succeeded through the same Istio origin directly.
 
 App hostnames forward directly to
 `http://octelium-ingress-dataplane.octelium.svc.cluster.local:8080` with their

--- a/clusters/homelab/apps/octelium-public/deployment.yaml
+++ b/clusters/homelab/apps/octelium-public/deployment.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        homelab.rst.io/cloudflared-config-revision: cloudflared-2026-7-3
+        homelab.rst.io/cloudflared-config-revision: ci-kubernetes-route-2026-07-26-v2
       labels:
         app.kubernetes.io/name: cloudflared
         app.kubernetes.io/part-of: octelium-public

--- a/clusters/homelab/apps/octelium-public/deployment.yaml
+++ b/clusters/homelab/apps/octelium-public/deployment.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        homelab.rst.io/cloudflared-config-revision: ci-kubernetes-route-2026-07-26-v2
+        homelab.rst.io/cloudflared-config-revision: cloudflared-2026-7-3
       labels:
         app.kubernetes.io/name: cloudflared
         app.kubernetes.io/part-of: octelium-public
@@ -36,7 +36,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cloudflared
-          image: cloudflare/cloudflared:2026.6.1@sha256:6d91c121b803126f7a5344005d17a9324788fc09d305b6e2560ec6040a7ae283
+          image: cloudflare/cloudflared:2026.7.3@sha256:e39ee8da81ad5e05d77f38d2f51c60ca51bf2a8450ac3abab50c17fdb91d91bf
           imagePullPolicy: IfNotPresent
           args:
             - tunnel

--- a/docs/knowledge-base/operations/continuous-improvement.md
+++ b/docs/knowledge-base/operations/continuous-improvement.md
@@ -89,6 +89,20 @@ policy`.
   renewed probe failures as the storage incident rather than an Octelium
   routing failure.
 
+- **Status:** update prepared; live verification pending
+- **Area:** Octelium / public gRPC transport
+- **Evidence:** After PostgreSQL recovered, authenticated Octelium CLI calls
+  still hung through `octelium-api.stinkyboi.com` while the same client and
+  session succeeded through a TLS-preserving local CONNECT proxy to the
+  in-cluster Istio gateway. Both `cloudflared` `2026.6.1` replicas selected
+  QUIC successfully but logged that `2026.7.3` was the recommended update.
+  Desired state now pins that multi-architecture image by digest.
+- **Risk:** The update may not address Cloudflare edge behavior; retain the
+  in-cluster comparison path until authenticated public status and connect
+  calls pass.
+- **Next step:** Verify web login, `octelium status`, and a sustained
+  `octelium connect` through the public API after rollout.
+
 - **Status:** open; alert semantics fixed, scrape failure unresolved
 - **Area:** observability / kube-state-metrics
 - **Evidence:** Read-only checks on 2026-07-19 showed all four expected nodes


### PR DESCRIPTION
## Summary
- update cloudflared from 2026.6.1 to the connector-recommended 2026.7.3 release
- pin the multi-architecture image digest and roll both tunnel replicas
- record the public authenticated gRPC failure and direct-origin comparison

## Validation
- kubectl kustomize clusters/homelab/apps/octelium-public
- kubectl apply --dry-run=client -f rendered.yaml
- nix develop --command bash scripts/ci/conftest-policies.sh (5886 passed)
- git diff --check

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

> Live Terragrunt plan skipped because this pull request did not change `IaC/**`, flake inputs, OpenTofu/Terragrunt policy inputs, or live-plan helper scripts.

Rendered Conftest policies still ran for workflows and Kubernetes manifests in this required check.

<!-- terragrunt-plan:end -->
