### PR TITLE
fix(cordium): schedule workspace pods

### DIFF
--- a/IaC/.catalog/units/live/kubernetes-node-labels/terragrunt.hcl
+++ b/IaC/.catalog/units/live/kubernetes-node-labels/terragrunt.hcl
@@ -17,6 +17,7 @@ inputs = {
     }
     zimaboard-1 = {
       "octelium.com/node-mode-controlplane" = ""
+      "octelium.com/node-mode-cordium"      = ""
     }
     zimaboard-2 = {
       "octelium.com/node-mode-dataplane" = ""

--- a/clusters/homelab/apps/cordium/README.md
+++ b/clusters/homelab/apps/cordium/README.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD013 -->
+
 # Cordium
 
 Cordium is bootstrapped into the self-hosted Octelium Cluster with the upstream
@@ -34,6 +36,10 @@ unconfined AppArmor profile. The repo-owned `cordium` Namespace therefore
 enforces the `privileged` Pod Security profile while continuing to audit and
 warn against `restricted`. Keep this exception limited to Cordium Workspaces;
 ordinary homelab workloads must not use this Namespace.
+
+Workspace Pods select `octelium.com/node-mode-cordium=`. Terragrunt manages
+that label on `zimaboard-1`, the lower-reserved-capacity 8 GB worker; the
+smaller `zimaboard-2` cannot satisfy the default Workspace memory limit.
 
 Cordium genesis owns the system Service `default.cordium`, whose primary
 hostname is `cordium`. The homelab catalog must not also declare a `cordium`
@@ -94,6 +100,7 @@ kubectl -n octelium get job cordium-genesis
 kubectl -n octelium logs job/cordium-genesis
 kubectl -n octelium get deploy,svc -l octelium.com/app=cordium
 kubectl get namespace cordium --show-labels
+kubectl get node zimaboard-1 --show-labels
 kubectl -n cordium get deploy,pod,pvc
 octeliumctl get svc default.cordium
 octeliumctl get svc cordium-agent-api.homelab

--- a/docs/knowledge-base/architecture/cluster-topology.md
+++ b/docs/knowledge-base/architecture/cluster-topology.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD013 -->
+
 # Cluster Topology
 
 Tags: #architecture #talos #kubernetes
@@ -11,7 +13,7 @@ control-plane node and three Zimaboard workers.
 | --- | --- | --- | --- |
 | `acer` | `10.1.0.199` | control-plane | Canonical Talos and Kubernetes API endpoint |
 | `zimaboard-0` | `10.1.0.200` | worker | Hyphenated Kubernetes node name |
-| `zimaboard-1` | `10.1.0.201` | worker | Hyphenated Kubernetes node name |
+| `zimaboard-1` | `10.1.0.201` | worker | Octelium control-plane and Cordium Workspace node |
 | `zimaboard-2` | `10.1.0.202` | worker | Hyphenated Kubernetes node name |
 
 ## Monitoring Contract
@@ -31,6 +33,13 @@ pressure rules have no current data.
 
 Update the Grafana alert regex and expected count in the same change that adds,
 removes, or renames a node.
+
+## Workload Scheduling
+
+Terragrunt manages `octelium.com/node-mode-cordium=` on `zimaboard-1` because
+Cordium-generated Workspace Pods require that selector. Of the worker nodes,
+`zimaboard-1` has enough memory for the default Workspace limit and lower
+reserved load than `zimaboard-0`; `zimaboard-2` is too small.
 
 ## Canonical Endpoints
 

--- a/docs/octelium.md
+++ b/docs/octelium.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD013 -->
+
 # Octelium Client Bridge
 
 This repository uses Octelium for human access to homelab applications. App
@@ -495,7 +497,7 @@ Terragrunt/OpenTofu manages the Octelium node labels:
 | Node | Octelium label |
 | --- | --- |
 | `zimaboard-0` | `octelium.com/node-mode-dataplane=` |
-| `zimaboard-1` | `octelium.com/node-mode-controlplane=` |
+| `zimaboard-1` | `octelium.com/node-mode-controlplane=`, `octelium.com/node-mode-cordium=` |
 | `zimaboard-2` | `octelium.com/node-mode-dataplane=` |
 
 Argo CD manages:


### PR DESCRIPTION
## Summary

- add Cordium's required node selector label to `zimaboard-1` through the existing Terragrunt-managed node label map
- document the worker choice and end-to-end validation path
- record the scheduling contract in the homelab knowledge base

## Validation

- `terragrunt hcl fmt --check`
- `terragrunt hcl validate`
- `bash scripts/ci/static-checks.sh`
- `bash scripts/ci/conftest-policies.sh` (6,507 tests passed)
- targeted `pre-commit run --files ...`
- `markdownlint-cli2` on changed Markdown files

A focused local `terragrunt plan` could not decrypt state because the operator AWS SSO session is expired; the credentialed PR Terragrunt plan remains the source of truth.

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

Rendered from saved `plan.out` files with `terragrunt show -no-color plan.out`.

Source commit: `609eebda9e4080b977073e7dd811ebc5c255808b`.

> `IaC/live/aws-ssm-parameters` and `IaC/live/kubernetes-secrets` are intentionally excluded from PR plans because they require protected apply credentials or decrypted SSM reads.

> No affected Argo CD bootstrap units were planned.

> No affected Argo CD Application registration units were planned.

> AzureAD application registration plans were skipped because the plan environment did not provide `ARM_CLIENT_ID`, `ARM_CLIENT_SECRET`, and `ARM_TENANT_ID`. Production apply still fails fast when `IaC/live/azuread-applications` changes and those credentials are absent.


<!-- terragrunt-plan:end -->
