### PR TITLE
docs: record Radarr config corruption

### DIFF
--- a/docs/knowledge-base/operations/continuous-improvement.md
+++ b/docs/knowledge-base/operations/continuous-improvement.md
@@ -251,6 +251,11 @@ policy`.
   at 03:00 Pacific with no failures. Backup `20260730T100002Z` verified
   password-free globals and all six dumps; the successful Job also exercised
   the live 14-day retention command without error.
+  Read-only inspection on 2026-08-01 found Radarr independently
+  `CrashLoopBackOff` with 785 restarts because its NFS-backed
+  `/config/config.xml` was empty. The local-config Deluge replacement remained
+  healthy with zero restarts, 17 torrents, and successful Sonarr connectivity,
+  separating this recurrence from the completed Deluge cutover.
 - **Risk:** probe hardening limits crash-recovery loops but cannot make the
   shared storage path responsive. Sonarr and Prowlarr can remain Kubernetes
   `Running` while database calls fail, while Deluge and Radarr turn sustained


### PR DESCRIPTION
## Summary

Record the 2026-08-01 Radarr recurrence discovered during Deluge rollout verification.

## Evidence

- Radarr was `CrashLoopBackOff` with 785 restarts
- the previous container repeatedly reported `/config/config.xml: Document is empty`
- Deluge remained healthy on local config with zero restarts, 17 torrents, and successful Sonarr connectivity

This PR records the finding only; it does not mutate or expand Radarr desired state.

## Validation

- `git diff --check`
- affected-file pre-commit hooks


<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

> Live Terragrunt plan skipped because this pull request did not change `IaC/**`, flake inputs, OpenTofu/Terragrunt policy inputs, or live-plan helper scripts.

Rendered Conftest policies still ran for workflows and Kubernetes manifests in this required check.

<!-- terragrunt-plan:end -->
