### PR TITLE
fix(n8n): fence postgres recovery

### DIFF
--- a/clusters/homelab/apps/n8n-postgres/README.md
+++ b/clusters/homelab/apps/n8n-postgres/README.md
@@ -39,7 +39,39 @@ This desired state points n8n at PostgreSQL. It preserves the existing
 current SQLite contents must be preserved, then import them after n8n starts
 against PostgreSQL.
 
+## NFS Interruption Recovery
+
+The readiness probe removes PostgreSQL from its Service after six failed
+checks, but startup and liveness failures now tolerate 30 minutes of QNAP
+recovery and shutdown receives 120 seconds to finish. This reduces forced
+crash recovery after an NFS stall.
+
+Recovery from the 2026-08-03 stale-lock incident is staged. Phase 1 keeps the
+StatefulSet at zero replicas without modifying its retained PVC. After live
+validation confirms `n8n-postgres-0` is absent, phase 2 may add an
+incident-specific, completion-marked hook that removes only
+`pgdata/postmaster.pid` before restoring one replica. Never remove the lock
+until the old writer is fenced.
+
 ## Validation
+
+### Recovery Phase 1: Fenced
+
+```sh
+kubectl kustomize clusters/homelab/apps/n8n-postgres
+kubectl -n argocd get application n8n-postgres
+kubectl -n automation get statefulset n8n-postgres \
+  -o jsonpath='{.spec.replicas}{" "}{.status.currentReplicas}{"\n"}'
+kubectl -n automation get pod n8n-postgres-0 --ignore-not-found
+kubectl -n automation get pvc data-n8n-postgres-0
+```
+
+Expected phase-one results: Argo CD reports the Application synced, the
+StatefulSet prints desired replica count `0` with no current replica, the pod
+lookup prints nothing, and the retained PostgreSQL PVC remains `Bound`. Do not
+run the recovery hook until all four conditions hold.
+
+### Recovery Phase 2: Restored
 
 After Argo CD syncs `n8n-postgres`, verify the secrets, StatefulSet, PVC, and
 database connectivity:

--- a/clusters/homelab/apps/n8n-postgres/README.md
+++ b/clusters/homelab/apps/n8n-postgres/README.md
@@ -23,9 +23,9 @@ The app password is mounted into n8n through `n8n-postgres-client` and read via
 
 The PostgreSQL init script creates:
 
-| Role | Database | Notes |
-|------|----------|-------|
-| `n8n` | `n8n` | Owns the database and `public` schema used by n8n |
+| Role  | Database | Notes                                             |
+| ----- | -------- | ------------------------------------------------- |
+| `n8n` | `n8n`    | Owns the database and `public` schema used by n8n |
 
 The init script runs only when PostgreSQL initializes an empty data directory.
 Changing database names, users, or passwords after first boot requires an
@@ -80,7 +80,8 @@ database connectivity:
 kubectl -n automation get externalsecret n8n-postgres-auth n8n-postgres-client
 kubectl -n automation get secret n8n-postgres-auth n8n-postgres-client
 kubectl -n automation get statefulset,pod,pvc,svc -l app.kubernetes.io/name=n8n-postgres
-kubectl -n automation exec statefulset/n8n-postgres -- psql -U postgres -d n8n -c '\du'
+kubectl -n automation exec statefulset/n8n-postgres -- \
+  psql -U postgres -d n8n -c '\du'
 ```
 
 The role list should include `n8n`, and n8n should report healthy only after

--- a/clusters/homelab/apps/n8n-postgres/statefulset.yaml
+++ b/clusters/homelab/apps/n8n-postgres/statefulset.yaml
@@ -13,7 +13,9 @@ metadata:
     app.kubernetes.io/part-of: homelab-automation
 spec:
   serviceName: n8n-postgres
-  replicas: 1
+  # Recovery phase 1: keep the only PostgreSQL writer stopped until the
+  # repository-owned recovery hook clears the stale lock in phase 2.
+  replicas: 0
   selector:
     matchLabels:
       app.kubernetes.io/name: n8n-postgres
@@ -24,6 +26,7 @@ spec:
         app.kubernetes.io/part-of: homelab-automation
     spec:
       automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 120
       securityContext:
         fsGroup: 65534
         fsGroupChangePolicy: OnRootMismatch
@@ -86,6 +89,17 @@ spec:
           ports:
             - name: postgres
               containerPort: 5432
+          startupProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - postgres
+                - -d
+                - postgres
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 180
           readinessProbe:
             exec:
               command:
@@ -109,7 +123,7 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 30
             timeoutSeconds: 5
-            failureThreshold: 3
+            failureThreshold: 60
           resources:
             requests:
               cpu: 100m

--- a/docs/knowledge-base/architecture/storage-and-state.md
+++ b/docs/knowledge-base/architecture/storage-and-state.md
@@ -87,6 +87,13 @@ validation passed with zero pod restarts. The incident-only hook is now removed
 from desired state, while the explicit retained claim, 30-minute startup and
 liveness windows, and 120-second termination grace remain.
 
+`n8n-postgres` is declared at zero replicas for phase one of the 2026-08-03
+stale-lock recovery after its NFS-backed `postmaster.pid` became inaccessible.
+The retained claim is unchanged. Phase two must confirm the old pod is absent
+before an incident-specific hook removes only that lock and restores one
+replica. The restored pod has 30-minute startup and liveness windows plus a
+120-second termination grace period.
+
 `media-postgres` uses 30-minute startup and runtime liveness windows plus a
 120-second termination grace period. Its readiness probe executes `SELECT 1`
 instead of treating socket acceptance as usable database service. The writable

--- a/docs/knowledge-base/operations/continuous-improvement.md
+++ b/docs/knowledge-base/operations/continuous-improvement.md
@@ -175,7 +175,7 @@ policy`.
   to an opaque sinkhole response.
 
 - **Status:** `affine-postgres` restored; `media-postgres` and Prowlarr
