### PR TITLE
fix: use current cloudflare grpc setting

### DIFF
--- a/docs/knowledge-base/operations/continuous-improvement.md
+++ b/docs/knowledge-base/operations/continuous-improvement.md
@@ -99,16 +99,17 @@ policy`.
   After that digest-pinned update rolled out healthy, authenticated public
   `octelium status` still hung. The direct route completed login and reached
   `isConnected: true` with the unprivileged `gvisor` implementation, proving
-  the client, session, database, and Istio origin path.
+  the client, session, database, and Istio origin path. The first protected
+  reconciliation run injected the scoped token successfully, but Cloudflare
+  returned `Undefined zone setting: grpc`; the zone now exposes
+  `long_lived_grpc=off`, so the reconciler targets that current setting ID.
 - **Risk:** The normal public CLI path remains unavailable even though browser
   access and an unauthenticated gRPC-shaped probe work.
-- **Next step:** Set a scoped Cloudflare API token as the protected
-  `homelab-production` environment secret
-  `CLOUDFLARE_ZONE_SETTINGS_TOKEN`, then dispatch
-  `.github/workflows/octelium-cloudflare-grpc.yml` from `main`. If the workflow
-  confirms the zone setting is already on and the public path still fails,
-  investigate Cloudflare edge trailer handling with the direct-origin result
-  as the control.
+- **Next step:** Merge the corrected setting ID, dispatch
+  `.github/workflows/octelium-cloudflare-grpc.yml` from `main`, and retry the
+  public client path. If the workflow confirms the zone setting is already on
+  and the public path still fails, investigate Cloudflare edge trailer handling
+  with the direct-origin result as the control.
 
 - **Status:** open; alert semantics fixed, scrape failure unresolved
 - **Area:** observability / kube-state-metrics

--- a/scripts/octelium-cloudflare-grpc.sh
+++ b/scripts/octelium-cloudflare-grpc.sh
@@ -109,7 +109,7 @@ zone_id="$(
 )"
 
 current_value="$(
-  cf_api GET "/zones/${zone_id}/settings/grpc" |
+  cf_api GET "/zones/${zone_id}/settings/long_lived_grpc" |
     jq -er '.result.value'
 )"
 
@@ -123,10 +123,10 @@ if [[ "$current_value" == "on" ]]; then
   exit 0
 fi
 
-cf_api PATCH "/zones/${zone_id}/settings/grpc" '{"value":"on"}' >/dev/null
+cf_api PATCH "/zones/${zone_id}/settings/long_lived_grpc" '{"value":"on"}' >/dev/null
 
 updated_value="$(
-  cf_api GET "/zones/${zone_id}/settings/grpc" |
+  cf_api GET "/zones/${zone_id}/settings/long_lived_grpc" |
     jq -er '.result.value'
 )"
 


### PR DESCRIPTION
## Summary
- target Cloudflare zone setting `long_lived_grpc` instead of the undefined legacy `grpc` ID
- record the failed protected run and verified current zone setting

## Validation
- `bash -n scripts/octelium-cloudflare-grpc.sh`
- `scripts/octelium-cloudflare-grpc.sh --dry-run` → `off`
- `nix develop --command bash scripts/ci/static-checks.sh`
- signed commit hooks

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

> Live Terragrunt plan skipped because this pull request did not change `IaC/**`, flake inputs, OpenTofu/Terragrunt policy inputs, or live-plan helper scripts.

Rendered Conftest policies still ran for workflows and Kubernetes manifests in this required check.

<!-- terragrunt-plan:end -->
