### PR TITLE
fix(deluge): use native AirVPN provider

### DIFF
--- a/clusters/homelab/apps/deluge/README.md
+++ b/clusters/homelab/apps/deluge/README.md
@@ -23,17 +23,13 @@ causes External Secrets to render a fresh Kubernetes Secret, and the pod
 template annotation rolls Deluge so Gluetun reads the new WireGuard profile at
 startup.
 
-Gluetun runs this profile through its `custom` WireGuard provider so it uses the
-exact AirVPN peer instead of selecting a random AirVPN server from provider
-metadata. Gluetun's custom WireGuard path still requires the endpoint host to
-be an IP address at startup, while AirVPN profiles can contain an endpoint DNS
-name. Gluetun's startup wrapper reads the secret profile, resolves a DNS
-endpoint to its current IPv4 address when needed, strips IPv6 `Address` and
-`AllowedIPs` entries, and writes the normalized profile into an in-memory
-volume at `/gluetun/wireguard/wg0.conf` before starting Gluetun. The wrapper
-runs again whenever Kubernetes restarts the Gluetun sidecar, so a rotating
-AirVPN DNS record cannot leave repeated recovery attempts pinned to a stale
-peer address. Keep
+Gluetun uses its native AirVPN WireGuard provider. Its startup wrapper reads
+the private key, preshared key, and first IPv4 interface address from the
+secret profile, then Gluetun selects a current server from its bundled AirVPN
+metadata. Endpoint and server-key fields from the generated profile are
+intentionally ignored. This removes the custom provider's IP-only endpoint
+conversion and avoids depending on DNS before Gluetun has restored its own DNS
+server and firewall during a container restart. Keep
 `homelab.rst.io/wireguard-profile-renderer-revision` in the pod template so
 renderer-only changes roll the singleton and clear stale Gluetun network rules.
 

--- a/clusters/homelab/apps/deluge/values.yaml
+++ b/clusters/homelab/apps/deluge/values.yaml
@@ -44,105 +44,36 @@ controllers:
           - /bin/sh
           - -ec
           - |
-            source_config=/vpn-source/wg0.conf
-            target_config=/gluetun/wireguard/wg0.conf
-            test -s "$source_config"
-            endpoint="$(
-              awk -F= '
-                tolower($1) ~ /^[[:space:]]*endpoint[[:space:]]*$/ {
+            profile_value() {
+              awk -F= -v key="$1" '
+                tolower($1) ~ "^[[:space:]]*" key "[[:space:]]*$" {
                   value=$2
                   gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
                   print value
                   exit
                 }
-              ' "$source_config"
-            )"
-            host="${endpoint%:*}"
-            port="${endpoint##*:}"
-            if [ -z "$endpoint" ] || [ "$host" = "$endpoint" ] || [ -z "$port" ]; then
-              echo "WireGuard config must contain Endpoint = host:port" >&2
-              exit 1
-            fi
-            if printf "%s\n" "$host" | grep -Eq '^[0-9]+([.][0-9]+){3}$'; then
-              endpoint_ip="$host"
-            else
-              endpoint_ip="$(
-                nslookup "$host" |
-                  awk '/^Address: / {print $2}' |
-                  grep -E '^[0-9]+([.][0-9]+){3}$' |
-                  head -n 1
-              )"
-              if [ -z "$endpoint_ip" ]; then
-                echo "failed to resolve WireGuard endpoint hostname" >&2
-                exit 1
-              fi
-            fi
-            awk -F= -v replacement="Endpoint = ${endpoint_ip}:${port}" '
-              function trim(value) {
-                gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
-                return value
-              }
-
-              function ipv4_cidr_list(value, parts, count, output, item, i) {
-                count = split(value, parts, ",")
-                output = ""
-                for (i = 1; i <= count; i++) {
-                  item = trim(parts[i])
-                  if (item ~ /^[0-9]+([.][0-9]+){3}\/[0-9]+$/) {
-                    output = output (output == "" ? "" : ", ") item
+              ' /vpn-source/wg0.conf
+            }
+            export WIREGUARD_PRIVATE_KEY="$(profile_value privatekey)"
+            export WIREGUARD_PRESHARED_KEY="$(profile_value presharedkey)"
+            export WIREGUARD_ADDRESSES="$(
+              profile_value address |
+                tr ',' '\n' |
+                awk '
+                  /^[[:space:]]*[0-9]+([.][0-9]+){3}\/[0-9]+[[:space:]]*$/ {
+                    gsub(/^[[:space:]]+|[[:space:]]+$/, "")
+                    print
+                    exit
                   }
-                }
-                return output
-              }
-
-              /^[[:space:]]*Endpoint[[:space:]]*=/ && !done {
-                print replacement
-                done=1
-                next
-              }
-
-              tolower($1) ~ /^[[:space:]]*address[[:space:]]*$/ {
-                ipv4_addresses = ipv4_cidr_list($2)
-                if (ipv4_addresses == "" || address_done) {
-                  next
-                }
-                print "Address = " ipv4_addresses
-                address_done=1
-                next
-              }
-
-              tolower($1) ~ /^[[:space:]]*allowedips[[:space:]]*$/ {
-                ipv4_allowed_ips = ipv4_cidr_list($2)
-                if (ipv4_allowed_ips == "" || allowed_ips_done) {
-                  next
-                }
-                print "AllowedIPs = " ipv4_allowed_ips
-                allowed_ips_done=1
-                next
-              }
-
-              { print }
-              END {
-                if (!done) {
-                  print "WireGuard config must contain Endpoint = host:port" > "/dev/stderr"
-                  exit 1
-                }
-                if (!address_done) {
-                  print "WireGuard config must contain an IPv4 Address entry" > "/dev/stderr"
-                  exit 1
-                }
-                if (!allowed_ips_done) {
-                  print "WireGuard config must contain IPv4 AllowedIPs" > "/dev/stderr"
-                  exit 1
-                }
-              }
-            ' "$source_config" >"${target_config}.tmp"
-            chmod 0400 "${target_config}.tmp"
-            mv "${target_config}.tmp" "$target_config"
+                '
+            )"
+            test -n "$WIREGUARD_PRIVATE_KEY"
+            test -n "$WIREGUARD_PRESHARED_KEY"
+            test -n "$WIREGUARD_ADDRESSES"
             exec /gluetun-entrypoint
         env:
           TZ: America/Los_Angeles
