### PR TITLE
fix: reconcile Octelium Cloudflare origin port

### DIFF
--- a/.github/workflows/octelium-cloudflare-origin-port-remove.yml
+++ b/.github/workflows/octelium-cloudflare-origin-port-remove.yml
@@ -1,4 +1,4 @@
-name: Reconcile Octelium Cloudflare Origin Port
+name: Remove Octelium Cloudflare Origin Port
 
 on:
   workflow_dispatch:
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  reconcile:
+  remove:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     environment:
@@ -23,7 +23,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Reconcile Cloudflare Origin Port
+      - name: Remove Cloudflare Origin Port
         env:
           CLOUDFLARE_ZONE_SETTINGS_TOKEN: ${{ secrets.CLOUDFLARE_ZONE_SETTINGS_TOKEN }}
-        run: scripts/octelium-cloudflare-origin-port.sh
+        run: scripts/octelium-cloudflare-origin-port.sh remove

--- a/.github/workflows/octelium-cloudflare-origin-port.yml
+++ b/.github/workflows/octelium-cloudflare-origin-port.yml
@@ -1,0 +1,25 @@
+name: Reconcile Octelium Cloudflare Origin Port
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  reconcile:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    environment:
+      name: homelab-production
+    permissions:
+      contents: read
+    steps:
+      - name: Check Out Repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          persist-credentials: false
+
+      - name: Reconcile Cloudflare Origin Port
+        env:
+          CLOUDFLARE_ZONE_SETTINGS_TOKEN: ${{ secrets.CLOUDFLARE_ZONE_SETTINGS_TOKEN }}
+        run: scripts/octelium-cloudflare-origin-port.sh

--- a/clusters/homelab/apps/octelium/README.md
+++ b/clusters/homelab/apps/octelium/README.md
@@ -259,7 +259,7 @@ kubectl kustomize clusters/homelab/apps/octelium
 kubectl kustomize clusters/homelab/apps/istio
 scripts/octelium-enterprise-package.sh --help
 bash -n scripts/octelium-entra-oidc.sh
-bash -n scripts/octelium-gateway-dns.sh scripts/octelium-public-dns.sh
+bash -n scripts/octelium-gateway-dns.sh scripts/octelium-public-dns.sh scripts/octelium-cloudflare-origin-port.sh
 scripts/octelium-e2e-check.sh --help
 ```
 

--- a/docs/knowledge-base/architecture/secrets-and-identity.md
+++ b/docs/knowledge-base/architecture/secrets-and-identity.md
@@ -100,8 +100,12 @@ roles need identity-based KMS permissions for both keys.
   for `n8n-webhook.stinkyboi.com` and `policy-bot-hook.stinkyboi.com`; those
   routes remain unauthenticated at Octelium but path-limited in Istio and
   validated by the receiving application credentials or signatures.
-  The public API direct-origin reconciler reuses the cert-manager Cloudflare
-  DNS token; it does not require Zone Settings permission. The former
+  The public API DNS reconciler reuses the cert-manager Cloudflare DNS token.
+  The protected `octelium-cloudflare-origin-port.yml` workflow uses the
+  `homelab-production` environment secret `CLOUDFLARE_ZONE_SETTINGS_TOKEN`
+  only for zone read and Transform Rules edit while reconciling the exact API
+  hostname's destination port; the token value never enters git or workflow
+  output. The former
   `/homelab/octelium/cloudflare-zone-settings-token` declaration has no runtime
   consumer and remains only until secret retirement is reviewed separately.
   Octelium portal login uses Microsoft Entra OIDC. The Entra application is

--- a/docs/knowledge-base/operations/continuous-improvement.md
+++ b/docs/knowledge-base/operations/continuous-improvement.md
@@ -89,7 +89,7 @@ policy`.
   renewed probe failures as the storage incident rather than an Octelium
   routing failure.
 
-- **Status:** direct-origin gateway live; high-port WAN fallback in progress
+- **Status:** high-port origin proven; Cloudflare rule reconciliation pending
 - **Area:** Octelium / public gRPC transport
 - **Evidence:** After PostgreSQL recovered, authenticated Octelium CLI calls
   still hung through `octelium-api.stinkyboi.com` while the same client and
