### PR TITLE
fix(deluge): refresh rotating VPN endpoint

### DIFF
--- a/clusters/homelab/apps/deluge/README.md
+++ b/clusters/homelab/apps/deluge/README.md
@@ -12,7 +12,7 @@ The `deluge-vpn` ExternalSecret reads the AirVPN WireGuard profile from AWS
 SSM Parameter Store and publishes it as `wg0.conf`:
 
 | SSM parameter | Kubernetes Secret key |
-|---------------|-----------------------|
+| --- | --- |
 | `/homelab/deluge/vpn/wireguard-config` | `wg0.conf` |
 
 The `deluge-vpn` ExternalSecret uses `refreshPolicy: OnChange`. After replacing
@@ -27,12 +27,19 @@ Gluetun runs this profile through its `custom` WireGuard provider so it uses the
 exact AirVPN peer instead of selecting a random AirVPN server from provider
 metadata. Gluetun's custom WireGuard path still requires the endpoint host to
 be an IP address at startup, while AirVPN profiles can contain an endpoint DNS
-name. A `config-wireguard` init container reads the secret profile, resolves a
-DNS endpoint to its first IPv4 address when needed, strips IPv6 `Address` and
+name. Gluetun's startup wrapper reads the secret profile, resolves a DNS
+endpoint to its current IPv4 address when needed, strips IPv6 `Address` and
 `AllowedIPs` entries, and writes the normalized profile into an in-memory
-volume mounted at `/gluetun/wireguard/wg0.conf`. Keep
+volume at `/gluetun/wireguard/wg0.conf` before starting Gluetun. The wrapper
+runs again whenever Kubernetes restarts the Gluetun sidecar, so a rotating
+AirVPN DNS record cannot leave repeated recovery attempts pinned to a stale
+peer address. Keep
 `homelab.rst.io/wireguard-profile-renderer-revision` in the pod template so
 renderer-only changes roll the singleton and clear stale Gluetun network rules.
+
+Public IP discovery is disabled because Deluge does not consume it. VPN and
+daemon health remain covered by the local health endpoint and Prometheus
+metrics without Gluetun trying to persist unused data under `/tmp`.
 
 The AirVPN forwarded port is not secret desired state. This deployment uses
 AirVPN forwarded port `5983`; set Deluge's incoming BitTorrent port to that same
@@ -88,7 +95,7 @@ verified.
 Use these Deluge paths:
 
 | Setting | Path |
-|---------|------|
+| --- | --- |
 | Download to | `/downloads/incomplete` |
 | Move completed to | `/downloads/complete` |
 | Radarr label path | `/downloads/complete/radarr` |

--- a/clusters/homelab/apps/deluge/values.yaml
+++ b/clusters/homelab/apps/deluge/values.yaml
@@ -28,10 +28,18 @@ controllers:
               /downloads/complete/radarr \
               /downloads/complete/sonarr \
               /downloads/complete/manual
-      config-wireguard:
+      gluetun:
         image:
-          repository: busybox
-          tag: 1.38.0@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
+          repository: ghcr.io/qdm12/gluetun
+          tag: v3.41.3@sha256:fa19cc76b2af13d57a8d3dc3066f2ada061b1c761b8aecf989b3877c0486e027
+        restartPolicy: Always
+        lifecycle:
+          postStart:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - (ip rule del table 51820; ip -6 rule del table 51820) || true
         command:
           - /bin/sh
           - -ec
@@ -131,18 +139,7 @@ controllers:
             ' "$source_config" >"${target_config}.tmp"
             chmod 0400 "${target_config}.tmp"
             mv "${target_config}.tmp" "$target_config"
-      gluetun:
-        image:
-          repository: ghcr.io/qdm12/gluetun
-          tag: v3.41.3@sha256:fa19cc76b2af13d57a8d3dc3066f2ada061b1c761b8aecf989b3877c0486e027
-        restartPolicy: Always
-        lifecycle:
-          postStart:
-            exec:
-              command:
-                - /bin/sh
-                - -c
-                - (ip rule del table 51820; ip -6 rule del table 51820) || true
+            exec /gluetun-entrypoint
         env:
           TZ: America/Los_Angeles
           VPN_SERVICE_PROVIDER: custom
@@ -151,6 +148,7 @@ controllers:
           FIREWALL_INPUT_PORTS: "8112"
           FIREWALL_VPN_INPUT_PORTS: "5983"
           HEALTH_RESTART_VPN: "on"