-          VPN_SERVICE_PROVIDER: custom
+          VPN_SERVICE_PROVIDER: airvpn
           VPN_TYPE: wireguard
           FIREWALL: "on"
           FIREWALL_INPUT_PORTS: "8112"
@@ -490,13 +421,6 @@ persistence:
       deluge:
         gluetun:
           - path: /dev/net/tun
-  vpn-profile:
-    enabled: true
-    type: emptyDir
-    advancedMounts:
-      deluge:
-        gluetun:
-          - path: /gluetun/wireguard
   vpn-profile-source:
     enabled: true
     type: secret

--- a/docs/knowledge-base/architecture/secrets-and-identity.md
+++ b/docs/knowledge-base/architecture/secrets-and-identity.md
@@ -164,10 +164,10 @@ roles need identity-based KMS permissions for both keys.
   refreshes on ExternalSecret changes; after replacing the SSM profile value,
   bump `homelab.rst.io/wireguard-profile-ssm-version` on both the
   ExternalSecret and Deluge pod template so the Secret is rerendered and
-  Gluetun starts with the new profile. Gluetun's startup wrapper resolves an
-  endpoint DNS name in the profile to an IPv4 address on every container start
-  before handing it to Gluetun, so sidecar recovery refreshes rotating AirVPN
-  endpoint records instead of reusing the pod's first answer.
+  Gluetun starts with the new profile. Its startup wrapper extracts the private
+  key, preshared key, and first IPv4 interface address, while Gluetun's native
+  AirVPN provider selects the server. The profile's endpoint and server key are
+  not used, avoiding custom-provider DNS resolution during sidecar recovery.
 - n8n uses `/homelab/n8n/encryption-key` as a first-boot bootstrap key only;
   existing PVCs keep using their persisted `/home/node/.n8n/config` key.
   `n8n-postgres` uses generated `/homelab/n8n/postgres-admin-password` and

--- a/docs/knowledge-base/operations/continuous-improvement.md
+++ b/docs/knowledge-base/operations/continuous-improvement.md
@@ -602,3 +602,12 @@ policy`.
   zero errors, and the pod mounted only `deluge-config-local` and
   `media-downloads`. The 2026-08-02 scheduled backup also completed and
   validated archive `20260802T103004Z.tar.gz`.
+  Roughly three hours later, another VPN health failure exposed a restart
+  bootstrap loop: Gluetun had changed the pod resolver to its own
+  `127.0.0.1`, then Kubernetes restarted the container and the wrapper tried to
+  resolve AirVPN before that local DNS server existed. Gluetun exited with
+  `failed to resolve WireGuard endpoint hostname`, accumulated nine restarts,
+  and left Argo CD `Progressing`. The wrapper now passes only the profile's
+  client keys and IPv4 address to Gluetun's native AirVPN provider. Gluetun
+  owns server selection, so container recovery no longer needs pre-start DNS
+  or the removed writable normalized-profile volume.


### PR DESCRIPTION
## Summary
- replace the custom WireGuard provider and pre-start endpoint resolver with Gluetun’s native AirVPN provider
- extract only the private key, preshared key, and IPv4 client address from the existing secret profile
- remove the generated-profile emptyDir and document the restart-loop root cause

## Root cause
After Gluetun rewrote the pod resolver to `127.0.0.1`, a Gluetun-only liveness restart reran the custom wrapper before Gluetun DNS was available. The wrapper could not resolve the AirVPN endpoint, exited, and entered CrashLoopBackOff. The existing Gluetun firewall also prevented falling back to Kubernetes DNS. Native AirVPN server selection removes that circular DNS bootstrap dependency.

## Validation
- `git diff --check`
- Helm app-template 4.4.0 render plus deployment assertions and wrapper `/bin/sh -n`
- Helm server-side dry-run
- `kubectl kustomize clusters/homelab/apps/deluge`
- Conftest: 6,669 tests, 0 failures
- signed commit hooks: whitespace, EOF, YAML, codespell, Checkov diff/secrets

## Operational note
A forced container restart is intentionally not performed because live mutations must use GitOps. The rollout supplies the production restart test; the removed resolver means the observed restart-time failure path no longer exists.

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

> Live Terragrunt plan skipped because this pull request did not change `IaC/**`, flake inputs, OpenTofu/Terragrunt policy inputs, or live-plan helper scripts.

Rendered Conftest policies still ran for workflows and Kubernetes manifests in this required check.

<!-- terragrunt-plan:end -->
