### PR TITLE
fix(openclaw): stop doctor blocking startup

### DIFF
--- a/clusters/homelab/apps/openclaw/README.md
+++ b/clusters/homelab/apps/openclaw/README.md
@@ -234,12 +234,12 @@ ingress. Egress is not restricted, and all sessions share the pod's persistent
 workspace, operator toolbox, and mounted application credentials. If a sandbox
 backend is added later, document and validate it before changing this setting.
 
-During startup, the bootstrap always runs OpenClaw's safe non-interactive
-doctor repairs before applying desired state. This keeps version upgrades from
-blocking on stale runtime config and gives valid legacy PVC auth/order entries
-a chance to migrate to the canonical `openai` route while preserving secrets
-and OAuth state on the PVC. It also pins `gateway.mode` to `local`, which is
-required for the container-managed gateway process.
+During startup, the bootstrap validates the persisted config before applying
+desired state. It does not run automatic doctor repairs: doctor scans session
+history on the NFS-backed PVC, so accumulated orphan transcripts can block the
+pod before the gateway starts. Run migrations as explicit, reviewed maintenance
+when an upgrade requires them. Bootstrap also pins `gateway.mode` to `local`,
+which is required for the container-managed gateway process.
 
 Run the interactive login from a tailnet-connected operator machine:
 

--- a/clusters/homelab/apps/openclaw/values.yaml
+++ b/clusters/homelab/apps/openclaw/values.yaml
@@ -166,7 +166,6 @@ controllers:
               printf '{}\n' > "$OPENCLAW_CONFIG_PATH"
             fi
 
-            openclaw doctor --fix --non-interactive
             openclaw config validate
 
             openclaw config set --strict-json \

--- a/docs/knowledge-base/operations/continuous-improvement.md
+++ b/docs/knowledge-base/operations/continuous-improvement.md
@@ -459,6 +459,17 @@ policy`.
   count stays unchanged.
 
 - **Status:** mitigated in desired state; rollout validation pending
+- **Area:** agent runtime / startup
+- **Evidence:** The first 2026-08-13 rollout stalled in `bootstrap-config`
+  before the app container started. Automatic `openclaw doctor --fix` found
+  5,344 orphan transcripts and remained blocked scanning the NFS-backed session
+  directory. Repository bootstrap now validates config without running doctor.
+- **Risk:** future OpenClaw upgrades that require config migration will fail
+  validation instead of repairing persisted state automatically.
+- **Next step:** verify the replacement pod becomes ready. Run doctor or a
+  specific migration only as reviewed maintenance when an upgrade requires it.
+
+- **Status:** mitigated in desired state; rollout validation pending
 - **Area:** agent runtime / sandboxing
 - **Evidence:** On 2026-07-19, restored OpenClaw cron runs reported that
   `agents.defaults.sandbox.mode=non-main` requires Docker, but the workload has


### PR DESCRIPTION
## Summary
- stop running `openclaw doctor --fix` on every pod startup
- keep config validation and reviewed migrations
- record the NFS session-scan failure in the knowledge base

## Validation
- `git diff --check`
- focused `pre-commit` hooks
- Helm app-template 4.4.0 render and Kubernetes client dry-run

<!-- terragrunt-plan:start -->
## Terragrunt Plan Output

> Live Terragrunt plan skipped because this pull request did not change `IaC/**`, flake inputs, OpenTofu/Terragrunt policy inputs, or live-plan helper scripts.

Rendered Conftest policies still ran for workflows and Kubernetes manifests in this required check.

<!-- terragrunt-plan:end -->
