### PR TITLE
fix: add octelium cloudflare grpc reconciliation

### DIFF
--- a/.github/workflows/octelium-cloudflare-grpc.yml
+++ b/.github/workflows/octelium-cloudflare-grpc.yml
@@ -1,0 +1,54 @@
+name: Reconcile Octelium Cloudflare gRPC
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  reconcile:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    environment:
+      name: homelab-production
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Check Out Repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          persist-credentials: false
+
+      - name: Verify Inputs
+        env:
+          AWS_APPLY_ROLE_ARN: ${{ vars.AWS_ROLE_TO_ASSUME_HOMELAB || secrets.AWS_ROLE_TO_ASSUME_HOMELAB }}
+          CLOUDFLARE_ZONE_SETTINGS_TOKEN: ${{ secrets.CLOUDFLARE_ZONE_SETTINGS_TOKEN }}
+        run: |
+          test -n "${AWS_APPLY_ROLE_ARN}" || { echo "AWS_ROLE_TO_ASSUME_HOMELAB must be set for homelab-production."; exit 1; }
+          test -n "${CLOUDFLARE_ZONE_SETTINGS_TOKEN}" || { echo "CLOUDFLARE_ZONE_SETTINGS_TOKEN must be set as a homelab-production environment secret."; exit 1; }
+          test "${CLOUDFLARE_ZONE_SETTINGS_TOKEN}" != "REPLACE_ME" || { echo "CLOUDFLARE_ZONE_SETTINGS_TOKEN must not be REPLACE_ME."; exit 1; }
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885
+        with:
+          aws-region: us-west-2
+          mask-aws-account-id: true
+          role-session-name: octelium-cloudflare-grpc-${{ github.run_id }}
+          role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME_HOMELAB || secrets.AWS_ROLE_TO_ASSUME_HOMELAB }}
+          unset-current-credentials: true
+
+      - name: Inject Cloudflare Token
+        env:
+          CLOUDFLARE_ZONE_SETTINGS_TOKEN: ${{ secrets.CLOUDFLARE_ZONE_SETTINGS_TOKEN }}
+        run: |
+          aws ssm put-parameter \
+            --region us-west-2 \
+            --name /homelab/octelium/cloudflare-zone-settings-token \
+            --type SecureString \
+            --key-id alias/homelab-opentofu \
+            --overwrite \
+            --value "${CLOUDFLARE_ZONE_SETTINGS_TOKEN}" >/dev/null
+
+      - name: Reconcile Cloudflare gRPC
+        run: scripts/octelium-cloudflare-grpc.sh

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -148,9 +148,10 @@ Create two GitHub environments:
   deployment branches to `main`.
 
 Add `OCTELIUM_CI_AUTH_TOKEN` to both environments. Add
-`AZUREAD_CLIENT_SECRET` to `homelab-production`; adding it to `homelab-plan`
-lets trusted pull requests render AzureAD application plans, otherwise that PR
-plan phase is skipped with a warning. Repository-level secrets also work, but
+`AZUREAD_CLIENT_SECRET` and `CLOUDFLARE_ZONE_SETTINGS_TOKEN` to
+`homelab-production`; adding `AZUREAD_CLIENT_SECRET` to `homelab-plan` lets
+trusted pull requests render AzureAD application plans, otherwise that PR plan
+phase is skipped with a warning. Repository-level secrets also work, but
 environment secrets are preferred so production credentials can have approval
 rules and tighter rotation:
 
@@ -158,6 +159,7 @@ rules and tighter rotation:
 |--------|-------------|---------|
 | `OCTELIUM_CI_AUTH_TOKEN` | both | Octelium clientless access token for User `homelab-ci`, scoped to the public `kubernetes-api-ci` Service. |
 | `AZUREAD_CLIENT_SECRET` | `homelab-production`; optional in `homelab-plan` | Microsoft Entra application secret used by the AzureAD provider during production applies and optional trusted PR plans. |
+| `CLOUDFLARE_ZONE_SETTINGS_TOKEN` | `homelab-production` | Cloudflare API token with `Zone:Read` and `Zone Settings:Edit` used by the manually dispatched Octelium gRPC reconciler. |
 
 The retired `/homelab/github-actions-runner/registration-token` SSM parameter
 has no runtime consumer. Its declaration and preexisting-parameter adoption