@@ -121,12 +121,16 @@ policy`.
   `525`, while the dedicated Envoy logged `filter_chain_not_found` for that
   connection. This proves the high port reaches Istio and that Cloudflare's
   origin handshake omits the SNI required by the original exact-host Gateway.
+  After the SNI-tolerant Gateway and API-only `VirtualService` rolled out, the
+  Cloudflare TCP/8443 probe returned HTTP/2 `200` with `grpc-status: 16`, while
+  a request for another Host returned `route_not_found`. The remaining
+  standard-port cutover is owned by the protected
+  `octelium-cloudflare-origin-port.yml` workflow using the existing
+  `homelab-production` GitHub Actions secret.
 - **Risk:** The normal public CLI path remains unavailable even though browser
   access and an unauthenticated gRPC-shaped probe work.
-- **Next step:** Let the dedicated Gateway accept origin TLS without SNI while
-  moving its routing into an API-only `VirtualService`, add the exact-host
-  Cloudflare destination-port override, then verify the proxied API gRPC
-  response and a real public `octelium connect`.
+- **Next step:** Run the protected Cloudflare workflow, verify the standard
+  TCP/443 API response, and complete a real public `octelium connect`.
 
 - **Status:** open; alert semantics fixed, scrape failure unresolved
 - **Area:** observability / kube-state-metrics

--- a/docs/knowledge-base/operations/validation-gates.md
+++ b/docs/knowledge-base/operations/validation-gates.md
@@ -103,7 +103,7 @@ kubectl kustomize clusters/homelab/platform/multus
 kubectl kustomize clusters/homelab/apps/octelium-storage
 kubectl kustomize clusters/homelab/apps/octelium-cluster
 kubectl kustomize clusters/homelab/apps/octelium-public
-bash -n scripts/octelium-gateway-dns.sh scripts/octelium-public-dns.sh scripts/octelium-entra-oidc.sh
+bash -n scripts/octelium-gateway-dns.sh scripts/octelium-public-dns.sh scripts/octelium-cloudflare-origin-port.sh scripts/octelium-entra-oidc.sh
 scripts/octelium-cluster-bootstrap.sh --help
 ```
 

--- a/docs/networking-tailnet-ingress.md
+++ b/docs/networking-tailnet-ingress.md
@@ -95,6 +95,15 @@ that Advanced Security can block all inbound traffic to a forwarded device.
 The Cloudflare Origin Rule must match
 `http.host eq "octelium-api.stinkyboi.com"` and override the destination port
 to `8443`; the client URL remains standard HTTPS on port `443`.
+Reconcile it without exposing the token by running the protected workflow:
+
+```sh
+gh workflow run octelium-cloudflare-origin-port.yml --ref main
+```
+
+The `homelab-production` environment secret
+`CLOUDFLARE_ZONE_SETTINGS_TOKEN` must grant zone read and Transform Rules edit
+for `stinkyboi.com`.
 
 Prometheus is intentionally absent from the tailnet route inventory. Grafana is
 the reviewed metrics UI, and Kiali is the reviewed read-only mesh UI. Direct

--- a/docs/networking-tailnet-ingress.md
+++ b/docs/networking-tailnet-ingress.md
@@ -104,6 +104,14 @@ gh workflow run octelium-cloudflare-origin-port.yml --ref main
 The `homelab-production` environment secret
 `CLOUDFLARE_ZONE_SETTINGS_TOKEN` must grant zone read and Transform Rules edit
 for `stinkyboi.com`.
+Rollback is the same protected path and is safe to repeat:
+
+```sh
+gh workflow run octelium-cloudflare-origin-port-remove.yml --ref main
+```
+
+The workflow succeeds with an `already absent` message when no owned rule
+remains. Reapply it with the default command above.
 
 Prometheus is intentionally absent from the tailnet route inventory. Grafana is
 the reviewed metrics UI, and Kiali is the reviewed read-only mesh UI. Direct

--- a/docs/octelium.md
+++ b/docs/octelium.md
@@ -363,6 +363,13 @@ verifies both that mapping and an unauthenticated `grpc-status: 16` response
 from the NodePort before changing DNS. All browser, app, and callback hostnames
 remain on `octelium-public`.
 
+Reconcile the Cloudflare Origin Rule through its protected workflow so the
+token remains masked inside the `homelab-production` environment:
+
+```sh
+gh workflow run octelium-cloudflare-origin-port.yml --ref main
+```
+
 Once the API and gRPC path are true, create or rotate the
 `homelab-octelium-client` credential, store it in SSM, bump
 `remoteRef.version` on `octelium-client-auth`, update the ExternalSecret target
@@ -570,6 +577,7 @@ kubectl kustomize clusters/homelab/apps/istio
 kubectl kustomize clusters/homelab/platform/multus
 bash -n scripts/octelium-gateway-dns.sh
 bash -n scripts/octelium-public-dns.sh
+bash -n scripts/octelium-cloudflare-origin-port.sh
 bash -n scripts/octelium-entra-oidc.sh
 scripts/octelium-cluster-bootstrap.sh --help
 scripts/octelium-enterprise-package.sh --help

