### PR TITLE
fix(prowlarr): avoid stalled acer nfs path

### DIFF
--- a/clusters/homelab/apps/prowlarr/values.yaml
+++ b/clusters/homelab/apps/prowlarr/values.yaml
@@ -6,6 +6,8 @@ controllers:
       identifier: prowlarr
     pod:
       automountServiceAccountToken: false
+      nodeSelector:
+        kubernetes.io/hostname: zimaboard-0
       annotations:
         homelab.rst.io/access-mode: "octelium"
     initContainers:

--- a/docs/knowledge-base/operations/continuous-improvement.md
+++ b/docs/knowledge-base/operations/continuous-improvement.md
@@ -143,8 +143,8 @@ policy`.
   with observable denial behavior instead of switching the shared resolver back
   to an opaque sinkhole response.
 
-- **Status:** `affine-postgres` restored; `media-postgres` phase-one staging
-  validated and phase two awaiting rollout; open for other NFS workloads
+- **Status:** `affine-postgres` restored; `media-postgres` local cutover
+  validated; Prowlarr placement awaiting rollout; open for other NFS workloads
 - **Area:** storage / database recovery
 - **Evidence:** Read-only inspection on 2026-07-19 found simultaneous probe
   failures across NFS-backed workloads on multiple healthy Kubernetes nodes.
@@ -209,6 +209,16 @@ policy`.
   TCP disabled, and 50 `SELECT 1` probes completing in 1.63 seconds. Backup
   `20260730T045748Z` verified the six custom-format dumps and password-free
   globals before phase two was released.
+  Live phase-two validation at signed revision `88098e7f` confirmed the legacy
+  writer at zero replicas, the local-only writer Ready on `acer`, the one-time
+  fence present, read/write SQL available, and 50 probes completing in 1.71
+  seconds. The remaining Prowlarr search stall was outside PostgreSQL: its raw
+  tracker HTTPS request completed in 0.49 seconds, while one read of the
+  NFS-backed `/config/config.xml` took 10.2 seconds and two live searches
+  exceeded 30 seconds. The equivalent reads in Sonarr and Radarr on
+  `zimaboard-0` took 79 and 281 milliseconds, and that node's NFS client
+  recorded 12 lifetime write timeouts versus 26,065,641 on `acer`. Desired
+  state now pins Prowlarr to `zimaboard-0` without replacing its retained PVC.
 - **Risk:** probe hardening limits crash-recovery loops but cannot make the
   shared storage path responsive. Sonarr and Prowlarr can remain Kubernetes
   `Running` while database calls fail, while Deluge and Radarr turn sustained
@@ -217,11 +227,12 @@ policy`.
   hours, but the actual RPO is the age of the newest verified set and can be
   older. A failed nightly NFS backup has no freshness alert while the
   kube-state-metrics scrape path is unhealthy.
-- **Next step:** publish the writable replacement revision and validate the
-  writer fence, scheduled backup, and indexer searches in Prowlarr, Sonarr, and
-  Radarr. Separately inspect QNAP pool, disk, NFS-service, and network history
-  because the same failure domain still affects other NFS-backed workloads.
-  Restore backup freshness alerting when a reliable metric source is available.
+- **Next step:** validate the Prowlarr placement rollout and repeat searches in
+  Prowlarr, Sonarr, and Radarr. Verify the first scheduled local PostgreSQL
+  backup after 03:00 Pacific. Separately inspect QNAP pool, disk, NFS-service,
+  and network history because the same failure domain still affects other
+  NFS-backed workloads. Restore backup freshness alerting when a reliable
+  metric source is available.
 
 - **Status:** PostgreSQL alert path mitigated; kube-state-metrics scrape open
 - **Area:** monitoring / PostgreSQL availability


### PR DESCRIPTION
## Summary

- pin Prowlarr to `zimaboard-0`
- retain the existing Prowlarr PVC and configuration unchanged
- record the post-PostgreSQL residual NFS finding and validation gate

## Root cause

The local PostgreSQL cutover is healthy and read/write SQL remains fast, but Prowlarr searches still stalled. Live isolation showed:

- raw Prowlarr-to-IPTorrents DNS/TLS/HTTP: 0.49s
- one Prowlarr `/config/config.xml` read on Acer: 10.2s
- equivalent Sonarr/Radarr reads on `zimaboard-0`: 79ms / 281ms
- two Prowlarr searches timed out after 30s
- Acer NFS client lifetime WRITE timeouts: 26,065,641
- `zimaboard-0` lifetime WRITE timeouts: 12

Prowlarr's remaining state path is its NFS-backed `/config` PVC, and its current Acer placement was incidental. This change keeps the retained data but selects the measured healthier NFS client path.

## Validation

- app-template 4.4.0 renders the `zimaboard-0` selector
- rendered Helm resources pass server-side dry-run
- Prowlarr Kustomize resources pass server-side dry-run
- changed-file pre-commit, Checkov diff/secrets, codespell, YAML, and whitespace checks pass
- commit has a good signature

## Live gate

After sync, require Prowlarr Ready on `zimaboard-0` with the same PVC/PV, fast `/config` reads and API health, then repeat Prowlarr, Sonarr, and Radarr searches without new Npgsql or NFS-correlated timeouts.


<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

> Live Terragrunt plan skipped because this pull request did not change `IaC/**`, flake inputs, OpenTofu/Terragrunt policy inputs, or live-plan helper scripts.

Rendered Conftest policies still ran for workflows and Kubernetes manifests in this required check.

<!-- terragrunt-plan:end -->
