### PR TITLE
fix: verify Octelium Cloudflare transport

### DIFF
--- a/docs/knowledge-base/architecture/secrets-and-identity.md
+++ b/docs/knowledge-base/architecture/secrets-and-identity.md
@@ -103,9 +103,10 @@ roles need identity-based KMS permissions for both keys.
   The public API DNS reconciler reuses the cert-manager Cloudflare DNS token.
   The protected `octelium-cloudflare-origin-port.yml` workflow uses the
   `homelab-production` environment secret `CLOUDFLARE_ZONE_SETTINGS_TOKEN`
-  only for zone read and Origin Rules edit while reconciling the exact API
-  hostname's destination port and verifying its TLS/HTTP2 origin transport;
-  the token value never enters git or workflow output. The former
+  only for zone read, Zone Settings read, and Origin Rules edit while
+  reconciling the exact API hostname's destination port and verifying its
+  TLS/HTTP2 origin transport; the token value never enters git or workflow
+  output. The former
   `/homelab/octelium/cloudflare-zone-settings-token` declaration has no runtime
   consumer and remains only until secret retirement is reviewed separately.
   Octelium portal login uses Microsoft Entra OIDC. The Entra application is

--- a/docs/knowledge-base/architecture/secrets-and-identity.md
+++ b/docs/knowledge-base/architecture/secrets-and-identity.md
@@ -103,9 +103,9 @@ roles need identity-based KMS permissions for both keys.
   The public API DNS reconciler reuses the cert-manager Cloudflare DNS token.
   The protected `octelium-cloudflare-origin-port.yml` workflow uses the
   `homelab-production` environment secret `CLOUDFLARE_ZONE_SETTINGS_TOKEN`
-  only for zone read and Transform Rules edit while reconciling the exact API
-  hostname's destination port; the token value never enters git or workflow
-  output. The former
+  only for zone read and Origin Rules edit while reconciling the exact API
+  hostname's destination port and verifying its TLS/HTTP2 origin transport;
+  the token value never enters git or workflow output. The former
   `/homelab/octelium/cloudflare-zone-settings-token` declaration has no runtime
   consumer and remains only until secret retirement is reviewed separately.
   Octelium portal login uses Microsoft Entra OIDC. The Entra application is

--- a/docs/networking-tailnet-ingress.md
+++ b/docs/networking-tailnet-ingress.md
@@ -102,10 +102,8 @@ gh workflow run octelium-cloudflare-origin-port.yml --ref main
 ```
 
 The `homelab-production` environment secret
-`CLOUDFLARE_ZONE_SETTINGS_TOKEN` must grant zone read and Origin Rules edit
+`CLOUDFLARE_ZONE_SETTINGS_TOKEN` must grant zone read and Transform Rules edit
 for `stinkyboi.com`.
-The apply workflow also verifies Full or Full (strict) SSL and HTTP/2 to the
-origin before reconciling the rule.
 Rollback is the same protected path and is safe to repeat:
 
 ```sh

--- a/docs/networking-tailnet-ingress.md
+++ b/docs/networking-tailnet-ingress.md
@@ -102,8 +102,10 @@ gh workflow run octelium-cloudflare-origin-port.yml --ref main
 ```
 
 The `homelab-production` environment secret
-`CLOUDFLARE_ZONE_SETTINGS_TOKEN` must grant zone read and Transform Rules edit
+`CLOUDFLARE_ZONE_SETTINGS_TOKEN` must grant zone read and Origin Rules edit
 for `stinkyboi.com`.
+The apply workflow also verifies Full or Full (strict) SSL and HTTP/2 to the
+origin before reconciling the rule.
 Rollback is the same protected path and is safe to repeat:
 
 ```sh

--- a/docs/networking-tailnet-ingress.md
+++ b/docs/networking-tailnet-ingress.md
@@ -50,7 +50,7 @@ why `stinkyboi.com` is the Octelium cluster domain even though
 ## Route Inventory
 
 | Surface | HTTPS host | Backbone |
-|-----|------------------|---------------|
+| --- | --- | --- |
 | Octelium browser control plane | `https://stinkyboi.com`, `https://octelium.stinkyboi.com`, `https://portal.stinkyboi.com` | `octelium-public` Cloudflare Tunnel to Istio/Octelium |
 | Octelium CLI API | `https://octelium-api.stinkyboi.com` | Cloudflare normal gRPC proxy on client TCP/443, Origin Rule to WAN TCP/8443, then UPnP to the API-only Istio gateway NodePort |
 | app UIs | existing `https://*.stinkyboi.com` app hostnames | `octelium-public` Cloudflare Tunnel to Octelium `WEB` Services; clientless except AFFiNE |