--- a/docs/secrets-aws-ssm.md
+++ b/docs/secrets-aws-ssm.md
@@ -227,7 +227,11 @@ The `octelium-api-upnp` CronJob maintains its leased UPnP port mapping;
 run `scripts/octelium-public-dns.sh` from the homelab LAN to verify the mapping
 and reconcile the proxied A record. The script reuses the cert-manager
 Cloudflare token because DNS edit permission is sufficient; no separate
-zone-settings token is required. The old
+zone-settings token is required for DNS. The protected
+`octelium-cloudflare-origin-port.yml` workflow separately uses the
+`homelab-production` environment secret `CLOUDFLARE_ZONE_SETTINGS_TOKEN` to
+reconcile the exact-host destination-port override without exposing the value.
+That token needs zone read and Transform Rules edit for `stinkyboi.com`. The old
 `/homelab/octelium/cloudflare-zone-settings-token` declaration is retained
 temporarily so removing a secret value is a separate reviewed operation.
 

--- a/scripts/octelium-cloudflare-origin-port.sh
+++ b/scripts/octelium-cloudflare-origin-port.sh
@@ -6,9 +6,15 @@ api_hostname="octelium-api.stinkyboi.com"
 origin_port=8443
 rule_description="Octelium API origin port"
 token="${CLOUDFLARE_ZONE_SETTINGS_TOKEN:-}"
+action="${1:-apply}"
 
 if [[ -z "$token" || "$token" == "REPLACE_ME" ]]; then
   echo "error: CLOUDFLARE_ZONE_SETTINGS_TOKEN is required" >&2
+  exit 1
+fi
+
+if [[ "$action" != "apply" && "$action" != "remove" ]]; then
+  echo "error: action must be apply or remove" >&2
   exit 1
 fi
 
@@ -57,6 +63,33 @@ ruleset_id="$(
     <<<"$rulesets"
 )"
 
+if [[ -n "$ruleset_id" ]]; then
+  ruleset="$(cf_api GET "/zones/${zone_id}/rulesets/${ruleset_id}")"
+  rule_id="$(
+    jq -r \
+      --arg description "$rule_description" \
+      'first(.result.rules[]? | select(.description == $description) | .id) // ""' \
+      <<<"$ruleset"
+  )"
+else
+  rule_id=""
+fi
+
+if [[ "$action" == "remove" ]]; then
+  if [[ -z "$rule_id" ]]; then
+    echo "Cloudflare Origin Rule is already absent for ${api_hostname}"
+    exit 0
+  fi
+
+  cf_api DELETE "/zones/${zone_id}/rulesets/${ruleset_id}/rules/${rule_id}" >/dev/null
+  verified="$(cf_api GET "/zones/${zone_id}/rulesets/${ruleset_id}")"
+  jq -e \
+    --arg description "$rule_description" \
+    'all(.result.rules[]?; .description != $description)' >/dev/null <<<"$verified"
+  echo "Removed Cloudflare Origin Rule for ${api_hostname}"
+  exit 0
+fi
+
 rule_payload="$(
   jq -cn \
     --arg description "$rule_description" \
@@ -86,14 +119,6 @@ if [[ -z "$ruleset_id" ]]; then
   ruleset_id="$(jq -er '.result.id' <<<"$created")"
   echo "Created Cloudflare Origin Rule for ${api_hostname} -> TCP/${origin_port}"
 else
-  ruleset="$(cf_api GET "/zones/${zone_id}/rulesets/${ruleset_id}")"
-  rule_id="$(
-    jq -r \
-      --arg description "$rule_description" \
-      'first(.result.rules[]? | select(.description == $description) | .id) // ""' \
-      <<<"$ruleset"
-  )"
-
   if [[ -z "$rule_id" ]]; then
     cf_api POST "/zones/${zone_id}/rulesets/${ruleset_id}/rules" "$rule_payload" >/dev/null
     echo "Added Cloudflare Origin Rule for ${api_hostname} -> TCP/${origin_port}"