--- a/docs/knowledge-base/architecture/secrets-and-identity.md
+++ b/docs/knowledge-base/architecture/secrets-and-identity.md
@@ -100,6 +100,12 @@ roles need identity-based KMS permissions for both keys.
   for `n8n-webhook.stinkyboi.com` and `policy-bot-hook.stinkyboi.com`; those
   routes remain unauthenticated at Octelium but path-limited in Istio and
   validated by the receiving application credentials or signatures.
+  The separate Cloudflare zone-settings token is stored as the protected
+  `homelab-production` environment secret
+  `CLOUDFLARE_ZONE_SETTINGS_TOKEN`. The manually dispatched
+  `.github/workflows/octelium-cloudflare-grpc.yml` workflow injects it into
+  `/homelab/octelium/cloudflare-zone-settings-token` and runs the repo-owned
+  gRPC reconciler; the token value never belongs in git.
   Octelium portal login uses Microsoft Entra OIDC. The Entra application is
   managed by `IaC/live/azuread-applications/octelium` and writes generated
   client material to `/homelab/octelium/entra/*`; these values are copied into

--- a/docs/knowledge-base/operations/continuous-improvement.md
+++ b/docs/knowledge-base/operations/continuous-improvement.md
@@ -102,11 +102,12 @@ policy`.
   the client, session, database, and Istio origin path.
 - **Risk:** The normal public CLI path remains unavailable even though browser
   access and an unauthenticated gRPC-shaped probe work.
-- **Next step:** Refresh the operator's AWS SSO session, run
-  `scripts/octelium-cloudflare-grpc.sh --dry-run`, and enable the zone gRPC
-  setting with the same repo-owned script if it is off. If it is already on,
-  investigate Cloudflare edge trailer handling with the direct-origin result
-  as the control.
+- **Next step:** Replace the `REPLACE_ME` value in
+  `/homelab/octelium/cloudflare-zone-settings-token` with a scoped Cloudflare
+  API token, run `scripts/octelium-cloudflare-grpc.sh --dry-run`, and enable
+  the zone gRPC setting with the same repo-owned script if it is off. If it is
+  already on, investigate Cloudflare edge trailer handling with the
+  direct-origin result as the control.
 
 - **Status:** open; alert semantics fixed, scrape failure unresolved
 - **Area:** observability / kube-state-metrics

--- a/docs/knowledge-base/operations/continuous-improvement.md
+++ b/docs/knowledge-base/operations/continuous-improvement.md
@@ -102,12 +102,13 @@ policy`.
   the client, session, database, and Istio origin path.
 - **Risk:** The normal public CLI path remains unavailable even though browser
   access and an unauthenticated gRPC-shaped probe work.
-- **Next step:** Replace the `REPLACE_ME` value in
-  `/homelab/octelium/cloudflare-zone-settings-token` with a scoped Cloudflare
-  API token, run `scripts/octelium-cloudflare-grpc.sh --dry-run`, and enable
-  the zone gRPC setting with the same repo-owned script if it is off. If it is
-  already on, investigate Cloudflare edge trailer handling with the
-  direct-origin result as the control.
+- **Next step:** Add an approved repository-owned CI secret-injection path for
+  `/homelab/octelium/cloudflare-zone-settings-token`, then use it to inject a
+  scoped Cloudflare API token. Run
+  `scripts/octelium-cloudflare-grpc.sh --dry-run`, and enable the zone gRPC
+  setting with the same repo-owned script if it is off. If it is already on,
+  investigate Cloudflare edge trailer handling with the direct-origin result
+  as the control.
 
 - **Status:** open; alert semantics fixed, scrape failure unresolved
 - **Area:** observability / kube-state-metrics