-  cutovers validated; open for other NFS workloads
+  cutovers validated; `n8n-postgres` recovery fence prepared
 - **Area:** storage / database recovery
 - **Evidence:** Read-only inspection on 2026-07-19 found simultaneous probe
   failures across NFS-backed workloads on multiple healthy Kubernetes nodes.
@@ -267,6 +267,17 @@ policy`.
   `/config/config.xml` was empty. The local-config Deluge replacement remained
   healthy with zero restarts, 17 torrents, and successful Sonarr connectivity,
   separating this recurrence from the completed Deluge cutover.
+  On 2026-08-03, `n8n-postgres` entered `CrashLoopBackOff` and failed to open
+  its NFS-backed `postmaster.pid` with `Permission denied`; n8n then failed
+  database initialization and its public callback returned HTTP 503 `no healthy
+  upstream`. Argo CD remained synced, ExternalSecrets remained ready, and the
+  Kubernetes nodes and QNAP RPC services were reachable. Read-only node-side
+  inspection found no PostgreSQL process or other PVC consumer; `pgdata` was
+  mode `0700` with UID/GID `65534`, while `postmaster.pid` was a zero-byte mode
+  `000` file with the same owner. Desired state now prepares phase one by
+  fencing the StatefulSet at zero replicas without modifying its retained
+  claim, while adding 30-minute startup and liveness windows plus 120 seconds
+  for shutdown.
 - **Risk:** probe hardening limits crash-recovery loops but cannot make the
   shared storage path responsive. Sonarr and Prowlarr can remain Kubernetes
   `Running` while database calls fail, while Deluge and Radarr turn sustained
@@ -274,11 +285,16 @@ policy`.
   NFS-backed workloads across the cluster. The nominal local-disk RPO is 24
   hours, but the actual RPO is the age of the newest verified set and can be
   older. A failed nightly NFS backup has no freshness alert while the
-  kube-state-metrics scrape path is unhealthy.
-- **Next step:** inspect QNAP pool, disk, NFS-service, and network history
-  because the same failure domain still affects other NFS-backed workloads.
-  Check scheduled backups manually after storage incidents, and restore backup
-  freshness alerting when a reliable metric source is available.
+  kube-state-metrics scrape path is unhealthy. n8n remains unavailable until
+  the fence is live-validated and a separate recovery phase restores its
+  database.
+- **Next step:** merge the n8n PostgreSQL fence and confirm its pod is absent
+  while the retained claim stays bound, then use a separately reviewed,
+  completion-marked hook to clear only the stale lock and restore one replica.
+  Inspect QNAP pool, disk, NFS-service, and network history because the same
+  failure domain still affects other NFS-backed workloads. Check scheduled
+  backups manually after storage incidents, and restore backup freshness
+  alerting when a reliable metric source is available.
 
 - **Status:** PostgreSQL alert path mitigated; kube-state-metrics scrape open
 - **Area:** monitoring / PostgreSQL availability

--- a/docs/knowledge-base/workloads/inventory.md
+++ b/docs/knowledge-base/workloads/inventory.md
@@ -44,6 +44,11 @@ The clean writable StatefulSet has no active NFS mount and uses a one-time
 old-writer fence. A nightly CronJob writes verified 14-day logical backups to
 the former NFS claim; the sibling recovery overlay fences both before restore.
 
+`n8n-postgres` is temporarily declared at zero replicas for phase one of the
+2026-08-03 NFS stale-lock recovery. Its retained claim remains bound; phase two
+must fence the old pod before removing only `postmaster.pid` and restoring one
+replica.
+
 ## Requested Applications
 
 | App | Namespace | GitOps path | Terragrunt path | State | Depends on |


### PR DESCRIPTION
## Summary
- fence n8n-postgres at zero replicas without modifying its retained PVC
- add 30-minute startup and liveness recovery windows plus 120-second shutdown grace
- document the staged recovery and 2026-08-03 incident evidence

## Validation
- focused Kustomize render and client dry-run passed
- server-side diff produced only the intended StatefulSet changes
- Conftest: 6,723 passed
- focused Checkov: 87 passed, 0 failed
- signed-commit pre-commit hooks passed
- full static gate reached the history scan, then failed on 12 pre-existing historical gitleaks findings

## Rollout gate
After merge, require Argo synced at this revision, desired/current replicas 0/0, n8n-postgres-0 absent, and data-n8n-postgres-0 still Bound before phase-two lock recovery.

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

> Live Terragrunt plan skipped because this pull request did not change `IaC/**`, flake inputs, OpenTofu/Terragrunt policy inputs, or live-plan helper scripts.

Rendered Conftest policies still ran for workflows and Kubernetes manifests in this required check.

<!-- terragrunt-plan:end -->