--- a/scripts/octelium-cloudflare-origin-port.sh
+++ b/scripts/octelium-cloudflare-origin-port.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+zone_name="stinkyboi.com"
+api_hostname="octelium-api.stinkyboi.com"
+origin_port=8443
+rule_description="Octelium API origin port"
+token="${CLOUDFLARE_ZONE_SETTINGS_TOKEN:-}"
+
+if [[ -z "$token" || "$token" == "REPLACE_ME" ]]; then
+  echo "error: CLOUDFLARE_ZONE_SETTINGS_TOKEN is required" >&2
+  exit 1
+fi
+
+cf_api() {
+  local method="$1"
+  local path="$2"
+  local data="${3:-}"
+  local response
+
+  if [[ -n "$data" ]]; then
+    response="$(
+      curl -sS \
+        -X "$method" \
+        -H "Authorization: Bearer ${token}" \
+        -H "Content-Type: application/json" \
+        --data "$data" \
+        "https://api.cloudflare.com/client/v4${path}"
+    )"
+  else
+    response="$(
+      curl -sS \
+        -X "$method" \
+        -H "Authorization: Bearer ${token}" \
+        -H "Content-Type: application/json" \
+        "https://api.cloudflare.com/client/v4${path}"
+    )"
+  fi
+
+  if ! jq -e '.success == true' >/dev/null <<<"$response"; then
+    jq -r '.errors[]? | "Cloudflare API error \(.code): \(.message)"' <<<"$response" >&2
+    return 1
+  fi
+
+  printf '%s\n' "$response"
+}
+
+zone_id="$(
+  cf_api GET "/zones?name=${zone_name}" |
+    jq -er '.result[0].id'
+)"
+
+rulesets="$(cf_api GET "/zones/${zone_id}/rulesets")"
+ruleset_id="$(
+  jq -r \
+    'first(.result[] | select(.kind == "zone" and .phase == "http_request_origin") | .id) // ""' \
+    <<<"$rulesets"
+)"
+
+rule_payload="$(
+  jq -cn \
+    --arg description "$rule_description" \
+    --arg host "$api_hostname" \
+    --argjson port "$origin_port" \
+    '{
+      action: "route",
+      action_parameters: {origin: {port: $port}},
+      expression: ("(http.host eq \"" + $host + "\")"),
+      description: $description,
+      enabled: true
+    }'
+)"
+
+if [[ -z "$ruleset_id" ]]; then
+  create_payload="$(
+    jq -cn \
+      --argjson rule "$rule_payload" \
+      '{
+        name: "Homelab origin overrides",
+        kind: "zone",
+        phase: "http_request_origin",
+        rules: [$rule]
+      }'
+  )"
+  created="$(cf_api POST "/zones/${zone_id}/rulesets" "$create_payload")"
+  ruleset_id="$(jq -er '.result.id' <<<"$created")"
+  echo "Created Cloudflare Origin Rule for ${api_hostname} -> TCP/${origin_port}"
+else
+  ruleset="$(cf_api GET "/zones/${zone_id}/rulesets/${ruleset_id}")"
+  rule_id="$(
+    jq -r \
+      --arg description "$rule_description" \
+      'first(.result.rules[]? | select(.description == $description) | .id) // ""' \
+      <<<"$ruleset"
+  )"
+
+  if [[ -z "$rule_id" ]]; then
+    cf_api POST "/zones/${zone_id}/rulesets/${ruleset_id}/rules" "$rule_payload" >/dev/null
+    echo "Added Cloudflare Origin Rule for ${api_hostname} -> TCP/${origin_port}"
+  else
+    cf_api PATCH "/zones/${zone_id}/rulesets/${ruleset_id}/rules/${rule_id}" "$rule_payload" >/dev/null
+    echo "Updated Cloudflare Origin Rule for ${api_hostname} -> TCP/${origin_port}"
+  fi
+fi
+
+verified="$(cf_api GET "/zones/${zone_id}/rulesets/${ruleset_id}")"
+jq -e \
+  --arg description "$rule_description" \
+  --arg host "$api_hostname" \
+  --argjson port "$origin_port" \
+  'any(
+    .result.rules[]?;
+    .description == $description and
+    .enabled == true and
+    .action == "route" and
+    .action_parameters.origin.port == $port and
+    .expression == ("(http.host eq \"" + $host + "\")")
+  )' >/dev/null <<<"$verified"
+
+echo "Verified Cloudflare Origin Rule for ${api_hostname} -> TCP/${origin_port}"


### PR DESCRIPTION
## Summary
- add a protected manual workflow that uses the existing `homelab-production` Cloudflare secret
- idempotently reconcile the exact Octelium API origin-port rule to TCP/8443
- document the secret contract and operator command

## Validation
- `bash -n scripts/octelium-cloudflare-origin-port.sh`
- missing-secret fail-closed check
- `nix develop --command bash scripts/ci/conftest-policies.sh` (216 workflow checks and 6,480 manifest checks passed)
- commit hooks: YAML, codespell, Checkov, zizmor

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

> Live Terragrunt plan skipped because this pull request did not change `IaC/**`, flake inputs, OpenTofu/Terragrunt policy inputs, or live-plan helper scripts.

Rendered Conftest policies still ran for workflows and Kubernetes manifests in this required check.

<!-- terragrunt-plan:end -->