+          PUBLICIP_ENABLED: "off"
         resources:
           requests:
             cpu: 100m
@@ -497,11 +495,8 @@ persistence:
     type: emptyDir
     advancedMounts:
       deluge:
-        config-wireguard:
-          - path: /gluetun/wireguard
         gluetun:
           - path: /gluetun/wireguard
-            readOnly: true
   vpn-profile-source:
     enabled: true
     type: secret
@@ -511,6 +506,6 @@ persistence:
         path: wg0.conf
     advancedMounts:
       deluge:
-        config-wireguard:
+        gluetun:
           - path: /vpn-source
             readOnly: true

--- a/docs/knowledge-base/architecture/secrets-and-identity.md
+++ b/docs/knowledge-base/architecture/secrets-and-identity.md
@@ -164,8 +164,10 @@ roles need identity-based KMS permissions for both keys.
   refreshes on ExternalSecret changes; after replacing the SSM profile value,
   bump `homelab.rst.io/wireguard-profile-ssm-version` on both the
   ExternalSecret and Deluge pod template so the Secret is rerendered and
-  Gluetun starts with the new profile. The Deluge pod resolves an endpoint DNS
-  name in the profile to an IPv4 address before handing it to Gluetun.
+  Gluetun starts with the new profile. Gluetun's startup wrapper resolves an
+  endpoint DNS name in the profile to an IPv4 address on every container start
+  before handing it to Gluetun, so sidecar recovery refreshes rotating AirVPN
+  endpoint records instead of reusing the pod's first answer.
 - n8n uses `/homelab/n8n/encryption-key` as a first-boot bootstrap key only;
   existing PVCs keep using their persisted `/home/node/.n8n/config` key.
   `n8n-postgres` uses generated `/homelab/n8n/postgres-admin-password` and

--- a/docs/knowledge-base/operations/continuous-improvement.md
+++ b/docs/knowledge-base/operations/continuous-improvement.md
@@ -587,3 +587,11 @@ policy`.
   first scheduled NFS archive,
   `20260731T103003Z.tar.gz`, completed and passed archive listing validation
   before the migration-only mount was removed from the app pod.
+  On 2026-08-02, Gluetun then accumulated 11 clean Kubernetes-initiated
+  restarts while its internal health loop could not pass traffic through
+  `198.54.129.62`. The source AirVPN hostname had changed to
+  `198.54.129.125`, but the completed `config-wireguard` init container had
+  resolved it only once when the pod started. The resolver now runs in
+  Gluetun's startup wrapper, so every sidecar restart rebuilds the normalized
+  profile with the current DNS answer. Unused public-IP discovery is disabled
+  to stop permission errors while clearing `/tmp/gluetun/ip`.


### PR DESCRIPTION
## Summary

- run the existing WireGuard profile normalizer inside Gluetun startup instead of a one-shot init container
- resolve the AirVPN hostname again on every Gluetun restart so rotating endpoint records recover automatically
- disable unused public-IP discovery and document the observed failure and recovery model

## Root cause

The running pod had normalized `us3.vpn.airdns.org` to `198.54.129.62` at pod creation. During the incident the hostname resolved to `198.54.129.125`, but Kubernetes restarted only the restartable Gluetun init sidecar; the completed `config-wireguard` init container never reran, so every recovery attempt reused the stale endpoint.

## Validation

- signed commit and all commit-time hooks passed, including YAML, Checkov diff/secrets, codespell, and whitespace
- pinned `app-template` 4.4.0 Helm render passed; Gluetun owns both profile mounts and `config-wireguard` no longer renders
- Helm and Kustomize server-side dry runs passed
- repository Conftest: 6,669 passed, 0 failed
- current-tree gitleaks passed; the full static script still reports 12 pre-existing historical findings outside this diff

## Rollout gates

After merge, verify Argo Synced/Healthy, Gluetun resolves the current endpoint and stays at zero restarts, VPN/daemon metrics are 1, torrent count is 17 with zero errors, and only `deluge-config-local` plus `media-downloads` are mounted by the pod.

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

> Live Terragrunt plan skipped because this pull request did not change `IaC/**`, flake inputs, OpenTofu/Terragrunt policy inputs, or live-plan helper scripts.

Rendered Conftest policies still ran for workflows and Kubernetes manifests in this required check.

<!-- terragrunt-plan:end -->
