### PR TITLE
fix(n8n): restore fenced postgres

### DIFF
--- a/clusters/homelab/apps/n8n-postgres/README.md
+++ b/clusters/homelab/apps/n8n-postgres/README.md
@@ -46,12 +46,17 @@ checks, but startup and liveness failures now tolerate 30 minutes of QNAP
 recovery and shutdown receives 120 seconds to finish. This reduces forced
 crash recovery after an NFS stall.
 
-Recovery from the 2026-08-03 stale-lock incident is staged. Phase 1 keeps the
-StatefulSet at zero replicas without modifying its retained PVC. After live
-validation confirms `n8n-postgres-0` is absent, phase 2 may add an
-incident-specific, completion-marked hook that removes only
-`pgdata/postmaster.pid` before restoring one replica. Never remove the lock
-until the old writer is fenced.
+Recovery from the 2026-08-03 stale-lock incident is staged. Phase 1 fenced the
+StatefulSet at zero replicas without modifying its retained PVC; live
+validation confirmed `n8n-postgres-0` was absent and no process or pod still
+used the claim. Phase 2 declares that retained claim at sync wave `-2`, runs the
+incident-specific `n8n-postgres-stale-lock-recovery-20260803` Sync hook at wave
+`-1`, and restores one replica at wave `0`.
+
+The hook removes only `pgdata/postmaster.pid`, verifies its absence, then
+writes a durable completion marker. A retry that sees the marker leaves the
+database files unchanged, so it cannot remove a live server lock. Remove the
+one-shot hook from desired state after recovery validation passes.
 
 ## Validation
 
@@ -66,10 +71,9 @@ kubectl -n automation get pod n8n-postgres-0 --ignore-not-found
 kubectl -n automation get pvc data-n8n-postgres-0
 ```
 
-Expected phase-one results: Argo CD reports the Application synced, the
-StatefulSet prints desired replica count `0` with no current replica, the pod
-lookup prints nothing, and the retained PostgreSQL PVC remains `Bound`. Do not
-run the recovery hook until all four conditions hold.
+Required phase-one results were: Argo CD synced and healthy, desired/current
+replicas `0/0`, no PostgreSQL pod or process, and the original PVC still
+`Bound`. Revision `e9f42313` passed that gate before phase 2 was prepared.
 
 ### Recovery Phase 2: Restored
 
@@ -81,11 +85,17 @@ kubectl -n automation get externalsecret n8n-postgres-auth n8n-postgres-client
 kubectl -n automation get secret n8n-postgres-auth n8n-postgres-client
 kubectl -n automation get statefulset,pod,pvc,svc -l app.kubernetes.io/name=n8n-postgres
 kubectl -n automation exec statefulset/n8n-postgres -- \
-  psql -U postgres -d n8n -c '\du'
+  test -f /var/lib/postgresql/data/.homelab-postgres-recovery-20260803-complete
+kubectl -n automation exec statefulset/n8n-postgres -- \
+  psql -U postgres -d n8n -Atqc 'select 1'
+kubectl -n automation rollout status deployment/n8n --timeout=10m
+curl -sS -o /dev/null -w '%{http_code}\n' \
+  https://n8n-webhook.stinkyboi.com/webhook/__missing__
 ```
 
-The role list should include `n8n`, and n8n should report healthy only after
-the `wait-for-postgres` init container succeeds.
+Expected phase-two results: Argo records the recovery hook as succeeded, the
+marker exists, PostgreSQL and n8n are ready, SQL prints `1`, and the public
+callback no longer returns HTTP 503. Preserve the PVC throughout recovery.
 
 ## Backup And Restore
 

--- a/clusters/homelab/apps/n8n-postgres/kustomization.yaml
+++ b/clusters/homelab/apps/n8n-postgres/kustomization.yaml
@@ -4,5 +4,7 @@ resources:
   - externalsecret.yaml
   - initdb-configmap.yaml
   - networkpolicy.yaml
+  - pvc.yaml
+  - postgres-recovery-job.yaml
   - service.yaml
   - statefulset.yaml

