### PR TITLE
fix(argocd): allow Cordium workspace namespace

### DIFF
--- a/clusters/homelab/argocd/self-management/appproject.yaml
+++ b/clusters/homelab/argocd/self-management/appproject.yaml
@@ -38,6 +38,8 @@ spec:
     - server: https://kubernetes.default.svc
       namespace: cert-manager
     - server: https://kubernetes.default.svc
+      namespace: cordium
+    - server: https://kubernetes.default.svc
       namespace: cordium-storage
     - server: https://kubernetes.default.svc
       namespace: crossplane-system

--- a/docs/knowledge-base/architecture/gitops-flow.md
+++ b/docs/knowledge-base/architecture/gitops-flow.md
@@ -29,6 +29,8 @@ Argo CD parameter overrides as steady state.
 Cordium's CLI-native `ClusterConfig` is packaged into a generated ConfigMap and
 applied by an Argo CD PostSync hook after the upstream genesis hook completes.
 This keeps the non-Kubernetes API resource on the same reviewed GitOps path.
+The Cordium Application is allowed to deploy control resources to `octelium`
+and workspace support resources to the dedicated `cordium` namespace.
 The Cordium Application prunes removed repository-owned Kubernetes manifests;
 Cordium and Octelium resources generated through their native APIs remain
 outside Argo CD's tracking and are unaffected by that setting.


### PR DESCRIPTION
## Summary

- allow the homelab AppProject to deploy Cordium workspace support resources into `cordium`
- document the Cordium control/workspace namespace boundary

## Validation

- `nix flake check`
- `kubectl apply --dry-run=server -f clusters/homelab/argocd/self-management/appproject.yaml`
- signed commit hooks

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

> Live Terragrunt plan skipped because this pull request did not change `IaC/**`, flake inputs, OpenTofu/Terragrunt policy inputs, or live-plan helper scripts.

Rendered Conftest policies still ran for workflows and Kubernetes manifests in this required check.

<!-- terragrunt-plan:end -->