@@ -102,8 +102,9 @@ gh workflow run octelium-cloudflare-origin-port.yml --ref main
 ```
 
 The `homelab-production` environment secret
-`CLOUDFLARE_ZONE_SETTINGS_TOKEN` must grant zone read and Transform Rules edit
-for `stinkyboi.com`.
+`CLOUDFLARE_ZONE_SETTINGS_TOKEN` must grant zone read, Zone Settings read, and
+Origin Rules edit for `stinkyboi.com`. Zone Settings read authorizes the
+workflow's Full SSL and HTTP/2-to-origin checks.
 Rollback is the same protected path and is safe to repeat:
 
 ```sh

--- a/docs/octelium.md
+++ b/docs/octelium.md
@@ -372,6 +372,7 @@ gh workflow run octelium-cloudflare-origin-port.yml --ref main
 
 The workflow also verifies that the zone uses Full or Full (strict) SSL and
 allows HTTP/2 to the origin; Octelium's TLS gRPC endpoint requires both.
+Its token needs zone read and Origin Rules edit for `stinkyboi.com`.
 
 Once the API and gRPC path are true, create or rotate the
 `homelab-octelium-client` credential, store it in SSM, bump

--- a/docs/octelium.md
+++ b/docs/octelium.md
@@ -370,6 +370,9 @@ token remains masked inside the `homelab-production` environment:
 gh workflow run octelium-cloudflare-origin-port.yml --ref main
 ```
 
+The workflow also verifies that the zone uses Full or Full (strict) SSL and
+allows HTTP/2 to the origin; Octelium's TLS gRPC endpoint requires both.
+
 Once the API and gRPC path are true, create or rotate the
 `homelab-octelium-client` credential, store it in SSM, bump
 `remoteRef.version` on `octelium-client-auth`, update the ExternalSecret target

--- a/docs/octelium.md
+++ b/docs/octelium.md
@@ -372,7 +372,8 @@ gh workflow run octelium-cloudflare-origin-port.yml --ref main
 
 The workflow also verifies that the zone uses Full or Full (strict) SSL and
 allows HTTP/2 to the origin; Octelium's TLS gRPC endpoint requires both.
-Its token needs zone read and Origin Rules edit for `stinkyboi.com`.
+Its token needs zone read, Zone Settings read, and Origin Rules edit for
+`stinkyboi.com`.
 
 Once the API and gRPC path are true, create or rotate the
 `homelab-octelium-client` credential, store it in SSM, bump

--- a/docs/secrets-aws-ssm.md
+++ b/docs/secrets-aws-ssm.md
@@ -231,7 +231,7 @@ zone-settings token is required for DNS. The protected
 `octelium-cloudflare-origin-port.yml` workflow separately uses the
 `homelab-production` environment secret `CLOUDFLARE_ZONE_SETTINGS_TOKEN` to
 reconcile the exact-host destination-port override without exposing the value.
-That token needs zone read and Transform Rules edit for `stinkyboi.com`. The old
+That token needs zone read and Origin Rules edit for `stinkyboi.com`. The old
 `/homelab/octelium/cloudflare-zone-settings-token` declaration is retained
 temporarily so removing a secret value is a separate reviewed operation.
 

--- a/docs/secrets-aws-ssm.md
+++ b/docs/secrets-aws-ssm.md
@@ -231,7 +231,7 @@ zone-settings token is required for DNS. The protected
 `octelium-cloudflare-origin-port.yml` workflow separately uses the
 `homelab-production` environment secret `CLOUDFLARE_ZONE_SETTINGS_TOKEN` to
 reconcile the exact-host destination-port override without exposing the value.
-That token needs zone read and Origin Rules edit for `stinkyboi.com`. The old
+That token needs zone read and Transform Rules edit for `stinkyboi.com`. The old
 `/homelab/octelium/cloudflare-zone-settings-token` declaration is retained
 temporarily so removing a secret value is a separate reviewed operation.
 

--- a/docs/secrets-aws-ssm.md
+++ b/docs/secrets-aws-ssm.md
@@ -89,7 +89,7 @@ git, but they are copied into the encrypted OpenTofu remote state for that
 stack because Terraform manages the Kubernetes Secret.
 
 | App | ExternalSecret | Target Secret | SSM parameters |
-|-----|----------------|---------------|----------------|
+| --- | --- | --- | --- |
 | argocd | `argocd-oidc-sso` | `argocd-oidc-sso` | `/homelab/argocd/oidc/issuer`, `/homelab/argocd/oidc/client-id`, `/homelab/argocd/oidc/client-secret` |
 | argocd-image-updater | `argocd-image-updater-git` | `argocd-image-updater-git` | `/homelab/argocd-image-updater/github-app/id`, `/homelab/argocd-image-updater/github-app/installation-id`, `/homelab/argocd-image-updater/github-app/private-key` |
 | affine | `affine-secrets` | `affine-secrets` | `/homelab/affine/postgres-password`, `/homelab/affine/redis-password`, `/homelab/affine/private-key` |
@@ -110,7 +110,8 @@ stack because Terraform manages the Kubernetes Secret.
 | dispatcharr | `dispatcharr-postgres-env` | `dispatcharr-postgres-env` | `/homelab/media-postgres/dispatcharr-app-password` |
 | media-postgres | `media-postgres-auth`, `media-postgres-arr-env` | `media-postgres-auth`, `media-postgres-arr-env` | `/homelab/media-postgres/app-password` |
 | n8n-postgres | `n8n-postgres-auth`, `n8n-postgres-client` | `n8n-postgres-auth`, `n8n-postgres-client` | `/homelab/n8n/postgres-admin-password`, `/homelab/n8n/postgres-app-password` |
-| openclaw | `openclaw-secrets`, `openclaw-github-app-private-key` | `openclaw-secrets`, `openclaw-github-app-private-key` | `/homelab/openclaw/app-secret`, `/homelab/openclaw/litellm-token`, `/homelab/openclaw/discord-bot-token`, `/homelab/openclaw/grafana/username`, `/homelab/openclaw/grafana/password`, `/homelab/openclaw/github-app/id`, `/homelab/openclaw/github-app/installation-id`, `/homelab/openclaw/github-app/private-key` |
+| openclaw | `openclaw-secrets`, `openclaw-github-app-private-key` | `openclaw-secrets`, `openclaw-github-app-private-key` | `/homelab/openclaw/app-secret`, `/homelab/openclaw/litellm-token`, `/homelab/openclaw/discord-bot-token`, `/homelab/openclaw/grafana/username`, `/homelab/openclaw/grafana/password` |
+| openclaw (continued) | same as above | same as above | `/homelab/openclaw/github-app/id`, `/homelab/openclaw/github-app/installation-id`, `/homelab/openclaw/github-app/private-key` |
 | n8n | `n8n-secrets` | `n8n-secrets` | `/homelab/n8n/encryption-key`, plus `n8n-postgres-client` from `n8n-postgres` |
 | policy-bot | `policy-bot-config` | `policy-bot-config` | `/homelab/policy-bot/github-app/integration-id`, `/homelab/policy-bot/github-app/webhook-secret`, `/homelab/policy-bot/github-app/private-key`, `/homelab/policy-bot/oauth/client-id`, `/homelab/policy-bot/oauth/client-secret`, `/homelab/policy-bot/sessions-key` |
 
@@ -231,7 +232,9 @@ zone-settings token is required for DNS. The protected
 `octelium-cloudflare-origin-port.yml` workflow separately uses the
 `homelab-production` environment secret `CLOUDFLARE_ZONE_SETTINGS_TOKEN` to
 reconcile the exact-host destination-port override without exposing the value.
-That token needs zone read and Transform Rules edit for `stinkyboi.com`. The old
+That token needs zone read, Zone Settings read, and Origin Rules edit for
+`stinkyboi.com`. Zone Settings read authorizes the workflow's SSL mode and
+HTTP/2-to-origin checks. The old
 `/homelab/octelium/cloudflare-zone-settings-token` declaration is retained
 temporarily so removing a secret value is a separate reviewed operation.
 

--- a/scripts/octelium-cloudflare-origin-port.sh
+++ b/scripts/octelium-cloudflare-origin-port.sh
@@ -90,6 +90,24 @@ if [[ "$action" == "remove" ]]; then
   exit 0
 fi
 
+ssl_mode="$(cf_api GET "/zones/${zone_id}/settings/ssl" | jq -er '.result.value')"
+origin_max_http_version="$(
+  cf_api GET "/zones/${zone_id}/settings/origin_max_http_version" |
+    jq -er '.result.value'
+)"
+
+echo "Cloudflare origin transport: SSL=${ssl_mode}, HTTP/${origin_max_http_version} max"
+
+if [[ "$ssl_mode" != "full" && "$ssl_mode" != "strict" ]]; then
+  echo "error: Cloudflare SSL mode must be Full or Full (strict) for the TLS origin" >&2
+  exit 1
+fi
+
+if [[ "$origin_max_http_version" != "2" ]]; then
+  echo "error: Cloudflare HTTP/2 to Origin must be enabled for Octelium gRPC" >&2
+  exit 1
+fi
+
 rule_payload="$(
   jq -cn \
     --arg description "$rule_description" \


### PR DESCRIPTION
## Summary
- verify Cloudflare Full or Full strict SSL before reconciling the Octelium origin rule
- verify HTTP/2 to Origin is enabled for the gRPC API
- correct the documented Origin Rules token permission

## Validation
- commit hooks passed, including Checkov Diff, Checkov Secrets, codespell, and formatting
- bash syntax and diff checks passed

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

> Live Terragrunt plan skipped because this pull request did not change `IaC/**`, flake inputs, OpenTofu/Terragrunt policy inputs, or live-plan helper scripts.

Rendered Conftest policies still ran for workflows and Kubernetes manifests in this required check.

<!-- terragrunt-plan:end -->
