### PR TITLE
fix: enforce Octelium origin TLS

### DIFF
--- a/IaC/.catalog/units/live/aws-ssm-parameters/terragrunt.hcl
+++ b/IaC/.catalog/units/live/aws-ssm-parameters/terragrunt.hcl
@@ -122,7 +122,7 @@ inputs = {
       initial_value = local.placeholder
     }
     "/homelab/octelium/cloudflare-zone-settings-token" = {
-      description   = "Cloudflare API token with Zone:Read and Zone Settings:Edit permissions used to enable gRPC for the Octelium public API hostname."
+      description   = "Legacy Cloudflare zone-settings token placeholder with no runtime consumer; retained pending separate retirement review."
       initial_value = local.placeholder
     }
     "/homelab/octelium/postgres-password" = {

--- a/docs/knowledge-base/architecture/secrets-and-identity.md
+++ b/docs/knowledge-base/architecture/secrets-and-identity.md
@@ -103,10 +103,10 @@ roles need identity-based KMS permissions for both keys.
   The public API DNS reconciler reuses the cert-manager Cloudflare DNS token.
   The protected `octelium-cloudflare-origin-port.yml` workflow uses the
   `homelab-production` environment secret `CLOUDFLARE_ZONE_SETTINGS_TOKEN`
-  only for zone read, Zone Settings read, and Origin Rules edit while
-  reconciling the exact API hostname's destination port and verifying its
-  TLS/HTTP2 origin transport; the token value never enters git or workflow
-  output. The former
+  only for zone read, Zone Settings read, Origin Rules edit, and Config Settings
+  write while reconciling the exact API hostname's destination port and Full
+  (strict) TLS/HTTP2 origin transport; the token value never enters git or
+  workflow output. The former
   `/homelab/octelium/cloudflare-zone-settings-token` declaration has no runtime
   consumer and remains only until secret retirement is reviewed separately.
   Octelium portal login uses Microsoft Entra OIDC. The Entra application is

--- a/docs/networking-tailnet-ingress.md
+++ b/docs/networking-tailnet-ingress.md
@@ -92,19 +92,20 @@ If the mapping exists but WAN connections time out, use Xfinity Advanced
 Security's device-specific **Allow Access** flow for `zimaboard-0`; Xfinity
 [documents](https://www.xfinity.com/support/articles/xfi-port-forwarding)
 that Advanced Security can block all inbound traffic to a forwarded device.
-The Cloudflare Origin Rule must match
+Cloudflare rules must match
 `http.host eq "octelium-api.stinkyboi.com"` and override the destination port
-to `8443`; the client URL remains standard HTTPS on port `443`.
-Reconcile it without exposing the token by running the protected workflow:
+to `8443` while setting SSL to Full (strict); the client URL remains standard
+HTTPS on port `443`. Reconcile them without exposing the token by running the
+protected workflow:
 
 ```sh
 gh workflow run octelium-cloudflare-origin-port.yml --ref main
 ```
 
 The `homelab-production` environment secret
-`CLOUDFLARE_ZONE_SETTINGS_TOKEN` must grant zone read, Zone Settings read, and
-Origin Rules edit for `stinkyboi.com`. Zone Settings read authorizes the
-workflow's Full SSL and HTTP/2-to-origin checks.
+`CLOUDFLARE_ZONE_SETTINGS_TOKEN` must grant zone read, Zone Settings read,
+Origin Rules edit, and Config Settings write for `stinkyboi.com`. Zone Settings
+read authorizes the workflow's SSL and HTTP/2-to-origin checks.
 Rollback is the same protected path and is safe to repeat:
 
 ```sh

--- a/docs/octelium.md
+++ b/docs/octelium.md
@@ -363,17 +363,18 @@ verifies both that mapping and an unauthenticated `grpc-status: 16` response
 from the NodePort before changing DNS. All browser, app, and callback hostnames
 remain on `octelium-public`.
 
-Reconcile the Cloudflare Origin Rule through its protected workflow so the
-token remains masked inside the `homelab-production` environment:
+Reconcile the Cloudflare origin-port and TLS Configuration Rules through their
+protected workflow so the token remains masked inside the `homelab-production`
+environment:
 
 ```sh
 gh workflow run octelium-cloudflare-origin-port.yml --ref main
 ```
 
-The workflow also verifies that the zone uses Full or Full (strict) SSL and
-allows HTTP/2 to the origin; Octelium's TLS gRPC endpoint requires both.
-Its token needs zone read, Zone Settings read, and Origin Rules edit for
-`stinkyboi.com`.
+The workflow sets Full (strict) SSL for only the Octelium API hostname and
+verifies that the zone allows HTTP/2 to the origin; Octelium's TLS gRPC endpoint
+requires both. Its token needs zone read, Zone Settings read, Origin Rules edit,
+and Config Settings write for `stinkyboi.com`.
 
 Once the API and gRPC path are true, create or rotate the
 `homelab-octelium-client` credential, store it in SSM, bump

--- a/docs/secrets-aws-ssm.md
+++ b/docs/secrets-aws-ssm.md
@@ -231,10 +231,10 @@ Cloudflare token because DNS edit permission is sufficient; no separate
 zone-settings token is required for DNS. The protected
 `octelium-cloudflare-origin-port.yml` workflow separately uses the
 `homelab-production` environment secret `CLOUDFLARE_ZONE_SETTINGS_TOKEN` to
-reconcile the exact-host destination-port override without exposing the value.
-That token needs zone read, Zone Settings read, and Origin Rules edit for
-`stinkyboi.com`. Zone Settings read authorizes the workflow's SSL mode and
-HTTP/2-to-origin checks. The old
+reconcile the exact-host destination-port and Full (strict) TLS overrides
+without exposing the value. That token needs zone read, Zone Settings read,
+Origin Rules edit, and Config Settings write for `stinkyboi.com`. Zone Settings
+read authorizes the workflow's SSL mode and HTTP/2-to-origin checks. The old
 `/homelab/octelium/cloudflare-zone-settings-token` declaration is retained
 temporarily so removing a secret value is a separate reviewed operation.
 

--- a/scripts/octelium-cloudflare-origin-port.sh
+++ b/scripts/octelium-cloudflare-origin-port.sh
@@ -5,6 +5,7 @@ zone_name="stinkyboi.com"
 api_hostname="octelium-api.stinkyboi.com"
 origin_port=8443
 rule_description="Octelium API origin port"
+tls_rule_description="Octelium API origin TLS"
 token="${CLOUDFLARE_ZONE_SETTINGS_TOKEN:-}"
 action="${1:-apply}"
 
@@ -62,6 +63,11 @@ ruleset_id="$(
     'first(.result[] | select(.kind == "zone" and .phase == "http_request_origin") | .id) // ""' \
     <<<"$rulesets"
 )"
+tls_ruleset_id="$(
+  jq -r \
+    'first(.result[] | select(.kind == "zone" and .phase == "http_config_settings") | .id) // ""' \
+    <<<"$rulesets"
+)"
 
 if [[ -n "$ruleset_id" ]]; then
   ruleset="$(cf_api GET "/zones/${zone_id}/rulesets/${ruleset_id}")"
@@ -75,18 +81,40 @@ else
   rule_id=""
 fi
 
+if [[ -n "$tls_ruleset_id" ]]; then
+  tls_ruleset="$(cf_api GET "/zones/${zone_id}/rulesets/${tls_ruleset_id}")"
+  tls_rule_id="$(
+    jq -r \
+      --arg description "$tls_rule_description" \
+      'first(.result.rules[]? | select(.description == $description) | .id) // ""' \
+      <<<"$tls_ruleset"
+  )"
+else
+  tls_rule_id=""
+fi
+
 if [[ "$action" == "remove" ]]; then
-  if [[ -z "$rule_id" ]]; then
+  if [[ -n "$rule_id" ]]; then
+    cf_api DELETE "/zones/${zone_id}/rulesets/${ruleset_id}/rules/${rule_id}" >/dev/null
+    verified="$(cf_api GET "/zones/${zone_id}/rulesets/${ruleset_id}")"
+    jq -e \
+      --arg description "$rule_description" \
+      'all(.result.rules[]?; .description != $description)' >/dev/null <<<"$verified"
+    echo "Removed Cloudflare Origin Rule for ${api_hostname}"
+  else
     echo "Cloudflare Origin Rule is already absent for ${api_hostname}"
-    exit 0
   fi
 
-  cf_api DELETE "/zones/${zone_id}/rulesets/${ruleset_id}/rules/${rule_id}" >/dev/null
-  verified="$(cf_api GET "/zones/${zone_id}/rulesets/${ruleset_id}")"
-  jq -e \
-    --arg description "$rule_description" \
-    'all(.result.rules[]?; .description != $description)' >/dev/null <<<"$verified"
-  echo "Removed Cloudflare Origin Rule for ${api_hostname}"
+  if [[ -n "$tls_rule_id" ]]; then
+    cf_api DELETE "/zones/${zone_id}/rulesets/${tls_ruleset_id}/rules/${tls_rule_id}" >/dev/null
+    tls_verified="$(cf_api GET "/zones/${zone_id}/rulesets/${tls_ruleset_id}")"
+    jq -e \
+      --arg description "$tls_rule_description" \
+      'all(.result.rules[]?; .description != $description)' >/dev/null <<<"$tls_verified"
+    echo "Removed Cloudflare TLS Configuration Rule for ${api_hostname}"
+  else
+    echo "Cloudflare TLS Configuration Rule is already absent for ${api_hostname}"
+  fi
   exit 0
 fi
 
@@ -98,14 +126,44 @@ origin_max_http_version="$(
 
 echo "Cloudflare origin transport: SSL=${ssl_mode}, HTTP/${origin_max_http_version} max"
 
-if [[ "$ssl_mode" != "full" && "$ssl_mode" != "strict" ]]; then
-  echo "error: Cloudflare SSL mode must be Full or Full (strict) for the TLS origin" >&2
-  exit 1
-fi
-
 if [[ "$origin_max_http_version" != "2" ]]; then
   echo "error: Cloudflare HTTP/2 to Origin must be enabled for Octelium gRPC" >&2
   exit 1
+fi
+
+tls_rule_payload="$(
+  jq -cn \
+    --arg description "$tls_rule_description" \
+    --arg host "$api_hostname" \
+    '{
+      action: "set_config",
+      action_parameters: {ssl: "strict"},
+      expression: ("(http.host eq \"" + $host + "\")"),
+      description: $description,
+      enabled: true
+    }'
+)"
+
+if [[ -z "$tls_ruleset_id" ]]; then
+  create_payload="$(
+    jq -cn \
+      --argjson rule "$tls_rule_payload" \
+      '{
+        name: "Homelab configuration overrides",
+        kind: "zone",
+        phase: "http_config_settings",
+        rules: [$rule]
+      }'
+  )"
+  created="$(cf_api POST "/zones/${zone_id}/rulesets" "$create_payload")"
+  tls_ruleset_id="$(jq -er '.result.id' <<<"$created")"
+  echo "Created Cloudflare TLS Configuration Rule for ${api_hostname}"
+elif [[ -z "$tls_rule_id" ]]; then
+  cf_api POST "/zones/${zone_id}/rulesets/${tls_ruleset_id}/rules" "$tls_rule_payload" >/dev/null
+  echo "Added Cloudflare TLS Configuration Rule for ${api_hostname}"
+else
+  cf_api PATCH "/zones/${zone_id}/rulesets/${tls_ruleset_id}/rules/${tls_rule_id}" "$tls_rule_payload" >/dev/null
+  echo "Updated Cloudflare TLS Configuration Rule for ${api_hostname}"
 fi
 
 rule_payload="$(
@@ -161,3 +219,18 @@ jq -e \
   )' >/dev/null <<<"$verified"
 
 echo "Verified Cloudflare Origin Rule for ${api_hostname} -> TCP/${origin_port}"
+
+tls_verified="$(cf_api GET "/zones/${zone_id}/rulesets/${tls_ruleset_id}")"
+jq -e \
+  --arg description "$tls_rule_description" \
+  --arg host "$api_hostname" \
+  'any(
+    .result.rules[]?;
+    .description == $description and
+    .enabled == true and
+    .action == "set_config" and
+    .action_parameters.ssl == "strict" and
+    .expression == ("(http.host eq \"" + $host + "\")")
+  )' >/dev/null <<<"$tls_verified"
+
+echo "Verified Cloudflare TLS Configuration Rule for ${api_hostname}: Full (strict)"


### PR DESCRIPTION
## Summary
- reconcile a hostname-scoped Cloudflare Full (strict) Configuration Rule alongside the existing origin-port rule
- remove both owned rules through the protected rollback workflow
- document the Config Settings write permission and updated transport contract

## Root cause
Protected run 30716050087 proved the zone uses Flexible SSL while the Octelium origin accepts TLS only. Cloudflare therefore sent plaintext to the TLS listener and returned HTTP 520. HTTP/2 to origin is already enabled.

## Validation
- bash -n scripts/octelium-cloudflare-origin-port.sh
- git diff --check
- signed commit hooks (codespell, Checkov, zizmor where applicable)
- origin certificate verified for octelium-api.stinkyboi.com against the public CA chain

## Rollback
Run octelium-cloudflare-origin-port-remove.yml from main; it removes both repository-owned rules idempotently.

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `dc24177547b911603de7b9edc10e8b2b285a8818`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.

> AzureAD application registration plans were skipped because the plan environment did not provide `ARM_CLIENT_ID`, `ARM_CLIENT_SECRET`, and `ARM_TENANT_ID`. Production apply still fails fast when `IaC/live/azuread-applications` changes and those credentials are absent.


<!-- terragrunt-plan:end -->

