### PR TITLE
fix(argocd): recover Cordium sync

### DIFF
--- a/clusters/homelab/argocd/self-management/cordium-sync-recovery.yaml
+++ b/clusters/homelab/argocd/self-management/cordium-sync-recovery.yaml
@@ -1,0 +1,117 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cordium-sync-recovery
+  namespace: cordium
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+automountServiceAccountToken: true
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cordium-sync-recovery
+  namespace: cordium
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+rules:
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+    resourceNames:
+      - cordium-user-namespace-sysctl
+    verbs:
+      - get
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cordium-sync-recovery
+  namespace: cordium
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cordium-sync-recovery
+subjects:
+  - kind: ServiceAccount
+    name: cordium-sync-recovery
+    namespace: cordium
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: cordium-sync-recovery
+  namespace: cordium
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: cordium-sync-recovery
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress: []
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 10.96.0.1/32
+      ports:
+        - protocol: TCP
+          port: 443
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cordium-sync-recovery
+  namespace: cordium
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+    checkov.io/skip1: CKV_K8S_38=The recovery Job needs its narrowly scoped service-account token to patch one DaemonSet.
+spec:
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: cordium-sync-recovery
+        app.kubernetes.io/part-of: cordium
+    spec:
+      automountServiceAccountToken: true
+      enableServiceLinks: false
+      restartPolicy: OnFailure
+      serviceAccountName: cordium-sync-recovery
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: patch-daemonset
+          image: registry.k8s.io/kubectl:v1.36.1@sha256:d08f476d04d0e30f426f06bc6ff6c38913aaa4591943046b77e2f74a72d3611c
+          imagePullPolicy: IfNotPresent
+          args:
+            - patch
+            - daemonset
+            - cordium-user-namespace-sysctl
+            - --namespace=cordium
+            - --type=strategic
+            - --patch={"spec":{"template":{"spec":{"initContainers":[{"name":"enable-user-namespaces","securityContext":{"appArmorProfile":null}}]}}}}
+          resources:
+            requests:
+              cpu: 5m
+              memory: 16Mi
+            limits:
+              cpu: 50m
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65532
+            runAsNonRoot: true
+            runAsUser: 65532

--- a/clusters/homelab/argocd/self-management/kustomization.yaml
+++ b/clusters/homelab/argocd/self-management/kustomization.yaml
@@ -6,5 +6,6 @@ resources:
   - default-appproject.yaml
   - appproject.yaml
   - application.yaml
+  - cordium-sync-recovery.yaml
   - oidc-external-secret.yaml
   - virtualservice.yaml

--- a/docs/knowledge-base/architecture/gitops-flow.md
+++ b/docs/knowledge-base/architecture/gitops-flow.md
@@ -35,6 +35,11 @@ The Cordium Application prunes removed repository-owned Kubernetes manifests;
 Cordium and Octelium resources generated through their native APIs remain
 outside Argo CD's tracking and are unaffected by that setting.
 
+The temporary `cordium-sync-recovery` Job under Argo CD self-management removes
+an unsupported AppArmor field from the live sysctl DaemonSet so an earlier
+health-blocked Cordium sync can finish. Remove the Job and its narrow RBAC after
+the Cordium Application converges to the corrected manifest.
+
 ## Important Paths
 
 | Concern | Path |


### PR DESCRIPTION
## Summary

- add a temporary GitOps-managed recovery Job to remove the unsupported AppArmor field from the stuck live DaemonSet
- grant only `get` and `patch` on `cordium-user-namespace-sysctl`
- restrict the Job network path to the Kubernetes API
- document that these temporary resources must be pruned after Cordium converges

## Validation

- `nix flake check`
- `kubectl apply --dry-run=server -k clusters/homelab/argocd/self-management`
- exact strategic merge patch server-side dry-run
- signed commit hooks

## Why a recovery Job

The previous Cordium sync is waiting forever for the AppArmor-rejected pod to become healthy. That active operation prevents Argo CD from applying the corrected revision. Repository policy forbids an ad-hoc live patch, so this one-shot declarative Job unblocks the controller through the normal reviewed GitOps path.

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

> Live Terragrunt plan skipped because this pull request did not change `IaC/**`, flake inputs, OpenTofu/Terragrunt policy inputs, or live-plan helper scripts.

Rendered Conftest policies still ran for workflows and Kubernetes manifests in this required check.

<!-- terragrunt-plan:end -->