--- a/docs/knowledge-base/operations/continuous-improvement.md
+++ b/docs/knowledge-base/operations/continuous-improvement.md
@@ -102,11 +102,11 @@ policy`.
   the client, session, database, and Istio origin path.
 - **Risk:** The normal public CLI path remains unavailable even though browser
   access and an unauthenticated gRPC-shaped probe work.
-- **Next step:** Add an approved repository-owned CI secret-injection path for
-  `/homelab/octelium/cloudflare-zone-settings-token`, then use it to inject a
-  scoped Cloudflare API token. Run
-  `scripts/octelium-cloudflare-grpc.sh --dry-run`, and enable the zone gRPC
-  setting with the same repo-owned script if it is off. If it is already on,
+- **Next step:** Set a scoped Cloudflare API token as the protected
+  `homelab-production` environment secret
+  `CLOUDFLARE_ZONE_SETTINGS_TOKEN`, then dispatch
+  `.github/workflows/octelium-cloudflare-grpc.yml` from `main`. If the workflow
+  confirms the zone setting is already on and the public path still fails,
   investigate Cloudflare edge trailer handling with the direct-origin result
   as the control.
 

--- a/docs/octelium.md
+++ b/docs/octelium.md
@@ -364,13 +364,15 @@ Octelium ingress dataplane, and cluster DNS through namespace-scoped rules.
 The CLI and VPN path also requires Cloudflare to allow gRPC for the zone:
 
 ```sh
-scripts/octelium-cloudflare-grpc.sh --dry-run
-scripts/octelium-cloudflare-grpc.sh
+gh workflow run octelium-cloudflare-grpc.yml --ref main
 ```
 
-This reads `/homelab/octelium/cloudflare-zone-settings-token`, which must be a
-Cloudflare API token with `Zone:Read` and `Zone Settings:Edit` for
-`stinkyboi.com`. The cert-manager DNS-01 token cannot update this setting.
+Set `CLOUDFLARE_ZONE_SETTINGS_TOKEN` as a `homelab-production` environment
+secret first. The protected workflow writes it to
+`/homelab/octelium/cloudflare-zone-settings-token` with the existing KMS key,
+then runs `scripts/octelium-cloudflare-grpc.sh` to enable and verify the zone
+setting. The token requires `Zone:Read` and `Zone Settings:Edit` for
+`stinkyboi.com`; the cert-manager DNS-01 token cannot update this setting.
 
 Once the API and gRPC path are true, create or rotate the
 `homelab-octelium-client` credential, store it in SSM, bump

--- a/docs/secrets-aws-ssm.md
+++ b/docs/secrets-aws-ssm.md
@@ -223,11 +223,13 @@ would force the client onto the unsupported nested
 `octelium-api.octelium.stinkyboi.com` hostname.
 
 Octelium CLI and VPN sessions use gRPC against `octelium-api.stinkyboi.com`.
-Store a separate Cloudflare API token with `Zone:Read` and
-`Zone Settings:Edit` for `stinkyboi.com` in
-`/homelab/octelium/cloudflare-zone-settings-token`, then run
-`scripts/octelium-cloudflare-grpc.sh`. The cert-manager DNS-01 token is too
-narrow for this setting and returns Cloudflare error `9109`.
+Store a separate Cloudflare API token with `Zone:Read` and `Zone Settings:Edit`
+for `stinkyboi.com` as the `CLOUDFLARE_ZONE_SETTINGS_TOKEN` secret in the
+protected `homelab-production` GitHub environment, then dispatch
+`.github/workflows/octelium-cloudflare-grpc.yml` from `main`. The workflow
+injects the token into `/homelab/octelium/cloudflare-zone-settings-token` and
+runs the repo-owned reconciler. The cert-manager DNS-01 token is too narrow for
+this setting and returns Cloudflare error `9109`.
 
 The cert-manager Cloudflare value should be a scoped API token with permission
 to read the zone and edit DNS records for `stinkyboi.com`; do not store the


### PR DESCRIPTION
## Summary
- add a protected manual workflow that injects the scoped Cloudflare token through GitHub OIDC and the existing KMS key
- run the repo-owned idempotent Cloudflare gRPC reconciler after injection
- document the production environment secret contract and recovery path

## Validation
- `git diff --check`
- `nix develop --command bash scripts/ci/static-checks.sh`
- `nix develop --command bash scripts/ci/conftest-policies.sh` (6,291 passed)
- commit hooks, including YAML, Checkov, secrets, and zizmor

`actionlint` is not installed locally; repository YAML parsing, Conftest, zizmor, and CI cover the workflow.

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

> Live Terragrunt plan skipped because this pull request did not change `IaC/**`, flake inputs, OpenTofu/Terragrunt policy inputs, or live-plan helper scripts.

Rendered Conftest policies still ran for workflows and Kubernetes manifests in this required check.

<!-- terragrunt-plan:end -->