--- a/clusters/homelab/apps/n8n-postgres/postgres-recovery-job.yaml
+++ b/clusters/homelab/apps/n8n-postgres/postgres-recovery-job.yaml
@@ -1,0 +1,87 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: n8n-postgres-stale-lock-recovery-20260803
+  namespace: automation
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
+    argocd.argoproj.io/sync-wave: "-1"
+    checkov.io/skip1: CKV2_K8S_6=The recovery Job has no network dependency and exits after removing one fenced stale lock file.
+  labels:
+    app.kubernetes.io/name: n8n-postgres-recovery
+    app.kubernetes.io/component: database-recovery
+    app.kubernetes.io/part-of: homelab-automation
+spec:
+  backoffLimit: 2
+  activeDeadlineSeconds: 300
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: n8n-postgres-recovery
+        app.kubernetes.io/component: database-recovery
+        app.kubernetes.io/part-of: homelab-automation
+    spec:
+      automountServiceAccountToken: false
+      restartPolicy: OnFailure
+      securityContext:
+        fsGroup: 65534
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: remove-fenced-stale-lock
+          image: postgres:14.23-bookworm@sha256:70b9c8977b5fb87bd55c9e29472d778d76d56a6266143d47259da13d78a72afa
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              lock_file="/var/lib/postgresql/data/pgdata/postmaster.pid"
+              completion_file="/var/lib/postgresql/data/.homelab-postgres-recovery-20260803-complete"
+
+              if [ -e "$completion_file" ]; then
+                echo "recovery completion marker is present; leaving PostgreSQL files unchanged"
+                exit 0
+              fi
+
+              if [ ! -e "$lock_file" ]; then
+                echo "no stale PostgreSQL lock file is present"
+              else
+                echo "removing fenced stale PostgreSQL lock file"
+                rm -f -- "$lock_file"
+                if [ -e "$lock_file" ]; then
+                  echo "stale PostgreSQL lock file still exists after removal" >&2
+                  exit 1
+                fi
+                echo "stale PostgreSQL lock file removed"
+              fi
+
+              printf '%s\n' 'completed while n8n-postgres was fenced at zero replicas' > "$completion_file"
+              echo "recovery completion marker written"
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: data-n8n-postgres-0

--- a/clusters/homelab/apps/n8n-postgres/pvc.yaml
+++ b/clusters/homelab/apps/n8n-postgres/pvc.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: data-n8n-postgres-0
+  namespace: automation
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
+    argocd.argoproj.io/sync-wave: "-2"
+  labels:
+    app.kubernetes.io/name: n8n-postgres
+    app.kubernetes.io/part-of: homelab-automation
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: nfs-default
+  resources:
+    requests:
+      storage: 20Gi

--- a/clusters/homelab/apps/n8n-postgres/statefulset.yaml
+++ b/clusters/homelab/apps/n8n-postgres/statefulset.yaml
@@ -4,6 +4,7 @@ metadata:
   name: n8n-postgres
   namespace: automation
   annotations:
+    argocd.argoproj.io/sync-wave: "0"
     checkov.io/skip1: CKV_K8S_40=The pod runs as the QNAP NFS anonymous UID 65534 so PostgreSQL owns the squashed data directory without root.
     checkov.io/skip2: CKV_K8S_22=PostgreSQL requires writable image-managed runtime paths; persistent data is isolated on the data PVC.
     checkov.io/skip3: CKV_K8S_43=Image tags are pinned for GitOps review; digest pinning is tracked separately for homelab images.
@@ -13,9 +14,7 @@ metadata:
     app.kubernetes.io/part-of: homelab-automation
 spec:
   serviceName: n8n-postgres
-  # Recovery phase 1: keep the only PostgreSQL writer stopped until the
-  # repository-owned recovery hook clears the stale lock in phase 2.
-  replicas: 0
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: n8n-postgres

--- a/docs/knowledge-base/architecture/storage-and-state.md
+++ b/docs/knowledge-base/architecture/storage-and-state.md
@@ -87,12 +87,14 @@ validation passed with zero pod restarts. The incident-only hook is now removed
 from desired state, while the explicit retained claim, 30-minute startup and
 liveness windows, and 120-second termination grace remain.
 
-`n8n-postgres` is declared at zero replicas for phase one of the 2026-08-03
-stale-lock recovery after its NFS-backed `postmaster.pid` became inaccessible.
-The retained claim is unchanged. Phase two must confirm the old pod is absent
-before an incident-specific hook removes only that lock and restores one
-replica. The restored pod has 30-minute startup and liveness windows plus a
-120-second termination grace period.
+`n8n-postgres` was fenced at zero replicas for phase one of the 2026-08-03
+stale-lock recovery; live validation confirmed the pod and old process were
+absent while the retained claim stayed bound. Phase two declares that claim at
+sync wave `-2` and uses the idempotent
+`n8n-postgres-stale-lock-recovery-20260803` Sync hook at wave `-1` to remove
+only `postmaster.pid` before restoring one replica at wave `0`. A durable marker
+makes retries read-only after success. The restored pod has 30-minute startup
+and liveness windows plus a 120-second termination grace period.
 
 `media-postgres` uses 30-minute startup and runtime liveness windows plus a
 120-second termination grace period. Its readiness probe executes `SELECT 1`

