### PR TITLE
fix(cordium): support Talos without AppArmor

### DIFF
--- a/clusters/homelab/apps/cordium/user-namespace-sysctl.yaml
+++ b/clusters/homelab/apps/cordium/user-namespace-sysctl.yaml
@@ -36,8 +36,6 @@ spec:
               mountPath: /host-sysctl/user.max_user_namespaces
           securityContext:
             allowPrivilegeEscalation: false
-            appArmorProfile:
-              type: RuntimeDefault
             capabilities:
               drop:
                 - ALL

--- a/docs/knowledge-base/architecture/cluster-topology.md
+++ b/docs/knowledge-base/architecture/cluster-topology.md
@@ -40,6 +40,8 @@ Terragrunt manages `octelium.com/node-mode-cordium=` on `zimaboard-1` because
 Cordium-generated Workspace Pods require that selector. Of the worker nodes,
 `zimaboard-1` has enough memory for the default Workspace limit and lower
 reserved load than `zimaboard-0`; `zimaboard-2` is too small.
+Talos on `zimaboard-1` does not expose AppArmor enforcement, so repo-owned
+support Pods use RuntimeDefault seccomp without an AppArmor profile.
 
 ## Canonical Endpoints
 


### PR DESCRIPTION
## Summary

- remove the unsupported AppArmor profile from the sysctl init container
- retain RuntimeDefault seccomp, dropped capabilities, read-only root filesystem, and the narrow hostPath
- record the verified Talos node constraint

## Validation

- `nix flake check`
- `kubectl apply --dry-run=server -f clusters/homelab/apps/cordium/user-namespace-sysctl.yaml`
- signed commit hooks

## Live evidence

`zimaboard-1` rejected the prior pod with `Cannot enforce AppArmor: AppArmor is not enabled on the host` before the init container could run.

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

> Live Terragrunt plan skipped because this pull request did not change `IaC/**`, flake inputs, OpenTofu/Terragrunt policy inputs, or live-plan helper scripts.

Rendered Conftest policies still ran for workflows and Kubernetes manifests in this required check.

<!-- terragrunt-plan:end -->
