### PR TITLE
fix(deluge): preserve WireGuard key padding

### DIFF
--- a/clusters/homelab/apps/deluge/values.yaml
+++ b/clusters/homelab/apps/deluge/values.yaml
@@ -47,7 +47,7 @@ controllers:
             profile_value() {
               awk -F= -v key="$1" '
                 tolower($1) ~ "^[[:space:]]*" key "[[:space:]]*$" {
-                  value=$2
+                  value=substr($0, index($0, "=") + 1)
                   gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
                   print value
                   exit


### PR DESCRIPTION
## Summary
- preserve base64 padding when extracting WireGuard keys from the AirVPN profile

## Root cause
The native-provider rollout showed that `awk -F=` with `value=$2` discarded a trailing `=` from the 44-character WireGuard private key. Gluetun rejected the resulting key before opening the tunnel. Reading the substring after the first delimiter preserves padding.

## Validation
- fixture parser check: padding preserved
- redacted live-profile check: private key length 44, padding preserved
- `git diff --check`
- signed commit hooks: whitespace, EOF, YAML, codespell, Checkov diff/secrets

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

> Live Terragrunt plan skipped because this pull request did not change `IaC/**`, flake inputs, OpenTofu/Terragrunt policy inputs, or live-plan helper scripts.

Rendered Conftest policies still ran for workflows and Kubernetes manifests in this required check.

<!-- terragrunt-plan:end -->