--- a/docs/knowledge-base/operations/continuous-improvement.md
+++ b/docs/knowledge-base/operations/continuous-improvement.md
@@ -175,7 +175,7 @@ policy`.
   to an opaque sinkhole response.
 
 - **Status:** `affine-postgres` restored; `media-postgres` and Prowlarr
-  cutovers validated; `n8n-postgres` recovery fence prepared
+  cutovers validated; `n8n-postgres` restore prepared
 - **Area:** storage / database recovery
 - **Evidence:** Read-only inspection on 2026-07-19 found simultaneous probe
   failures across NFS-backed workloads on multiple healthy Kubernetes nodes.
@@ -274,10 +274,14 @@ policy`.
   Kubernetes nodes and QNAP RPC services were reachable. Read-only node-side
   inspection found no PostgreSQL process or other PVC consumer; `pgdata` was
   mode `0700` with UID/GID `65534`, while `postmaster.pid` was a zero-byte mode
-  `000` file with the same owner. Desired state now prepares phase one by
-  fencing the StatefulSet at zero replicas without modifying its retained
-  claim, while adding 30-minute startup and liveness windows plus 120 seconds
-  for shutdown.
+  `000` file with the same owner. Phase one fenced the StatefulSet at zero
+  replicas without modifying its retained claim, while adding 30-minute startup
+  and liveness windows plus 120 seconds for shutdown. Live validation at
+  `e9f42313` confirmed Argo CD synced and healthy, desired/current replicas
+  `0/0`, the old pod, process, and cgroup absent, no other claim consumer, and
+  the original PVC still bound to the same volume. Phase two declares that
+  claim at sync wave `-2`, runs the completion-marked recovery hook at wave
+  `-1`, and restores one replica at wave `0`.
 - **Risk:** probe hardening limits crash-recovery loops but cannot make the
   shared storage path responsive. Sonarr and Prowlarr can remain Kubernetes
   `Running` while database calls fail, while Deluge and Radarr turn sustained
@@ -286,11 +290,10 @@ policy`.
   hours, but the actual RPO is the age of the newest verified set and can be
   older. A failed nightly NFS backup has no freshness alert while the
   kube-state-metrics scrape path is unhealthy. n8n remains unavailable until
-  the fence is live-validated and a separate recovery phase restores its
-  database.
-- **Next step:** merge the n8n PostgreSQL fence and confirm its pod is absent
-  while the retained claim stays bound, then use a separately reviewed,
-  completion-marked hook to clear only the stale lock and restore one replica.
+  the recovery hook succeeds and the database and application checks pass.
+- **Next step:** merge and live-validate the n8n PostgreSQL restore, then remove
+  its one-shot recovery hook from desired state while retaining the explicit
+  claim and hardened probes.
   Inspect QNAP pool, disk, NFS-service, and network history because the same
   failure domain still affects other NFS-backed workloads. Check scheduled
   backups manually after storage incidents, and restore backup freshness

--- a/docs/knowledge-base/workloads/inventory.md
+++ b/docs/knowledge-base/workloads/inventory.md
@@ -44,10 +44,10 @@ The clean writable StatefulSet has no active NFS mount and uses a one-time
 old-writer fence. A nightly CronJob writes verified 14-day logical backups to
 the former NFS claim; the sibling recovery overlay fences both before restore.
 
-`n8n-postgres` is temporarily declared at zero replicas for phase one of the
-2026-08-03 NFS stale-lock recovery. Its retained claim remains bound; phase two
-must fence the old pod before removing only `postmaster.pid` and restoring one
-replica.
+`n8n-postgres` restores one replica through the fenced, completion-marked
+`n8n-postgres-stale-lock-recovery-20260803` Sync hook after phase-one live
+validation confirmed zero writers and the original bound claim. Its startup
+and liveness recovery windows are 30 minutes, with 120 seconds for shutdown.
 
 ## Requested Applications
 


### PR DESCRIPTION
## Summary

- declare the existing n8n PostgreSQL claim as retained at sync wave -2
- run a completion-marked Sync hook at wave -1 that removes only the fenced stale postmaster.pid
- restore one PostgreSQL replica at wave 0 and record the phase-one live gate

## Validation

- focused Kustomize render and client dry-run passed
- server-side diff passed with only intended mutable changes
- Conftest: 6,777 passed
- Checkov: 173 passed, 0 failed, 5 skipped
- pre-commit: passed

## Rollout

Argo CD auto-syncs after merge. Validate hook success, durable marker, SQL, n8n readiness, and the public webhook before removing the one-shot hook.

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

> Live Terragrunt plan skipped because this pull request did not change `IaC/**`, flake inputs, OpenTofu/Terragrunt policy inputs, or live-plan helper scripts.

Rendered Conftest policies still ran for workflows and Kubernetes manifests in this required check.

<!-- terragrunt-plan:end -->
